### PR TITLE
Refactor: optimize various code strutures and operator implementation

### DIFF
--- a/infini_train/src/kernels/cuda/cross_entropy.cu
+++ b/infini_train/src/kernels/cuda/cross_entropy.cu
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <cub/block/block_reduce.cuh>
+#include <cuda_runtime.h>
 #include <limits>
 #include <memory>
 #include <numeric>
@@ -17,16 +19,46 @@ namespace {
 constexpr float kNegativeInfinity = -std::numeric_limits<float>::infinity();
 }
 
-template <typename TargetType>
-__global__ void CrossEntropyForwardKernel(const float *input_ptr, const TargetType *target_ptr, float *loss_ptr, int bs,
-                                          int num_classes) {
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx < bs) {
-        float max_logit = kNegativeInfinity;
-        for (int j = 0; j < num_classes; ++j) { max_logit = max(max_logit, input_ptr[idx * num_classes + j]); }
-        float sum_exp = 0.0f;
-        for (int j = 0; j < num_classes; ++j) { sum_exp += expf(input_ptr[idx * num_classes + j] - max_logit); }
-        loss_ptr[idx] = -logf(expf(input_ptr[idx * num_classes + target_ptr[idx]] - max_logit) / sum_exp);
+template <size_t BLOCK_SIZE, typename TargetType>
+__global__ void CrossEntropyForwardKernel(const float *__restrict__ input_ptr,
+                                          const TargetType *__restrict__ target_ptr, float *__restrict__ loss_ptr,
+                                          int bs, int num_classes) {
+    __shared__ struct {
+        float max_logit;
+        float sum_exp;
+        TargetType target_class;
+        typename cub::BlockReduce<float, BLOCK_SIZE>::TempStorage reduce;
+    } shared;
+
+    const int sample_idx = blockIdx.x;
+    if (sample_idx >= bs) {
+        return;
+    }
+
+    const int tid = threadIdx.x;
+    const size_t base = sample_idx * num_classes;
+
+    if (tid == 0) {
+        shared.target_class = target_ptr[sample_idx];
+    }
+    __syncthreads();
+
+    // calculate the max
+    float thread_max = kNegativeInfinity;
+    for (int i = tid; i < num_classes; i += BLOCK_SIZE) { thread_max = fmaxf(thread_max, input_ptr[base + i]); }
+    shared.max_logit = cub::BlockReduce<float, BLOCK_SIZE>(shared.reduce).Reduce(thread_max, cub::Max());
+    __syncthreads();
+
+    // calculate the sum of exponents
+    float thread_sum = 0.0f;
+    for (int i = tid; i < num_classes; i += BLOCK_SIZE) { thread_sum += expf(input_ptr[base + i] - shared.max_logit); }
+    shared.sum_exp = cub::BlockReduce<float, BLOCK_SIZE>(shared.reduce).Sum(thread_sum);
+    __syncthreads();
+
+    // calculate the loss
+    if (tid == 0) {
+        const float target_val = input_ptr[base + shared.target_class] - shared.max_logit;
+        loss_ptr[sample_idx] = logf(shared.sum_exp) - target_val;
     }
 }
 
@@ -41,22 +73,22 @@ std::shared_ptr<Tensor> CrossEntropyForward(const std::shared_ptr<Tensor> &input
     const float *input_ptr = static_cast<const float *>(input->DataPtr());
     float *batched_loss_ptr = static_cast<float *>(batched_output->DataPtr());
 
-    int threads_per_block = 256;
-    int num_blocks = (bs + threads_per_block - 1) / threads_per_block;
+    constexpr int threads_per_block = 256;
+    int num_blocks = bs;
 
     // TODO(dcj): support multi datatypes later
     switch (target->Dtype()) {
     case DataType::kUINT8: {
         const uint8_t *target_ptr = static_cast<const uint8_t *>(target->DataPtr());
         // FIXME(dcj): do reduce on GPU
-        CrossEntropyForwardKernel<uint8_t>
+        CrossEntropyForwardKernel<threads_per_block, uint8_t>
             <<<num_blocks, threads_per_block>>>(input_ptr, target_ptr, batched_loss_ptr, bs, num_classes);
         break;
     }
     case DataType::kINT64: {
         const int64_t *target_ptr = static_cast<const int64_t *>(target->DataPtr());
         // FIXME(dcj): do reduce on GPU
-        CrossEntropyForwardKernel<int64_t>
+        CrossEntropyForwardKernel<threads_per_block, int64_t>
             <<<num_blocks, threads_per_block>>>(input_ptr, target_ptr, batched_loss_ptr, bs, num_classes);
         break;
     }
@@ -75,20 +107,53 @@ std::shared_ptr<Tensor> CrossEntropyForward(const std::shared_ptr<Tensor> &input
     return {std::make_shared<Tensor>(loss->To(input->GetDevice()))};
 }
 
-template <typename TargetType>
-__global__ void CrossEntropyBackwardKernel(const float *input_ptr, float *input_grad_ptr, const TargetType *target_ptr,
-                                           int bs, int num_classes) {
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx < bs) {
-        float max_logit = kNegativeInfinity;
-        for (int j = 0; j < num_classes; ++j) { max_logit = max(max_logit, input_ptr[idx * num_classes + j]); }
-        float sum_exp = 0.0f;
-        for (int j = 0; j < num_classes; ++j) { sum_exp += expf(input_ptr[idx * num_classes + j] - max_logit); }
-        for (int j = 0; j < num_classes; ++j) {
-            int idx_grad = idx * num_classes + j;
-            input_grad_ptr[idx_grad]
-                = (expf(input_ptr[idx_grad] - max_logit) / sum_exp - (j == target_ptr[idx] ? 1.0f : 0.0f)) / bs;
-        }
+template <typename TargetType, size_t BLOCK_SIZE>
+__global__ void CrossEntropyBackwardKernel(const float *__restrict__ input_ptr, float *__restrict__ input_grad_ptr,
+                                           const TargetType *__restrict__ target_ptr, int bs, int num_classes) {
+    __shared__ struct {
+        float max_logit;
+        float sum_exp;
+        int target_class;
+        typename cub::BlockReduce<float, BLOCK_SIZE>::TempStorage reduce;
+    } shared;
+
+    const int tid = threadIdx.x;
+    const int idx = blockIdx.x;
+
+    if (idx >= bs) {
+        return;
+    }
+
+    const size_t idx_base = idx * num_classes;
+
+    if (tid == 0) {
+        shared.target_class = static_cast<int>(target_ptr[idx]);
+    }
+    __syncthreads();
+
+    // calculate the max
+    float thread_max = kNegativeInfinity;
+    for (int i = tid; i < num_classes; i += BLOCK_SIZE) { thread_max = fmaxf(thread_max, input_ptr[idx_base + i]); }
+    shared.max_logit = cub::BlockReduce<float, BLOCK_SIZE>(shared.reduce).Reduce(thread_max, cub::Max());
+    __syncthreads();
+
+    // calculate the sum
+    float thread_sum = 0.0f;
+    for (int i = tid; i < num_classes; i += BLOCK_SIZE) {
+        thread_sum += expf(input_ptr[idx_base + i] - shared.max_logit);
+    }
+    shared.sum_exp = cub::BlockReduce<float, BLOCK_SIZE>(shared.reduce).Sum(thread_sum);
+    __syncthreads();
+
+    // calculate the gradient
+    const float inv_bs = 1.0f / bs;
+    const float scale = 1.0f / shared.sum_exp;
+    const int target = shared.target_class;
+
+    for (int i = tid; i < num_classes; i += BLOCK_SIZE) {
+        const int global_idx = idx_base + i;
+        const float exp_val = expf(input_ptr[global_idx] - shared.max_logit);
+        input_grad_ptr[global_idx] = (exp_val * scale - (j == target)) * inv_bs;
     }
 }
 
@@ -106,20 +171,20 @@ std::shared_ptr<Tensor> CrossEntropyBackward(const std::shared_ptr<Tensor> &inpu
     const float *input_ptr = static_cast<const float *>(input->DataPtr());
     float *input_grad_ptr = static_cast<float *>(grad_input->DataPtr());
 
-    int threads_per_block = 256;
-    int num_blocks = (bs + threads_per_block - 1) / threads_per_block;
+    constexpr int threads_per_block = 256;
+    int num_blocks = bs;
 
     // TODO(dcj): support multi datatypes later
     switch (target->Dtype()) {
     case DataType::kUINT8: {
         const uint8_t *target_ptr = static_cast<const uint8_t *>(target->DataPtr());
-        CrossEntropyBackwardKernel<uint8_t>
+        CrossEntropyBackwardKernel<uint8_t, threads_per_block>
             <<<num_blocks, threads_per_block>>>(input_ptr, input_grad_ptr, target_ptr, bs, num_classes);
         break;
     }
     case DataType::kINT64: {
         const int64_t *target_ptr = static_cast<const int64_t *>(target->DataPtr());
-        CrossEntropyBackwardKernel<int64_t>
+        CrossEntropyBackwardKernel<int64_t, threads_per_block>
             <<<num_blocks, threads_per_block>>>(input_ptr, input_grad_ptr, target_ptr, bs, num_classes);
         break;
     }

--- a/infini_train/src/kernels/cuda/cross_entropy.cu
+++ b/infini_train/src/kernels/cuda/cross_entropy.cu
@@ -153,7 +153,7 @@ __global__ void CrossEntropyBackwardKernel(const float *__restrict__ input_ptr, 
     for (int i = tid; i < num_classes; i += BLOCK_SIZE) {
         const int global_idx = idx_base + i;
         const float exp_val = expf(input_ptr[global_idx] - shared.max_logit);
-        input_grad_ptr[global_idx] = (exp_val * scale - (j == target)) * inv_bs;
+        input_grad_ptr[global_idx] = (exp_val * scale - (i == target)) * inv_bs;
     }
 }
 

--- a/infini_train/src/kernels/cuda/elementwise.cu
+++ b/infini_train/src/kernels/cuda/elementwise.cu
@@ -42,12 +42,9 @@ void LaunchKernel(Kernel &&kernel, const std::shared_ptr<Tensor> &output, const 
         = [](const auto &...ts) { return std::make_tuple(static_cast<T *>(ts ? ts->DataPtr() : nullptr)...); };
     auto input_ptrs = extract_ptrs(inputs...);
 
-    cudaDeviceProp prop;
-    cudaGetDeviceProperties(&prop, output->GetDevice().Index());
-
     const size_t num_elements = output->NumElements();
-    dim3 block_dims(std::min(BLOCK_SIZE, static_cast<size_t>(prop.maxThreadsPerBlock)));
-    dim3 grid_dims(std::min(CEIL_DIV(num_elements, block_dims.x), static_cast<size_t>(prop.maxGridSize[0])));
+    dim3 block_dims(std::min(BLOCK_SIZE, static_cast<size_t>(1024)));
+    dim3 grid_dims(CEIL_DIV(num_elements, block_dims.x));
     const size_t step = grid_dims.x * block_dims.x;
 
     for (size_t offset = 0; offset < num_elements; offset += step) {
@@ -297,8 +294,8 @@ std::pair<std::shared_ptr<Tensor>, std::shared_ptr<Tensor>> AddBackward(const st
     CHECK_EQ(a_dims.size(), grad_output->Dims().size());
 
     auto grad_a = std::make_shared<Tensor>(a_dims, DataType::kFLOAT32, grad_output->GetDevice());
-    cudaMemcpy(grad_a->DataPtr(), grad_output->DataPtr(), grad_output->NumElements() * sizeof(float),
-               cudaMemcpyDeviceToDevice);
+    cudaMemcpyAsync(grad_a->DataPtr(), grad_output->DataPtr(), grad_output->NumElements() * sizeof(float),
+                    cudaMemcpyDeviceToDevice, 0);
 
     auto grad_b = std::make_shared<Tensor>(b_dims, DataType::kFLOAT32, grad_output->GetDevice());
     grad_b->Fill<float>(0.0f);
@@ -325,15 +322,15 @@ std::pair<std::shared_ptr<Tensor>, std::shared_ptr<Tensor>> AddBackward(const st
     int64_t *d_b_strides = nullptr;
     int64_t *d_b_dims = nullptr;
 
-    cudaMalloc(&d_out_strides, ndim * sizeof(int64_t));
-    cudaMalloc(&d_out_dims, ndim * sizeof(int64_t));
-    cudaMalloc(&d_b_strides, b_ndim * sizeof(int64_t));
-    cudaMalloc(&d_b_dims, b_ndim * sizeof(int64_t));
+    cudaMallocAsync(&d_out_strides, 2 * (ndim + b_ndim) * sizeof(*d_out_strides), 0);
+    d_out_dims = d_out_strides + ndim;
+    d_b_strides = d_out_dims + ndim;
+    d_b_dims = d_b_strides + b_ndim;
 
-    cudaMemcpy(d_out_strides, out_strides.data(), ndim * sizeof(int64_t), cudaMemcpyHostToDevice);
-    cudaMemcpy(d_out_dims, out_dims.data(), ndim * sizeof(int64_t), cudaMemcpyHostToDevice);
-    cudaMemcpy(d_b_strides, b_strides.data(), b_ndim * sizeof(int64_t), cudaMemcpyHostToDevice);
-    cudaMemcpy(d_b_dims, b_dims.data(), b_ndim * sizeof(int64_t), cudaMemcpyHostToDevice);
+    cudaMemcpyAsync(d_out_strides, out_strides.data(), ndim * sizeof(int64_t), cudaMemcpyHostToDevice, 0);
+    cudaMemcpyAsync(d_out_dims, out_dims.data(), ndim * sizeof(int64_t), cudaMemcpyHostToDevice, 0);
+    cudaMemcpyAsync(d_b_strides, b_strides.data(), b_ndim * sizeof(int64_t), cudaMemcpyHostToDevice, 0);
+    cudaMemcpyAsync(d_b_dims, b_dims.data(), b_ndim * sizeof(int64_t), cudaMemcpyHostToDevice, 0);
 
     int threads = 256;
     int blocks = (num_elements + threads - 1) / threads;
@@ -342,10 +339,7 @@ std::pair<std::shared_ptr<Tensor>, std::shared_ptr<Tensor>> AddBackward(const st
                                                  static_cast<float *>(grad_b->DataPtr()), d_out_strides, d_out_dims,
                                                  ndim, d_b_strides, d_b_dims, b_ndim, num_elements);
     // NOTE(zbl): cudaFree() needs explicit sync when cudaMallocAsync() is called
-    cudaFree(d_out_strides);
-    cudaFree(d_out_dims);
-    cudaFree(d_b_strides);
-    cudaFree(d_b_dims);
+    cudaFreeAsync(d_out_strides, 0);
 
     return {grad_a, grad_b};
 }

--- a/infini_train/src/kernels/cuda/slice.cu
+++ b/infini_train/src/kernels/cuda/slice.cu
@@ -61,17 +61,20 @@ std::shared_ptr<Tensor> SliceForward(const std::shared_ptr<Tensor> &input, const
     int64_t total_elements = stride;
 
     int64_t *new_dims_dev, *starts_dev, *steps_dev, *input_strides_dev, *output_strides_dev;
-    cudaMalloc(&new_dims_dev, ends.size() * sizeof(int64_t));
-    cudaMalloc(&starts_dev, starts.size() * sizeof(int64_t));
-    cudaMalloc(&steps_dev, steps.size() * sizeof(int64_t));
-    cudaMalloc(&input_strides_dev, dims.size() * sizeof(int64_t));
-    cudaMalloc(&output_strides_dev, new_dims.size() * sizeof(int64_t));
 
-    cudaMemcpy(new_dims_dev, new_dims.data(), ends.size() * sizeof(int64_t), cudaMemcpyHostToDevice);
-    cudaMemcpy(starts_dev, starts.data(), starts.size() * sizeof(int64_t), cudaMemcpyHostToDevice);
-    cudaMemcpy(steps_dev, steps.data(), steps.size() * sizeof(int64_t), cudaMemcpyHostToDevice);
-    cudaMemcpy(input_strides_dev, src_strides.data(), dims.size() * sizeof(int64_t), cudaMemcpyHostToDevice);
-    cudaMemcpy(output_strides_dev, dst_strides.data(), new_dims.size() * sizeof(int64_t), cudaMemcpyHostToDevice);
+    cudaMallocAsync(&new_dims_dev,
+                    (ends.size() + starts.size() + steps.size() + dims.size() + new_dims.size()) * sizeof(int64_t), 0);
+    starts_dev = new_dims_dev + ends.size();
+    steps_dev = starts_dev + starts.size();
+    input_strides_dev = steps_dev + steps.size();
+    output_strides_dev = input_strides_dev + dims.size();
+
+    cudaMemcpyAsync(new_dims_dev, new_dims.data(), ends.size() * sizeof(int64_t), cudaMemcpyHostToDevice, 0);
+    cudaMemcpyAsync(starts_dev, starts.data(), starts.size() * sizeof(int64_t), cudaMemcpyHostToDevice, 0);
+    cudaMemcpyAsync(steps_dev, steps.data(), steps.size() * sizeof(int64_t), cudaMemcpyHostToDevice, 0);
+    cudaMemcpyAsync(input_strides_dev, src_strides.data(), dims.size() * sizeof(int64_t), cudaMemcpyHostToDevice, 0);
+    cudaMemcpyAsync(output_strides_dev, dst_strides.data(), new_dims.size() * sizeof(int64_t), cudaMemcpyHostToDevice,
+                    0);
 
     int threads_per_block = 256;
     int num_blocks = (total_elements + threads_per_block - 1) / threads_per_block;
@@ -80,11 +83,7 @@ std::shared_ptr<Tensor> SliceForward(const std::shared_ptr<Tensor> &input, const
         static_cast<const float *>(input->DataPtr()), static_cast<float *>(new_tensor->DataPtr()), new_dims_dev,
         starts_dev, steps_dev, input_strides_dev, output_strides_dev, num_dims, total_elements);
     // NOTE(zbl): cudaFree() needs explicit sync when cudaMallocAsync() is called
-    cudaFree(new_dims_dev);
-    cudaFree(starts_dev);
-    cudaFree(steps_dev);
-    cudaFree(input_strides_dev);
-    cudaFree(output_strides_dev);
+    cudaFreeAsync(new_dims_dev, 0);
 
     return new_tensor;
 }
@@ -142,17 +141,20 @@ std::shared_ptr<Tensor> SliceBackward(const std::shared_ptr<Tensor> &grad_output
 
     int dims_size = dims.size();
     int64_t *new_dims_dev, *starts_dev, *steps_dev, *input_strides_dev, *output_strides_dev;
-    cudaMalloc(&new_dims_dev, ends.size() * sizeof(int64_t));
-    cudaMalloc(&starts_dev, starts.size() * sizeof(int64_t));
-    cudaMalloc(&steps_dev, steps.size() * sizeof(int64_t));
-    cudaMalloc(&input_strides_dev, dims.size() * sizeof(int64_t));
-    cudaMalloc(&output_strides_dev, new_dims.size() * sizeof(int64_t));
 
-    cudaMemcpy(new_dims_dev, new_dims.data(), ends.size() * sizeof(int64_t), cudaMemcpyHostToDevice);
-    cudaMemcpy(starts_dev, starts.data(), starts.size() * sizeof(int64_t), cudaMemcpyHostToDevice);
-    cudaMemcpy(steps_dev, steps.data(), steps.size() * sizeof(int64_t), cudaMemcpyHostToDevice);
-    cudaMemcpy(input_strides_dev, src_strides.data(), dims.size() * sizeof(int64_t), cudaMemcpyHostToDevice);
-    cudaMemcpy(output_strides_dev, dst_strides.data(), new_dims.size() * sizeof(int64_t), cudaMemcpyHostToDevice);
+    cudaMallocAsync(&new_dims_dev,
+                    (ends.size() + starts.size() + steps.size() + dims.size() + new_dims.size()) * sizeof(int64_t), 0);
+    starts_dev = new_dims_dev + ends.size();
+    steps_dev = starts_dev + starts.size();
+    input_strides_dev = steps_dev + steps.size();
+    output_strides_dev = input_strides_dev + dims.size();
+
+    cudaMemcpyAsync(new_dims_dev, new_dims.data(), ends.size() * sizeof(int64_t), cudaMemcpyHostToDevice, 0);
+    cudaMemcpyAsync(starts_dev, starts.data(), starts.size() * sizeof(int64_t), cudaMemcpyHostToDevice, 0);
+    cudaMemcpyAsync(steps_dev, steps.data(), steps.size() * sizeof(int64_t), cudaMemcpyHostToDevice, 0);
+    cudaMemcpyAsync(input_strides_dev, src_strides.data(), dims.size() * sizeof(int64_t), cudaMemcpyHostToDevice, 0);
+    cudaMemcpyAsync(output_strides_dev, dst_strides.data(), new_dims.size() * sizeof(int64_t), cudaMemcpyHostToDevice,
+                    0);
 
     int threads_per_block = 256;
     int num_blocks = (total_elements + threads_per_block - 1) / threads_per_block;
@@ -162,11 +164,7 @@ std::shared_ptr<Tensor> SliceBackward(const std::shared_ptr<Tensor> &grad_output
         starts_dev, steps_dev, input_strides_dev, output_strides_dev, num_dims, total_elements);
 
     // NOTE(zbl): cudaFree() needs explicit sync when cudaMallocAsync() is called
-    cudaFree(new_dims_dev);
-    cudaFree(starts_dev);
-    cudaFree(steps_dev);
-    cudaFree(input_strides_dev);
-    cudaFree(output_strides_dev);
+    cudaFreeAsync(new_dims_dev, 0);
 
     return grad_input;
 }

--- a/infini_train/src/kernels/cuda/softmax.cu
+++ b/infini_train/src/kernels/cuda/softmax.cu
@@ -79,10 +79,7 @@ void LaunchForward(const std::shared_ptr<Tensor> &output, const std::shared_ptr<
     T *output_ptr = static_cast<T *>(output->DataPtr());
     const T *input_ptr = static_cast<const T *>(input->DataPtr());
 
-    cudaDeviceProp prop;
-    cudaGetDeviceProperties(&prop, input->GetDevice().Index());
-
-    if (BLOCK_SIZE > prop.maxThreadsPerBlock) {
+    if (BLOCK_SIZE > 1024) {
         LOG(FATAL) << "CUDA softmax forward: 'BLOCK_SIZE used is larger than the max number of thread per block' at "
                    << __FILE__ << ":" << __LINE__;
     }
@@ -164,10 +161,7 @@ void LaunchBackward(const std::shared_ptr<Tensor> &grad_input, const std::shared
     const T *grad_output_ptr = static_cast<const T *>(grad_output->DataPtr());
     const T *output_ptr = static_cast<const T *>(output->DataPtr());
 
-    cudaDeviceProp prop;
-    cudaGetDeviceProperties(&prop, output->GetDevice().Index());
-
-    if (BLOCK_SIZE > prop.maxThreadsPerBlock) {
+    if (BLOCK_SIZE > 1024) {
         LOG(FATAL) << "CUDA softmax backward: 'BLOCK_SIZE used is larger than the max number of thread per block' at "
                    << __FILE__ << ":" << __LINE__;
     }

--- a/infini_train/src/kernels/cuda/split.cu
+++ b/infini_train/src/kernels/cuda/split.cu
@@ -109,18 +109,21 @@ std::shared_ptr<Tensor> SplitBackward(const std::vector<int64_t> &input_dims, in
         host_grad_output_ptrs.push_back(static_cast<const float *>(grad_output->DataPtr()));
     }
 
+    const void *device_ptr;
     const float **device_grad_output_ptrs;
-    cudaMalloc(&device_grad_output_ptrs, sizeof(float *) * num_splits);
-    cudaMemcpy(device_grad_output_ptrs, host_grad_output_ptrs.data(), sizeof(float *) * num_splits,
-               cudaMemcpyHostToDevice);
+    int64_t *device_H_outs;
+    cudaMallocAsync(&device_ptr, (sizeof(float *) + sizeof(int64_t)) * num_splits, 0);
+    device_grad_output_ptrs = static_cast<const float **>(device_ptr);
+    device_H_outs = static_cast<int64_t *>(device_grad_output_ptrs + num_splits);
+
+    cudaMemcpyAsync(device_grad_output_ptrs, host_grad_output_ptrs.data(), sizeof(float *) * num_splits,
+                    cudaMemcpyHostToDevice, 0);
 
     // init H_out for each split
     std::vector<int64_t> H_outs(num_splits);
     for (int i = 0; i < num_splits; ++i) { H_outs[i] = std::min(split_size, H_in - i * split_size); }
 
-    int64_t *device_H_outs;
-    cudaMalloc(&device_H_outs, sizeof(int64_t) * num_splits);
-    cudaMemcpy(device_H_outs, H_outs.data(), sizeof(int64_t) * num_splits, cudaMemcpyHostToDevice);
+    cudaMemcpyAsync(device_H_outs, H_outs.data(), sizeof(int64_t) * num_splits, cudaMemcpyHostToDevice, 0);
 
     int64_t total_elements = N * H_in * W;
     int threads_per_block = 256;
@@ -131,8 +134,7 @@ std::shared_ptr<Tensor> SplitBackward(const std::vector<int64_t> &input_dims, in
                                                            split_size, num_splits, device_H_outs);
 
     // NOTE(zbl): cudaFree() needs explicit sync when cudaMallocAsync() is called
-    cudaFree(device_H_outs);
-    cudaFree(device_grad_output_ptrs);
+    cudaFreeAsync(device_ptr, 0);
     return grad_input;
 }
 } // namespace infini_train::kernels::cuda

--- a/infini_train/src/kernels/cuda/split.cu
+++ b/infini_train/src/kernels/cuda/split.cu
@@ -109,12 +109,12 @@ std::shared_ptr<Tensor> SplitBackward(const std::vector<int64_t> &input_dims, in
         host_grad_output_ptrs.push_back(static_cast<const float *>(grad_output->DataPtr()));
     }
 
-    const void *device_ptr;
+    void *device_ptr;
     const float **device_grad_output_ptrs;
     int64_t *device_H_outs;
     cudaMallocAsync(&device_ptr, (sizeof(float *) + sizeof(int64_t)) * num_splits, 0);
-    device_grad_output_ptrs = static_cast<const float **>(device_ptr);
-    device_H_outs = static_cast<int64_t *>(device_grad_output_ptrs + num_splits);
+    device_grad_output_ptrs = (const float **)(device_ptr);
+    device_H_outs = reinterpret_cast<int64_t *>(device_grad_output_ptrs + num_splits);
 
     cudaMemcpyAsync(device_grad_output_ptrs, host_grad_output_ptrs.data(), sizeof(float *) * num_splits,
                     cudaMemcpyHostToDevice, 0);

--- a/infini_train/src/kernels/cuda/transform.cu
+++ b/infini_train/src/kernels/cuda/transform.cu
@@ -130,12 +130,13 @@ std::shared_ptr<Tensor> TransposeForward(const std::shared_ptr<Tensor> &input, i
     // Allocate device memory for dims and strides
     // TODO(zbl): avoid using cudaMalloc?
     int64_t *in_dims_dev, *in_strides_dev, *out_strides_dev;
-    cudaMalloc(&in_dims_dev, sizeof(int64_t) * ndim);
-    cudaMalloc(&in_strides_dev, sizeof(int64_t) * ndim);
-    cudaMalloc(&out_strides_dev, sizeof(int64_t) * ndim);
-    cudaMemcpy(in_dims_dev, in_dims.data(), sizeof(int64_t) * ndim, cudaMemcpyHostToDevice);
-    cudaMemcpy(in_strides_dev, in_strides.data(), sizeof(int64_t) * ndim, cudaMemcpyHostToDevice);
-    cudaMemcpy(out_strides_dev, out_strides.data(), sizeof(int64_t) * ndim, cudaMemcpyHostToDevice);
+    cudaMallocAsync(&in_dims_dev, 3 * sizeof(*in_dims_dev) * ndim, 0);
+    in_strides_dev = in_dims_dev + ndim;
+    out_strides_dev = in_strides_dev + ndim;
+
+    cudaMemcpyAsync(in_dims_dev, in_dims.data(), sizeof(int64_t) * ndim, cudaMemcpyHostToDevice, 0);
+    cudaMemcpyAsync(in_strides_dev, in_strides.data(), sizeof(int64_t) * ndim, cudaMemcpyHostToDevice, 0);
+    cudaMemcpyAsync(out_strides_dev, out_strides.data(), sizeof(int64_t) * ndim, cudaMemcpyHostToDevice, 0);
 
     int threads_per_block = 256;
     int num_blocks = (num_elements + threads_per_block - 1) / threads_per_block;
@@ -145,9 +146,7 @@ std::shared_ptr<Tensor> TransposeForward(const std::shared_ptr<Tensor> &input, i
         in_strides_dev, out_strides_dev, ndim, dim0, dim1, num_elements);
 
     // NOTE(zbl): cudaFree() needs explicit sync when cudaMallocAsync() is called
-    cudaFree(in_dims_dev);
-    cudaFree(in_strides_dev);
-    cudaFree(out_strides_dev);
+    cudaFreeAsync(in_dims_dev, 0);
 
     return output;
 }

--- a/infini_train/src/nn/init.cc
+++ b/infini_train/src/nn/init.cc
@@ -36,7 +36,7 @@ std::shared_ptr<Tensor> Normal(const std::shared_ptr<Tensor> &tensor, float mean
 #ifdef USE_CUDA
     case DeviceType::kCUDA: {
         // TODO(dcj): maybe use async API later?
-        cudaMemcpy(tensor->DataPtr(), buffer.data(), num_elements * sizeof(float), cudaMemcpyHostToDevice);
+        cudaMemcpyAsync(tensor->DataPtr(), buffer.data(), num_elements * sizeof(float), cudaMemcpyHostToDevice, 0);
         break;
     }
 #endif
@@ -125,7 +125,7 @@ std::shared_ptr<Tensor> Uniform(const std::shared_ptr<Tensor> &tensor, float a, 
 #ifdef USE_CUDA
     case DeviceType::kCUDA: {
         // TODO(dcj): maybe use async API later?
-        cudaMemcpy(tensor->DataPtr(), buffer.data(), num_elements * sizeof(float), cudaMemcpyHostToDevice);
+        cudaMemcpyAsync(tensor->DataPtr(), buffer.data(), num_elements * sizeof(float), cudaMemcpyHostToDevice, 0);
         break;
     }
 #endif
@@ -151,7 +151,7 @@ std::shared_ptr<Tensor> Ones(const std::shared_ptr<Tensor> &tensor) {
 #ifdef USE_CUDA
     case DeviceType::kCUDA: {
         // TODO(dcj): maybe use async API later?
-        cudaMemcpy(tensor->DataPtr(), buffer.data(), num_elements * sizeof(float), cudaMemcpyHostToDevice);
+        cudaMemcpyAsync(tensor->DataPtr(), buffer.data(), num_elements * sizeof(float), cudaMemcpyHostToDevice, 0);
         break;
     }
 #endif
@@ -177,7 +177,7 @@ std::shared_ptr<Tensor> Zeros(const std::shared_ptr<Tensor> &tensor) {
 #ifdef USE_CUDA
     case DeviceType::kCUDA: {
         // TODO(dcj): maybe use async API later?
-        cudaMemcpy(tensor->DataPtr(), buffer.data(), num_elements * sizeof(float), cudaMemcpyHostToDevice);
+        cudaMemcpyAsync(tensor->DataPtr(), buffer.data(), num_elements * sizeof(float), cudaMemcpyHostToDevice, 0);
         break;
     }
 #endif
@@ -200,7 +200,7 @@ std::shared_ptr<Tensor> Zeros(const std::shared_ptr<Tensor> &tensor) {
     case DATA_TYPE: {                                                                                                  \
         std::vector<TYPE> buffer(num_elements);                                                                        \
         std::iota(buffer.begin(), buffer.end(), static_cast<TYPE>(start));                                             \
-        cudaMemcpy(tensor->DataPtr(), buffer.data(), num_elements * sizeof(TYPE), cudaMemcpyHostToDevice);             \
+        cudaMemcpyAsync(tensor->DataPtr(), buffer.data(), num_elements * sizeof(TYPE), cudaMemcpyHostToDevice, 0);     \
         break;                                                                                                         \
     }
 


### PR DESCRIPTION
* refactor: change all `cudaMalloc`, `cudaMemcpy` and `cudaFree` to their async counterparts

* refactor: remove the `cudaGetDeviceProperties` used in elementwise.cu and softmax.cu for performance improvement (currently are replaced with reasonable hard-coded values)

* refactor: combine the device memory allocations and frees into a single one for operators that requires more than 1 set of those

* feat: add profiling for gpt2 cuda training example, which shows the elapsed time and tokens per second for each step

* refactor: optimize the implementation for both the forward and backward CUDA kernels of the cross entropy operator

Screenshot for passing mnist cuda example (only shows a portion at the end):
<img width="743" alt="image" src="https://github.com/user-attachments/assets/bc697aa6-994d-4408-a431-d64ad99a8838" />

Screenshot for passing gpt2 cuda example: 
![image](https://github.com/user-attachments/assets/321bf139-c800-49e4-99d9-356d0a501bac)
