### PR TITLE
Fix: fix gpt2 training on cuda, add Tensor helper functions

### DIFF
--- a/infini_train/include/tensor.h
+++ b/infini_train/include/tensor.h
@@ -109,6 +109,9 @@ public:
 
     friend std::ostream &operator<<(std::ostream &os, const Tensor &tensor);
 
+    void SaveAsNpy(const std::string &path) const;
+    void Print(std::ostream &os = std::cout) const;
+
 private:
     std::shared_ptr<TensorBuffer> buffer_;
     size_t offset_ = 0;

--- a/infini_train/src/autograd/misc.cc
+++ b/infini_train/src/autograd/misc.cc
@@ -159,6 +159,12 @@ std::vector<std::shared_ptr<Tensor>> Slice::Backward(const std::vector<std::shar
         grad_input = kernels::cpu::SliceBackward(grad_output, input, starts_, ends_, steps_);
         break;
     }
+#ifdef USE_CUDA
+    case DeviceType::kCUDA: {
+        grad_input = kernels::cuda::SliceBackward(grad_output, input, starts_, ends_, steps_);
+        break;
+    }
+#endif
     default:
         LOG(FATAL) << "Unsupported device type: " << static_cast<int>(input->GetDevice().Type());
         break;

--- a/infini_train/src/kernels/cuda/accumulate_grad.cu
+++ b/infini_train/src/kernels/cuda/accumulate_grad.cu
@@ -14,8 +14,8 @@ __global__ void AccumulateGradKernel(const float *grad_ptr, float rate, float *t
 void AccumulateGrad(const std::shared_ptr<Tensor> &gradient, float rate, const std::shared_ptr<Tensor> &tensor) {
     size_t num_elements = gradient->NumElements();
 
-    const float *grad_ptr = reinterpret_cast<const float *>(gradient->DataPtr());
-    float *tensor_ptr = reinterpret_cast<float *>(tensor->DataPtr());
+    const float *grad_ptr = static_cast<const float *>(gradient->DataPtr());
+    float *tensor_ptr = static_cast<float *>(tensor->DataPtr());
 
     int threads_per_block = 256;
     int num_blocks = (num_elements + threads_per_block - 1) / threads_per_block;
@@ -43,10 +43,10 @@ void AdamAccumulateGrad(const std::shared_ptr<Tensor> &grad, const std::shared_p
                         float beta1, float beta2, float eps, int64_t t) {
     size_t num_elements = grad->NumElements();
 
-    const float *grad_data = reinterpret_cast<const float *>(grad->DataPtr());
-    float *m_data = reinterpret_cast<float *>(m->DataPtr());
-    float *v_data = reinterpret_cast<float *>(v->DataPtr());
-    float *param_data = reinterpret_cast<float *>(param->DataPtr());
+    const float *grad_data = static_cast<const float *>(grad->DataPtr());
+    float *m_data = static_cast<float *>(m->DataPtr());
+    float *v_data = static_cast<float *>(v->DataPtr());
+    float *param_data = static_cast<float *>(param->DataPtr());
 
     const float bias_correction_m = 1.0f - std::pow(beta1, t);
     const float bias_correction_v = 1.0f - std::pow(beta2, t);

--- a/infini_train/src/kernels/cuda/cross_entropy.cu
+++ b/infini_train/src/kernels/cuda/cross_entropy.cu
@@ -37,9 +37,7 @@ std::shared_ptr<Tensor> CrossEntropyForward(const std::shared_ptr<Tensor> &input
     const int bs = std::accumulate(input_dims.rbegin() + 1, input_dims.rend(), 1, std::multiplies<int64_t>{});
     const int num_classes = *input_dims.rbegin();
 
-    auto batched_output
-        = std::make_shared<Tensor>(std::vector<int64_t>{bs}, DataType::kFLOAT32, Device(DeviceType::kCUDA, 0));
-
+    auto batched_output = std::make_shared<Tensor>(std::vector<int64_t>{bs}, DataType::kFLOAT32, input->GetDevice());
     const float *input_ptr = static_cast<const float *>(input->DataPtr());
     float *batched_loss_ptr = static_cast<float *>(batched_output->DataPtr());
 
@@ -74,7 +72,7 @@ std::shared_ptr<Tensor> CrossEntropyForward(const std::shared_ptr<Tensor> &input
                           static_cast<const float *>(loss_cpu.DataPtr()) + bs, 0.0f)
         / bs;
 
-    return {std::make_shared<Tensor>(loss->To(Device(DeviceType::kCUDA, 0)))};
+    return {std::make_shared<Tensor>(loss->To(input->GetDevice()))};
 }
 
 template <typename TargetType>
@@ -103,8 +101,8 @@ std::shared_ptr<Tensor> CrossEntropyBackward(const std::shared_ptr<Tensor> &inpu
     const int num_classes = *input_dims.rbegin();
 
     CHECK_EQ(grad_output->Dims().size(), 0);
-    auto grad_input = std::make_shared<Tensor>(input->Dims(), DataType::kFLOAT32, Device(DeviceType::kCUDA, 0));
-
+    auto grad_input = std::make_shared<Tensor>(input->Dims(), DataType::kFLOAT32, grad_output->GetDevice());
+    grad_input->Fill<float>(0.0f);
     const float *input_ptr = static_cast<const float *>(input->DataPtr());
     float *input_grad_ptr = static_cast<float *>(grad_input->DataPtr());
 

--- a/infini_train/src/kernels/cuda/embedding.cu
+++ b/infini_train/src/kernels/cuda/embedding.cu
@@ -42,56 +42,53 @@ std::shared_ptr<Tensor> EmbeddingForward(const std::shared_ptr<Tensor> &input, c
     const int batch_size = input->Dims().size() == 2 ? input->Dims()[0] : 1;
     const int max_seqlen = input->Dims().size() == 2 ? input->Dims()[1] : input->Dims()[0];
     const int embed_dim = weight->Dims()[1];
+    auto output_dims = input->Dims();
+    output_dims.push_back(embed_dim);
 
-    auto output = std::make_shared<Tensor>(std::vector<int64_t>{batch_size, max_seqlen, embed_dim}, DataType::kFLOAT32,
-                                           Device(DeviceType::kCUDA, 0));
-
+    auto output = std::make_shared<Tensor>(output_dims, DataType::kFLOAT32, input->GetDevice());
     int threads_per_block = 256;
     int num_blocks = (batch_size * max_seqlen * embed_dim + threads_per_block - 1) / threads_per_block;
     EmbeddingForwardKernel<<<num_blocks, threads_per_block>>>(
-        reinterpret_cast<const int64_t *>(input->DataPtr()), reinterpret_cast<float *>(output->DataPtr()),
-        reinterpret_cast<const float *>(weight->DataPtr()), batch_size, max_seqlen, embed_dim);
-
+        static_cast<const int64_t *>(input->DataPtr()), static_cast<float *>(output->DataPtr()),
+        static_cast<const float *>(weight->DataPtr()), batch_size, max_seqlen, embed_dim);
     return output;
 }
 
-__global__ void WeightBackwardKernel(float *grad_weight, const float *grad_output, const int64_t *input, int batch_size,
-                                     int max_seqlen, int embed_dim) {
+__global__ void EmbeddingBackwardKernel(const int64_t *input_ptr, const float *grad_output_ptr, float *grad_weight_ptr,
+                                        int num_tokens, int embedding_dim) {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx >= batch_size * max_seqlen) {
+    if (idx >= num_tokens) {
         return;
     }
 
-    int token = static_cast<int>(input[idx]);
-    if (token < 0) {
+    int token_id = static_cast<int>(input_ptr[idx]);
+    if (token_id < 0) {
         return;
     }
 
-    int c = threadIdx.x % embed_dim;
-    float grad = grad_output[idx * embed_dim + c];
-
-    atomicAdd(&grad_weight[token * embed_dim + c], grad);
+    for (int j = 0; j < embedding_dim; ++j) {
+        atomicAdd(&grad_weight_ptr[token_id * embedding_dim + j], grad_output_ptr[idx * embedding_dim + j]);
+    }
 }
 
 std::shared_ptr<Tensor> EmbeddingBackward(const std::shared_ptr<Tensor> &input, const std::vector<int64_t> &weight_dims,
                                           const std::shared_ptr<Tensor> &grad_output) {
     CHECK(input->Dtype() == DataType::kINT64);
     CHECK_EQ(weight_dims.size(), 2);
+    const int embedding_dim = weight_dims[1];
+    CHECK_EQ(input->Dims().size() + 1, grad_output->Dims().size());
+    for (int idx = 0; idx < input->Dims().size(); ++idx) { CHECK_EQ(input->Dims()[idx], grad_output->Dims()[idx]); }
+    CHECK_EQ(*grad_output->Dims().rbegin(), embedding_dim);
 
-    const int batch_size = input->Dims().size() == 2 ? input->Dims()[0] : 1;
-    const int max_seqlen = input->Dims().size() == 2 ? input->Dims()[1] : input->Dims()[0];
-    const int embed_dim = weight_dims[1];
-
-    auto grad_weight = std::make_shared<Tensor>(weight_dims, DataType::kFLOAT32, Device(DeviceType::kCUDA, 0));
+    auto grad_weight = std::make_shared<Tensor>(weight_dims, DataType::kFLOAT32, grad_output->GetDevice());
     grad_weight->Fill<float>(0.0f);
+    const int num_tokens = input->NumElements();
+    const int threads_per_block = 256;
+    const int num_blocks = (num_tokens + threads_per_block - 1) / threads_per_block;
 
-    int threads_per_block = 256;
-    int num_blocks = ((batch_size * max_seqlen * embed_dim) + threads_per_block - 1) / threads_per_block;
-
-    WeightBackwardKernel<<<num_blocks, threads_per_block>>>(
-        reinterpret_cast<float *>(grad_weight->DataPtr()), reinterpret_cast<const float *>(grad_output->DataPtr()),
-        reinterpret_cast<const int64_t *>(input->DataPtr()), batch_size, max_seqlen, embed_dim);
-
+    EmbeddingBackwardKernel<<<num_blocks, threads_per_block>>>(
+        static_cast<const int64_t *>(input->DataPtr()), static_cast<const float *>(grad_output->DataPtr()),
+        static_cast<float *>(grad_weight->DataPtr()), num_tokens, embedding_dim);
     return grad_weight;
 }
 } // namespace infini_train::kernels::cuda

--- a/infini_train/src/kernels/cuda/fused_embedding.cu
+++ b/infini_train/src/kernels/cuda/fused_embedding.cu
@@ -53,9 +53,9 @@ std::shared_ptr<Tensor> FusedEmbeddingForward(const std::shared_ptr<Tensor> &inp
     int threads_per_block = 256;
     int num_blocks = (batch_size * max_seqlen * embed_dim + threads_per_block - 1) / threads_per_block;
     FusedEmbeddingForwardKernel<<<num_blocks, threads_per_block>>>(
-        reinterpret_cast<const uint16_t *>(input->DataPtr()), reinterpret_cast<float *>(output->DataPtr()),
-        reinterpret_cast<const float *>(wte->DataPtr()), reinterpret_cast<const float *>(wpe->DataPtr()), batch_size,
-        max_seqlen, embed_dim);
+        static_cast<const uint16_t *>(input->DataPtr()), static_cast<float *>(output->DataPtr()),
+        static_cast<const float *>(wte->DataPtr()), static_cast<const float *>(wpe->DataPtr()), batch_size, max_seqlen,
+        embed_dim);
     return {output};
 }
 
@@ -114,13 +114,13 @@ FusedEmbeddingBackward(const std::shared_ptr<Tensor> &input, const std::shared_p
     int threads_per_block = 256;
     int num_blocks = ((max_seqlen * embed_dim) + threads_per_block - 1) / threads_per_block;
     WPEBackwardKernel<<<num_blocks, threads_per_block>>>(
-        reinterpret_cast<float *>(grad_wpe->DataPtr()), reinterpret_cast<const float *>(grad_output->DataPtr()),
-        reinterpret_cast<const uint16_t *>(input->DataPtr()), batch_size, max_seqlen, embed_dim);
+        static_cast<float *>(grad_wpe->DataPtr()), static_cast<const float *>(grad_output->DataPtr()),
+        static_cast<const uint16_t *>(input->DataPtr()), batch_size, max_seqlen, embed_dim);
 
     num_blocks = ((batch_size * max_seqlen * embed_dim) + threads_per_block - 1) / threads_per_block;
     WTEBackwardKernel<<<num_blocks, threads_per_block>>>(
-        reinterpret_cast<float *>(grad_wte->DataPtr()), reinterpret_cast<const float *>(grad_output->DataPtr()),
-        reinterpret_cast<const uint16_t *>(input->DataPtr()), batch_size, max_seqlen, embed_dim);
+        static_cast<float *>(grad_wte->DataPtr()), static_cast<const float *>(grad_output->DataPtr()),
+        static_cast<const uint16_t *>(input->DataPtr()), batch_size, max_seqlen, embed_dim);
 
     return {grad_wte, grad_wpe};
 }

--- a/infini_train/src/kernels/cuda/layernorm.cu
+++ b/infini_train/src/kernels/cuda/layernorm.cu
@@ -19,46 +19,58 @@ namespace infini_train::kernels::cuda {
         }                                                                                                              \
     } while (0)
 
-#ifndef WARP_SIZE
-#define WARP_SIZE 32
-#endif
-
-__forceinline__ __device__ float warpReduceSum(float val) {
-    unsigned mask = __activemask();
-    for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) { val += __shfl_down_sync(mask, val, offset); }
-    return val;
-}
-
-__global__ void LayerNormForwardKernel(const float *input, const float *weight, const float *bias, float *mean,
-                                       float *rstd, float *output, float eps, int batch_size, int max_seqlen,
+__global__ void LayerNormForwardKernel(const float *input, const float *weight, const float *bias, float *mean_out,
+                                       float *rstd_out, float *output, float eps, int batch_size, int max_seqlen,
                                        int embed_dim) {
-    int lane_id = threadIdx.x % WARP_SIZE;
-    int warp_id = threadIdx.x / WARP_SIZE;
-    int idx = blockIdx.x * (blockDim.x / WARP_SIZE) + warp_id;
-    if (idx >= batch_size * max_seqlen) {
-        return;
-    }
+    int idx = blockIdx.x; // token idx
+    const float *x = input + idx * embed_dim;
+    float *y = output + idx * embed_dim;
 
+    extern __shared__ float smem[]; // smem[0:threadnum] for sum, next for sqsum
     float sum = 0.0f;
-    for (int i = lane_id; i < embed_dim; i += WARP_SIZE) { sum += (float)input[idx * embed_dim + i]; }
-    float m = warpReduceSum(sum) / embed_dim;
-    if (lane_id == 0 && mean) {
-        mean[idx] = m;
+    float sqsum = 0.0f;
+
+    for (int i = threadIdx.x; i < embed_dim; i += blockDim.x) {
+        float val = x[i];
+        sum += val;
+        sqsum += val * val;
     }
 
-    sum = 0.0f;
-    for (int i = lane_id; i < embed_dim; i += WARP_SIZE) {
-        float diff = (float)input[idx * embed_dim + i] - m;
-        sum += diff * diff;
+    // block reduce sum
+    smem[threadIdx.x] = sum;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) {
+            smem[threadIdx.x] += smem[threadIdx.x + stride];
+        }
+        __syncthreads();
     }
-    float s = rsqrtf(warpReduceSum(sum) / embed_dim + eps);
-    if (lane_id == 0 && rstd) {
-        rstd[idx] = s;
+    float mean = smem[0] / embed_dim;
+    if (threadIdx.x == 0 && mean_out) {
+        mean_out[idx] = mean;
     }
+    __syncthreads();
 
-    for (int c = lane_id; c < embed_dim; c += WARP_SIZE) {
-        float n = s * ((float)input[idx * embed_dim + c] - m);
-        output[idx * embed_dim + c] = (float)(n * (float)weight[c] + (float)bias[c]);
+    // block reduce sqsum
+    smem[threadIdx.x] = sqsum;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (threadIdx.x < stride) {
+            smem[threadIdx.x] += smem[threadIdx.x + stride];
+        }
+        __syncthreads();
+    }
+    float var = smem[0] / embed_dim - mean * mean;
+    float rstd = rsqrtf(var + eps);
+    if (threadIdx.x == 0 && rstd_out) {
+        rstd_out[idx] = rstd;
+    }
+    __syncthreads();
+
+    // normalize
+    for (int i = threadIdx.x; i < embed_dim; i += blockDim.x) {
+        float norm = (x[i] - mean) * rstd;
+        y[i] = norm * weight[i] + bias[i];
     }
 }
 
@@ -75,80 +87,115 @@ std::shared_ptr<Tensor> LayerNormForward(const std::shared_ptr<Tensor> &input, c
     const int max_seqlen = input->Dims()[1];
     const int embed_dim = input->Dims()[2];
 
-    auto output = std::make_shared<Tensor>(std::vector<int64_t>{batch_size, max_seqlen, embed_dim}, DataType::kFLOAT32,
-                                           Device(DeviceType::kCUDA, 0));
-    mean = std::make_unique<Tensor>(std::vector<int64_t>{batch_size, max_seqlen}, DataType::kFLOAT32,
-                                    Device(DeviceType::kCUDA, 0));
-    rstd = std::make_unique<Tensor>(std::vector<int64_t>{batch_size, max_seqlen}, DataType::kFLOAT32,
-                                    Device(DeviceType::kCUDA, 0));
+    auto output = std::make_shared<Tensor>(input->Dims(), DataType::kFLOAT32, input->GetDevice());
+    mean = std::make_shared<Tensor>(std::vector<int64_t>{batch_size, max_seqlen}, DataType::kFLOAT32,
+                                    input->GetDevice());
+    rstd = std::make_shared<Tensor>(std::vector<int64_t>{batch_size, max_seqlen}, DataType::kFLOAT32,
+                                    input->GetDevice());
     mean->Fill<float>(0.0f);
     rstd->Fill<float>(0.0f);
 
     int threads_per_block = 256;
-    int warps_per_block = threads_per_block / WARP_SIZE;
-    int num_blocks = (batch_size * max_seqlen + warps_per_block - 1) / warps_per_block;
+    int num_blocks = batch_size * max_seqlen;
+    int shared_mem_size = threads_per_block * sizeof(float);
 
-    LayerNormForwardKernel<<<num_blocks, threads_per_block>>>(
-        reinterpret_cast<const float *>(input->DataPtr()), reinterpret_cast<const float *>(weight->DataPtr()),
-        reinterpret_cast<const float *>(bias->DataPtr()), reinterpret_cast<float *>(mean->DataPtr()),
-        reinterpret_cast<float *>(rstd->DataPtr()), reinterpret_cast<float *>(output->DataPtr()), eps, batch_size,
-        max_seqlen, embed_dim);
-
-    return {output};
+    LayerNormForwardKernel<<<num_blocks, threads_per_block, shared_mem_size>>>(
+        static_cast<const float *>(input->DataPtr()), static_cast<const float *>(weight->DataPtr()),
+        static_cast<const float *>(bias->DataPtr()), static_cast<float *>(mean->DataPtr()),
+        static_cast<float *>(rstd->DataPtr()), static_cast<float *>(output->DataPtr()), eps, batch_size, max_seqlen,
+        embed_dim);
+    return output;
 }
 
-__global__ void LayerNormBackwardKernel(float *grad_input, float *grad_weight, float *grad_bias,
-                                        const float *grad_output, const float *input, const float *weight,
-                                        const float *mean, const float *rstd, int batch_size, int max_seqlen,
-                                        int embed_dim) {
-    const int tid = threadIdx.x;
-    const int bid = blockIdx.x;
-    const int lane = tid % WARP_SIZE;
-    const int warp_id = tid / WARP_SIZE;
-    const int warps_per_block = blockDim.x / WARP_SIZE;
+// Helper function for warp/block-wide reduction
+__inline__ __device__ float BlockReduceSum(float val) {
+    static __shared__ float shared_sum[32]; // assuming <= 1024 threads
 
-    __shared__ float shared_grad_weight[32];
-    __shared__ float shared_grad_bias[32];
+    int lane = threadIdx.x % 32;
+    int warp_id = threadIdx.x / 32;
 
-    float grad_weight_sum = 0.0f;
-    float grad_bias_sum = 0.0f;
-    float grad_input_val = 0.0f;
+    // Warp reduction
+    for (int offset = 16; offset > 0; offset /= 2) { val += __shfl_down_sync(0xffffffff, val, offset); }
 
-    const int N = batch_size * max_seqlen * embed_dim;
-
-    for (int i = bid * embed_dim + tid; i < N; i += gridDim.x * embed_dim) {
-        int idx = i % embed_dim;
-        float val_x = input[i];
-        float val_grad_output = grad_output[i];
-        float norm_x = (val_x - mean[i / embed_dim]) * rstd[i / embed_dim];
-
-        grad_weight_sum += val_grad_output * norm_x;
-        grad_bias_sum += val_grad_output;
-
-        // Compute grad_input using grad_output
-        grad_input_val = val_grad_output * weight[idx] * rstd[i / embed_dim];
-        grad_input[i] = grad_input_val;
+    // Write reduced warp result to shared memory
+    if (lane == 0) {
+        shared_sum[warp_id] = val;
     }
 
-    grad_weight_sum = warpReduceSum(grad_weight_sum);
-    grad_bias_sum = warpReduceSum(grad_bias_sum);
+    __syncthreads();
 
-    if (lane == 0) {
-        shared_grad_weight[warp_id] = grad_weight_sum;
-        shared_grad_bias[warp_id] = grad_bias_sum;
+    // Final reduction among warps
+    val = (threadIdx.x < (blockDim.x + 31) / 32) ? shared_sum[lane] : 0.0f;
+    if (warp_id == 0) {
+        for (int offset = 16; offset > 0; offset /= 2) { val += __shfl_down_sync(0xffffffff, val, offset); }
+    }
+    return val;
+}
+
+__global__ void LayerNormBackwardKernel(const float *__restrict__ input, const float *__restrict__ grad_output,
+                                        const float *__restrict__ mean, const float *__restrict__ rstd,
+                                        const float *__restrict__ weight, float *__restrict__ grad_input,
+                                        float *__restrict__ grad_weight, float *__restrict__ grad_bias, int embed_dim) {
+    extern __shared__ float shared[]; // shared[0] = dnorm_mean, shared[1] = dnorm_norm_mean
+
+    int tid = threadIdx.x;
+    int token_idx = blockIdx.x;
+    int stride = blockDim.x;
+
+    const float *input_ptr = input + token_idx * embed_dim;
+    const float *grad_output_ptr = grad_output + token_idx * embed_dim;
+    float *grad_input_ptr = grad_input + token_idx * embed_dim;
+
+    float mean_val = mean[token_idx];
+    float rstd_val = rstd[token_idx];
+
+    float dnorm_mean = 0.f;
+    float dnorm_norm_mean = 0.f;
+
+    // Step 1: accumulate dnorm_mean and dnorm_norm_mean
+    for (int i = tid; i < embed_dim; i += stride) {
+        float gi = grad_output_ptr[i];
+        float wi = weight[i];
+        float xi = input_ptr[i];
+        float dnorm = wi * gi;
+        dnorm_mean += dnorm;
+        dnorm_norm_mean += dnorm * (xi - mean_val);
+    }
+
+    // Block-wide reductions
+    dnorm_mean = BlockReduceSum(dnorm_mean);
+    dnorm_norm_mean = BlockReduceSum(dnorm_norm_mean);
+
+    __syncthreads();
+
+    // Write reduced dnorm_mean and dnorm_norm_mean to shared memory
+    if (tid == 0) {
+        shared[0] = dnorm_mean / embed_dim;
+        shared[1] = (dnorm_norm_mean / embed_dim) * rstd_val - shared[0] * mean_val * rstd_val;
     }
     __syncthreads();
 
-    if (warp_id == 0 && lane < warps_per_block) {
-        grad_weight_sum = shared_grad_weight[lane];
-        grad_bias_sum = shared_grad_bias[lane];
-        grad_weight_sum = warpReduceSum(grad_weight_sum);
-        grad_bias_sum = warpReduceSum(grad_bias_sum);
+    dnorm_mean = shared[0];
+    dnorm_norm_mean = shared[1];
 
-        if (lane == 0) {
-            atomicAdd(&grad_weight[bid], grad_weight_sum);
-            atomicAdd(&grad_bias[bid], grad_bias_sum);
-        }
+    // Step 2: compute grad_input and accumulate grad_weight, grad_bias per dimension
+    for (int i = tid; i < embed_dim; i += stride) {
+        float go = grad_output_ptr[i];
+        float w = weight[i];
+        float x = input_ptr[i];
+
+        float norm = (x - mean_val) * rstd_val;
+
+        // compute grad_input
+        float dval = w * go;
+        dval -= dnorm_mean;
+        dval -= norm * dnorm_norm_mean;
+        dval *= rstd_val;
+        grad_input_ptr[i] = dval;
+
+        // accumulate grad_weight and grad_bias
+        atomicAdd(&grad_weight[i], go * norm);
+        atomicAdd(&grad_bias[i], go);
     }
 }
 
@@ -156,35 +203,26 @@ std::tuple<std::shared_ptr<Tensor>, std::shared_ptr<Tensor>, std::shared_ptr<Ten
 LayerNormBackward(const std::shared_ptr<Tensor> &input, const std::shared_ptr<Tensor> &weight,
                   const std::shared_ptr<Tensor> &bias, const std::shared_ptr<Tensor> &mean,
                   const std::shared_ptr<Tensor> &rstd, const std::shared_ptr<Tensor> &grad_output) {
-    CHECK_EQ(input->Dims().size(), 3);
-    CHECK_LE(input->Dims()[2], weight->Dims()[0]);
-    CHECK_LE(input->Dims()[2], bias->Dims()[0]);
-    CHECK_NE(mean, nullptr);
-    CHECK_NE(rstd, nullptr);
-
-    const int batch_size = input->Dims()[0];
-    const int max_seqlen = input->Dims()[1];
+    const int batch = input->Dims()[0];
+    const int seqlen = input->Dims()[1];
     const int embed_dim = input->Dims()[2];
 
-    auto grad_input = std::make_shared<Tensor>(input->Dims(), DataType::kFLOAT32, Device(DeviceType::kCUDA, 0));
-    auto grad_weight = std::make_shared<Tensor>(weight->Dims(), DataType::kFLOAT32, Device(DeviceType::kCUDA, 0));
-    auto grad_bias = std::make_shared<Tensor>(bias->Dims(), DataType::kFLOAT32, Device(DeviceType::kCUDA, 0));
-
+    auto grad_input = std::make_shared<Tensor>(input->Dims(), DataType::kFLOAT32, grad_output->GetDevice());
+    auto grad_weight = std::make_shared<Tensor>(weight->Dims(), DataType::kFLOAT32, grad_output->GetDevice());
+    auto grad_bias = std::make_shared<Tensor>(bias->Dims(), DataType::kFLOAT32, grad_output->GetDevice());
+    grad_input->Fill<float>(0.0f);
     grad_weight->Fill<float>(0.0f);
     grad_bias->Fill<float>(0.0f);
 
+    int num_blocks = batch * seqlen;
     int threads_per_block = 256;
-    int num_blocks = (batch_size * max_seqlen * embed_dim + threads_per_block - 1) / threads_per_block;
+    int shared_mem = 2 * sizeof(float); // for the block-wide `dnorm_mean` & `dnorm_norm_mean`
 
-    // TODO(zbl): check correctness
-    LayerNormBackwardKernel<<<num_blocks, threads_per_block>>>(
-        reinterpret_cast<float *>(grad_input->DataPtr()), reinterpret_cast<float *>(grad_weight->DataPtr()),
-        reinterpret_cast<float *>(grad_bias->DataPtr()), reinterpret_cast<const float *>(grad_output->DataPtr()),
-        reinterpret_cast<const float *>(input->DataPtr()), reinterpret_cast<const float *>(weight->DataPtr()),
-        reinterpret_cast<const float *>(mean->DataPtr()), reinterpret_cast<const float *>(rstd->DataPtr()), batch_size,
-        max_seqlen, embed_dim);
-    CUDA_CHECK(cudaGetLastError());
-
+    LayerNormBackwardKernel<<<num_blocks, threads_per_block, shared_mem>>>(
+        static_cast<const float *>(input->DataPtr()), static_cast<const float *>(grad_output->DataPtr()),
+        static_cast<const float *>(mean->DataPtr()), static_cast<const float *>(rstd->DataPtr()),
+        static_cast<const float *>(weight->DataPtr()), static_cast<float *>(grad_input->DataPtr()),
+        static_cast<float *>(grad_weight->DataPtr()), static_cast<float *>(grad_bias->DataPtr()), embed_dim);
     return {grad_input, grad_weight, grad_bias};
 }
 } // namespace infini_train::kernels::cuda

--- a/infini_train/src/kernels/cuda/linear.cu
+++ b/infini_train/src/kernels/cuda/linear.cu
@@ -69,10 +69,7 @@ std::shared_ptr<Tensor> MatmulForward(const std::shared_ptr<Tensor> &input, cons
     int64_t stride_a = n * k;
     int64_t stride_b = k * m;
     int64_t stride_c = m * n;
-    // TODO(zbl): check GEMM algo
-    // CUBLAS_GEMM_DEFAULT might requires TensorCore
-    // Use CUBLAS_GEMM_ALGO0 to disable TensorCore algos
-
+    // NOTE(zbl): the last cublasGemmAlgo_t param has no effect on GPU arch >= sm_80(Ampere)
     CUBLAS_CHECK(cublasGemmStridedBatchedEx(handle, CUBLAS_OP_N, CUBLAS_OP_N, n, m, k, &alpha, other->DataPtr(),
                                             CUDA_R_32F, lda, stride_a, input->DataPtr(), CUDA_R_32F, ldb, stride_b,
                                             &beta, output->DataPtr(), CUDA_R_32F, ldc, stride_c, bs, CUDA_R_32F,

--- a/infini_train/src/kernels/cuda/sigmoid.cu
+++ b/infini_train/src/kernels/cuda/sigmoid.cu
@@ -19,7 +19,7 @@ __global__ void SigmoidForwardKernel(const float *input_ptr, float *output_ptr, 
 std::shared_ptr<Tensor> SigmoidForward(const std::shared_ptr<Tensor> &input) {
     size_t num_elements = input->NumElements();
 
-    auto output = std::make_shared<Tensor>(input->Dims(), DataType::kFLOAT32, Device(DeviceType::kCUDA, 0));
+    auto output = std::make_shared<Tensor>(input->Dims(), DataType::kFLOAT32, input->GetDevice());
 
     const float *input_ptr = static_cast<const float *>(input->DataPtr());
     float *output_ptr = static_cast<float *>(output->DataPtr());
@@ -44,8 +44,8 @@ std::shared_ptr<Tensor> SigmoidBackward(const std::shared_ptr<Tensor> &output,
                                         const std::shared_ptr<Tensor> &grad_output) {
     size_t num_elements = output->NumElements();
 
-    auto grad_input = std::make_shared<Tensor>(output->Dims(), DataType::kFLOAT32, Device(DeviceType::kCUDA, 0));
-
+    auto grad_input = std::make_shared<Tensor>(output->Dims(), DataType::kFLOAT32, grad_output->GetDevice());
+    grad_input->Fill<float>(0.0f);
     const float *output_ptr = static_cast<const float *>(output->DataPtr());
     const float *grad_output_ptr = static_cast<float *>(grad_output->DataPtr());
     float *grad_input_ptr = static_cast<float *>(grad_input->DataPtr());

--- a/infini_train/src/kernels/cuda/softmax.cu
+++ b/infini_train/src/kernels/cuda/softmax.cu
@@ -10,15 +10,6 @@
 #include "infini_train/include/tensor.h"
 
 namespace infini_train::kernels::cuda {
-
-#define CUDA_CHECK(call)                                                                                               \
-    do {                                                                                                               \
-        cudaError_t status = call;                                                                                     \
-        if (status != cudaSuccess) {                                                                                   \
-            LOG(FATAL) << "CUDA Error: " << cudaGetErrorString(status) << " at " << __FILE__ << ":" << __LINE__;       \
-        }                                                                                                              \
-    } while (0)
-
 template <size_t BLOCK_SIZE, typename T>
 __global__ void SoftmaxForwardKernel(T *output, const T *input, int64_t outer_size, int64_t axis_size,
                                      int64_t inner_size) {
@@ -116,7 +107,6 @@ std::shared_ptr<Tensor> SoftmaxForward(const std::shared_ptr<Tensor> &input, int
     default:
         LOG(FATAL) << "CUDA softmax forward: 'Unsupported data type' at " << __FILE__ << ":" << __LINE__;
     }
-    CUDA_CHECK(cudaDeviceSynchronize());
     return output;
 }
 

--- a/infini_train/src/kernels/cuda/softmax.cu
+++ b/infini_train/src/kernels/cuda/softmax.cu
@@ -76,8 +76,8 @@ void LaunchForward(const std::shared_ptr<Tensor> &output, const std::shared_ptr<
         return;
     }
 
-    T *output_ptr = reinterpret_cast<T *>(output->DataPtr());
-    const T *input_ptr = reinterpret_cast<const T *>(input->DataPtr());
+    T *output_ptr = static_cast<T *>(output->DataPtr());
+    const T *input_ptr = static_cast<const T *>(input->DataPtr());
 
     cudaDeviceProp prop;
     cudaGetDeviceProperties(&prop, input->GetDevice().Index());
@@ -160,9 +160,9 @@ void LaunchBackward(const std::shared_ptr<Tensor> &grad_input, const std::shared
         return;
     }
 
-    T *grad_input_ptr = reinterpret_cast<T *>(grad_input->DataPtr());
-    const T *grad_output_ptr = reinterpret_cast<const T *>(grad_output->DataPtr());
-    const T *output_ptr = reinterpret_cast<const T *>(output->DataPtr());
+    T *grad_input_ptr = static_cast<T *>(grad_input->DataPtr());
+    const T *grad_output_ptr = static_cast<const T *>(grad_output->DataPtr());
+    const T *output_ptr = static_cast<const T *>(output->DataPtr());
 
     cudaDeviceProp prop;
     cudaGetDeviceProperties(&prop, output->GetDevice().Index());
@@ -186,6 +186,7 @@ std::shared_ptr<Tensor> SoftmaxBackward(const std::shared_ptr<Tensor> &grad_outp
     CHECK(dim >= 0 && dim < output->Dims().size());
 
     auto grad_input = std::make_shared<Tensor>(output_dims, dtype, output->GetDevice());
+    grad_input->Fill<float>(0.0f);
 
     switch (dtype) {
     case DataType::kFLOAT32:

--- a/infini_train/src/kernels/cuda/transform.cu
+++ b/infini_train/src/kernels/cuda/transform.cu
@@ -144,7 +144,7 @@ std::shared_ptr<Tensor> TransposeForward(const std::shared_ptr<Tensor> &input, i
 
     TransposeForwardKernel<<<num_blocks, threads_per_block>>>(
         reinterpret_cast<const float *>(input->DataPtr()), reinterpret_cast<float *>(output->DataPtr()), in_dims_dev,
-        in_strides_dev, out_strides_dev, ndim, dim0, dim1, threads_per_block);
+        in_strides_dev, out_strides_dev, ndim, dim0, dim1, num_elements);
 
     cudaFree(in_dims_dev);
     cudaFree(in_strides_dev);

--- a/infini_train/src/kernels/cuda/transform.cu
+++ b/infini_train/src/kernels/cuda/transform.cu
@@ -37,9 +37,8 @@ std::shared_ptr<Tensor> TrilForward(const std::shared_ptr<Tensor> &input, int64_
     int threads_per_block = 256;
     int num_blocks = (rows * cols + threads_per_block - 1) / threads_per_block;
 
-    TrilForwardKernel<<<num_blocks, threads_per_block>>>(reinterpret_cast<float *>(input->DataPtr()),
-                                                         reinterpret_cast<float *>(output->DataPtr()), rows, cols,
-                                                         diagonal);
+    TrilForwardKernel<<<num_blocks, threads_per_block>>>(static_cast<float *>(input->DataPtr()),
+                                                         static_cast<float *>(output->DataPtr()), rows, cols, diagonal);
     return output;
 }
 
@@ -64,12 +63,13 @@ std::shared_ptr<Tensor> TrilBackward(const std::shared_ptr<Tensor> &grad_output,
     int cols = grad_output->Dims()[1];
 
     auto grad_input = std::make_shared<Tensor>(grad_output->Dims(), grad_output->Dtype(), grad_output->GetDevice());
+    grad_input->Fill<float>(0.0f);
 
     int threads_per_block = 256;
     int num_blocks = (rows * cols + threads_per_block - 1) / threads_per_block;
 
-    TrilBackwardKernel<<<num_blocks, threads_per_block>>>(reinterpret_cast<const float *>(grad_output->DataPtr()),
-                                                          reinterpret_cast<float *>(grad_input->DataPtr()), rows, cols,
+    TrilBackwardKernel<<<num_blocks, threads_per_block>>>(static_cast<const float *>(grad_output->DataPtr()),
+                                                          static_cast<float *>(grad_input->DataPtr()), rows, cols,
                                                           diagonal);
 
     return grad_input;
@@ -84,30 +84,30 @@ __global__ void TransposeForwardKernel(const float *input, float *output, const 
     }
 
     int64_t remaining = idx;
-    int64_t in_flat_idx = 0;
+    // TODO(zbl): assume ndim <= 8 here
+    int64_t coords[8];
 
+    // 1. decode coord from output index
     for (int i = 0; i < ndim; ++i) {
-        // the i-th coords of output tensor
-        int64_t coord = remaining / out_strides[i];
+        coords[i] = remaining / out_strides[i];
         remaining %= out_strides[i];
-
-        // the corresponding dim in input after swapping dim0 & dim1
-        int64_t mapped_dim = coord;
-        if (i == dim0) {
-            mapped_dim = remaining / out_strides[dim1];
-        } else if (i == dim1) {
-            mapped_dim = remaining / out_strides[dim0];
-        }
-
-        // calculate flat idx of input using mapped_dim
-        in_flat_idx += mapped_dim * in_strides[i];
     }
 
-    // copy to output
+    // 2. swap the coordinates
+    int64_t tmp = coords[dim0];
+    coords[dim0] = coords[dim1];
+    coords[dim1] = tmp;
+
+    // 3. compute input flat index
+    int64_t in_flat_idx = 0;
+    for (int i = 0; i < ndim; ++i) { in_flat_idx += coords[i] * in_strides[i]; }
+
     output[idx] = input[in_flat_idx];
 }
 
 std::shared_ptr<Tensor> TransposeForward(const std::shared_ptr<Tensor> &input, int64_t dim0, int64_t dim1) {
+    // TODO(zbl): assume ndim <= 8 here
+    CHECK_LE(input->Dims().size(), 8);
     dim0 = dim0 < 0 ? dim0 + input->Dims().size() : dim0;
     dim1 = dim1 < 0 ? dim1 + input->Dims().size() : dim1;
     CHECK(dim0 >= 0 && dim0 < input->Dims().size() && dim1 >= 0 && dim1 < input->Dims().size());
@@ -117,7 +117,7 @@ std::shared_ptr<Tensor> TransposeForward(const std::shared_ptr<Tensor> &input, i
     std::swap(out_dims[dim0], out_dims[dim1]);
 
     auto output = std::make_shared<Tensor>(out_dims, input->Dtype(), input->GetDevice());
-
+    output->Fill<float>(0.0f);
     int64_t ndim = in_dims.size();
     int64_t num_elements = output->NumElements();
 
@@ -143,9 +143,10 @@ std::shared_ptr<Tensor> TransposeForward(const std::shared_ptr<Tensor> &input, i
     int num_blocks = (num_elements + threads_per_block - 1) / threads_per_block;
 
     TransposeForwardKernel<<<num_blocks, threads_per_block>>>(
-        reinterpret_cast<const float *>(input->DataPtr()), reinterpret_cast<float *>(output->DataPtr()), in_dims_dev,
+        static_cast<const float *>(input->DataPtr()), static_cast<float *>(output->DataPtr()), in_dims_dev,
         in_strides_dev, out_strides_dev, ndim, dim0, dim1, num_elements);
 
+    // NOTE(zbl): cudaFree() needs explicit sync when cudaMallocAsync() is called
     cudaFree(in_dims_dev);
     cudaFree(in_strides_dev);
     cudaFree(out_strides_dev);
@@ -188,8 +189,8 @@ std::shared_ptr<Tensor> MaskForward(const std::shared_ptr<Tensor> &input, const 
     int num_blocks = (input->NumElements() + threads_per_block - 1) / threads_per_block;
 
     MaskForwardKernel<<<num_blocks, threads_per_block>>>(
-        reinterpret_cast<const float *>(input->DataPtr()), reinterpret_cast<const float *>(mask->DataPtr()),
-        reinterpret_cast<float *>(output->DataPtr()), value, batch_size, mask_size);
+        static_cast<const float *>(input->DataPtr()), static_cast<const float *>(mask->DataPtr()),
+        static_cast<float *>(output->DataPtr()), value, batch_size, mask_size);
     return output;
 }
 
@@ -218,13 +219,14 @@ std::shared_ptr<Tensor> MaskBackward(const std::shared_ptr<Tensor> &grad_output,
     int64_t batch_size = grad_output->NumElements() / mask_size;
 
     auto grad_input = std::make_shared<Tensor>(grad_output->Dims(), grad_output->Dtype(), grad_output->GetDevice());
+    grad_input->Fill<float>(0.0f);
 
     int threads_per_block = 256;
     int num_blocks = (grad_output->NumElements() + threads_per_block - 1) / threads_per_block;
 
     MaskBackwardKernel<<<num_blocks, threads_per_block>>>(
-        reinterpret_cast<const float *>(grad_output->DataPtr()), reinterpret_cast<const float *>(mask->DataPtr()),
-        reinterpret_cast<float *>(grad_input->DataPtr()), batch_size, mask_size);
+        static_cast<const float *>(grad_output->DataPtr()), static_cast<const float *>(mask->DataPtr()),
+        static_cast<float *>(grad_input->DataPtr()), batch_size, mask_size);
     return grad_input;
 }
 } // namespace infini_train::kernels::cuda


### PR DESCRIPTION
1. 修复：CUDA 上 GPT-2 训练前 20 步 loss 可与 torch 对齐。
![image](https://github.com/user-attachments/assets/24cfd01a-6a46-492c-a2c0-00319713e08e)

2. 添加：Tensor 的 SaveAsNpy() 以及 Print() 函数，效果如下：

<img width="810" alt="1745907714881" src="https://github.com/user-attachments/assets/bda31f95-695c-4f85-beac-52399662c3aa" />

