### PR TITLE
feat: Add kernel performance profiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 option(USE_CUDA "Support NVIDIA CUDA" OFF)
+option(PROFILE_MODE "ENABLE PROFILE MODE" ON)
 cmake_minimum_required(VERSION 3.28)
 
 project(infini_train VERSION 0.3.0 LANGUAGES CXX)
@@ -32,6 +33,10 @@ include_directories(${PROJECT_SOURCE_DIR}/third_party/eigen)
 include_directories(${PROJECT_SOURCE_DIR})
 file(GLOB_RECURSE SRC ${PROJECT_SOURCE_DIR}/infini_train/src/*.cc)
 list(FILTER SRC EXCLUDE REGEX ".*kernels/cpu/.*")
+
+if(PROFILE_MODE)
+    add_compile_definitions(PROFILE_MODE=1)
+endif()
 
 file (GLOB_RECURSE CPU_KERNELS ${PROJECT_SOURCE_DIR}/infini_train/src/kernels/cpu/*.cc)
 add_library(infini_train_cpu_kernels STATIC ${CPU_KERNELS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 option(USE_CUDA "Support NVIDIA CUDA" OFF)
-option(PROFILE_MODE "ENABLE PROFILE MODE" ON)
+option(PROFILE_MODE "ENABLE PROFILE MODE" OFF)
 cmake_minimum_required(VERSION 3.28)
 
 project(infini_train VERSION 0.3.0 LANGUAGES CXX)

--- a/example/gpt2/main.cc
+++ b/example/gpt2/main.cc
@@ -156,7 +156,7 @@ int main(int argc, char *argv[]) {
         }
         float lossf = 0.0f;
 #ifdef PROFILE_MODE
-        Profiler::Instance().SetTag("Step " + std::to_string(step));
+        Profiler::Instance().SetTag("Step_" + std::to_string(step));
 #endif
         for (int micro_step = 0; micro_step < grad_accum_steps; ++micro_step) {
             // (bs, seq_len), (bs, seq_len)

--- a/infini_train/include/dispatcher.h
+++ b/infini_train/include/dispatcher.h
@@ -2,11 +2,15 @@
 
 #include <iostream>
 #include <map>
+#include <type_traits>
 #include <utility>
 
 #include "glog/logging.h"
 
 #include "infini_train/include/device.h"
+#ifdef PROFILE_MODE
+#include "infini_train/include/profiler.h"
+#endif
 
 namespace infini_train {
 class KernelFunction {
@@ -15,7 +19,29 @@ public:
 
     // TODO(dcj): support auto-deduction of return type and parameter types
     template <typename RetT, class... ArgsT> RetT Call(ArgsT... args) const {
-        return (*reinterpret_cast<RetT (*)(ArgsT...)>(func_ptr_))(std::forward<ArgsT>(args)...);
+#ifdef PROFILE_MODE
+        const auto &ctx = GetProfileContext();
+        Profiler::Instance().StartRecord(ctx.name, ctx.device);
+#endif
+
+        using FuncT = RetT (*)(ArgsT...);
+        auto fn = reinterpret_cast<FuncT>(func_ptr_);
+
+        if constexpr (std::is_void_v<RetT>) {
+            fn(std::forward<ArgsT>(args)...);
+
+#ifdef PROFILE_MODE
+            Profiler::Instance().EndRecord(ctx.name, ctx.device);
+#endif
+            return;
+        } else {
+            RetT ret = fn(std::forward<ArgsT>(args)...);
+
+#ifdef PROFILE_MODE
+            Profiler::Instance().EndRecord(ctx.name, ctx.device);
+#endif
+            return ret;
+        }
     }
 
 private:
@@ -34,6 +60,9 @@ public:
     const KernelFunction &GetKernel(KeyT key) const {
         CHECK(key_to_kernel_map_.contains(key))
             << "Kernel not found: " << key.second << " on device: " << static_cast<int>(key.first);
+#ifdef PROFILE_MODE
+        SetProfileContext(key.second, key.first);
+#endif
         return key_to_kernel_map_.at(key);
     }
 

--- a/infini_train/include/profiler.h
+++ b/infini_train/include/profiler.h
@@ -36,7 +36,7 @@ struct KernelCallRecord {
     std::string tag;
     std::string timestamp;
     std::string name;
-    DeviceType device;
+    std::string device;
     int64_t host_us;
     int64_t device_us;
     int64_t max_device_mem_usage_mb;
@@ -69,7 +69,7 @@ public:
     void SetTag(const std::string &tag);
 
 private:
-    void RecordKernel(const std::string &name, int64_t host_us, int64_t device_us = 0,
+    void RecordKernel(const std::string &name, const std::string &device, int64_t host_us, int64_t device_us = 0,
                       int64_t max_device_mem_usage_mb = 0);
 
     std::mutex mtx_;

--- a/infini_train/include/profiler.h
+++ b/infini_train/include/profiler.h
@@ -39,6 +39,7 @@ struct KernelCallRecord {
     DeviceType device;
     int64_t host_us;
     int64_t device_us;
+    int64_t max_device_mem_usage_mb;
 };
 
 class Profiler {
@@ -68,7 +69,8 @@ public:
     void SetTag(const std::string &tag);
 
 private:
-    void RecordKernel(const std::string &name, int64_t host_us, int64_t device_us = 0);
+    void RecordKernel(const std::string &name, int64_t host_us, int64_t device_us = 0,
+                      int64_t max_device_mem_usage_mb = 0);
 
     std::mutex mtx_;
     std::map<std::string, KernelProfileInfo> stats_;

--- a/infini_train/include/profiler.h
+++ b/infini_train/include/profiler.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <chrono>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <string>
+
+#include "glog/logging.h"
+
+#include "infini_train/include/device.h"
+
+namespace infini_train {
+
+struct ProfileContext {
+    std::string name;
+    DeviceType device;
+};
+
+inline thread_local ProfileContext g_profile_context;
+
+inline void SetProfileContext(const std::string &name, DeviceType device) {
+    g_profile_context.name = name;
+    g_profile_context.device = device;
+}
+
+inline const ProfileContext &GetProfileContext() { return g_profile_context; }
+
+struct KernelProfileInfo {
+    int64_t host_total_us = 0;
+    int64_t device_total_us = 0;
+    int count = 0;
+};
+
+struct KernelCallRecord {
+    std::string tag;
+    std::string timestamp;
+    std::string name;
+    DeviceType device;
+    int64_t host_us;
+    int64_t device_us;
+};
+
+class Profiler {
+public:
+    enum class SortBy {
+        HostTimeTotal,
+        HostTimePercentage,
+        HostTimeAverage,
+        DeviceTimeTotal,
+        DeviceTimePercentage,
+        DeviceTimeAverage,
+        Count,
+        NotSorted
+    };
+
+    static Profiler &Instance();
+
+    void StartRecord(const std::string &name, DeviceType device);
+    void EndRecord(const std::string &name, DeviceType device);
+
+    void Report(std::ostream &os = std::cout, SortBy sort_by = SortBy::NotSorted) const;
+    void Report(const std::string &file_path, SortBy sort_by = SortBy::NotSorted) const;
+    void PrintRecords(std::ostream &os = std::cout) const;
+    void PrintRecords(const std::string &file_path) const;
+
+    void Reset();
+    void SetTag(const std::string &tag);
+
+private:
+    void RecordKernel(const std::string &name, int64_t host_us, int64_t device_us = 0);
+
+    std::mutex mtx_;
+    std::map<std::string, KernelProfileInfo> stats_;
+    std::vector<KernelCallRecord> call_records_;
+    std::string current_tag_ = "Untagged";
+
+#ifdef USE_CUDA
+    struct EventPair {
+        void *start;
+        void *stop;
+    };
+#endif
+
+    // thread-local tracking
+    thread_local static inline std::map<std::string, std::chrono::high_resolution_clock::time_point> cpu_timing_map_;
+
+#ifdef USE_CUDA
+    thread_local static inline std::map<std::string, EventPair> cuda_timing_map_;
+#endif
+};
+} // namespace infini_train

--- a/infini_train/src/profiler.cc
+++ b/infini_train/src/profiler.cc
@@ -1,0 +1,222 @@
+#include "infini_train/include/profiler.h"
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <unordered_map>
+#ifdef USE_CUDA
+#include "cuda_runtime.h"
+#endif
+
+namespace infini_train {
+namespace {
+inline std::string GetCurrentTimestamp() {
+    auto now = std::chrono::system_clock::now();
+    auto now_time = std::chrono::system_clock::to_time_t(now);
+    std::tm tm_buf;
+#ifdef _WIN32
+    localtime_s(&tm_buf, &now_time);
+#else
+    localtime_r(&now_time, &tm_buf);
+#endif
+    char buffer[20];
+    std::strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", &tm_buf);
+    return std::string(buffer);
+}
+} // namespace
+
+Profiler &Profiler::Instance() {
+    static Profiler profiler;
+    return profiler;
+}
+
+void Profiler::StartRecord(const std::string &name, DeviceType device) {
+    cpu_timing_map_[name] = std::chrono::high_resolution_clock::now();
+
+    switch (device) {
+    case DeviceType::kCPU:
+        break;
+#ifdef USE_CUDA
+    case DeviceType::kCUDA: {
+        cudaEvent_t start, stop;
+        cudaEventCreate(&start);
+        cudaEventCreate(&stop);
+        cudaEventRecord(start, 0);
+        cuda_timing_map_[name] = {reinterpret_cast<void *>(start), reinterpret_cast<void *>(stop)};
+        break;
+    }
+#endif
+    default:
+        LOG(FATAL) << "Unsupported device type.";
+        break;
+    }
+}
+
+void Profiler::EndRecord(const std::string &name, DeviceType device) {
+    int64_t host_us = 0;
+    int64_t device_us = 0;
+
+    auto cpu_start = cpu_timing_map_[name];
+    auto cpu_end = std::chrono::high_resolution_clock::now();
+    host_us = std::chrono::duration_cast<std::chrono::microseconds>(cpu_end - cpu_start).count();
+    cpu_timing_map_.erase(name);
+
+    switch (device) {
+    case DeviceType::kCPU:
+        device_us = host_us;
+        break;
+#ifdef USE_CUDA
+    case DeviceType::kCUDA: {
+        auto it = cuda_timing_map_.find(name);
+        if (it != cuda_timing_map_.end()) {
+            auto event_pair = it->second;
+            cudaEvent_t start = reinterpret_cast<cudaEvent_t>(event_pair.start);
+            cudaEvent_t stop = reinterpret_cast<cudaEvent_t>(event_pair.stop);
+            cudaEventRecord(stop, 0);
+            cudaEventSynchronize(stop);
+            float elapsed_ms;
+            cudaEventElapsedTime(&elapsed_ms, start, stop);
+            device_us = static_cast<int64_t>(elapsed_ms * 1000);
+            cudaEventDestroy(start);
+            cudaEventDestroy(stop);
+            cuda_timing_map_.erase(it);
+        }
+        break;
+    }
+#endif
+    default:
+        LOG(FATAL) << "Unsupported device type.";
+        break;
+    }
+
+    RecordKernel(name, host_us, device_us);
+}
+
+void Profiler::RecordKernel(const std::string &name, int64_t host_us, int64_t device_us) {
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        auto &entry = stats_[name];
+        entry.host_total_us += host_us;
+        entry.device_total_us += device_us;
+        entry.count += 1;
+    }
+
+    call_records_.emplace_back(
+        KernelCallRecord{current_tag_, GetCurrentTimestamp(), name, GetProfileContext().device, host_us, device_us});
+}
+
+void Profiler::Reset() {
+    std::lock_guard<std::mutex> lock(mtx_);
+    stats_.clear();
+    call_records_.clear();
+    current_tag_ = "Untagged";
+}
+
+void Profiler::SetTag(const std::string &tag) { current_tag_ = tag; }
+
+void Profiler::Report(std::ostream &os, SortBy sort_by) const {
+    os << "\n--- Profiler Report ---\n";
+
+    std::map<std::string, std::map<std::string, KernelProfileInfo>> grouped_stats;
+
+    for (const auto &rec : call_records_) {
+        auto &entry = grouped_stats[rec.tag][rec.name];
+        entry.host_total_us += rec.host_us;
+        entry.device_total_us += rec.device_us;
+        entry.count += 1;
+    }
+
+    for (const auto &[tag, kernel_map] : grouped_stats) {
+        os << "\nTag: " << tag << "\n";
+        os << std::left << std::setw(24) << "Name" << std::setw(10) << "Count" << std::setw(18) << "Host Total(us)"
+           << std::setw(10) << "Host %" << std::setw(20) << "Device Total(us)" << std::setw(10) << "Device %"
+           << std::setw(16) << "Avg Host(us)" << std::setw(18) << "Avg Device(us)"
+           << "\n";
+
+        int64_t host_sum = 0;
+        int64_t dev_sum = 0;
+        for (const auto &[_, info] : kernel_map) {
+            host_sum += info.host_total_us;
+            dev_sum += info.device_total_us;
+        }
+
+        std::vector<std::pair<std::string, KernelProfileInfo>> records(kernel_map.begin(), kernel_map.end());
+
+        auto compare = [&](const auto &a, const auto &b) {
+            const auto &[_, A] = a;
+            const auto &[__, B] = b;
+            switch (sort_by) {
+            case SortBy::HostTimeTotal:
+                return A.host_total_us > B.host_total_us;
+            case SortBy::HostTimePercentage:
+                return A.host_total_us * dev_sum > B.host_total_us * dev_sum;
+            case SortBy::HostTimeAverage:
+                return A.host_total_us / A.count > B.host_total_us / B.count;
+            case SortBy::DeviceTimeTotal:
+                return A.device_total_us > B.device_total_us;
+            case SortBy::DeviceTimePercentage:
+                return A.device_total_us * host_sum > B.device_total_us * host_sum;
+            case SortBy::DeviceTimeAverage:
+                return A.device_total_us / A.count > B.device_total_us / B.count;
+            case SortBy::Count:
+                return A.count > B.count;
+            case SortBy::NotSorted:
+                return false;
+            }
+            return false;
+        };
+
+        if (sort_by != SortBy::NotSorted) {
+            std::sort(records.begin(), records.end(), compare);
+        }
+
+        for (const auto &[name, info] : records) {
+            double host_pct = host_sum > 0 ? 100.0 * info.host_total_us / host_sum : 0.0;
+            double dev_pct = dev_sum > 0 ? 100.0 * info.device_total_us / dev_sum : 0.0;
+            double avg_host = static_cast<double>(info.host_total_us) / info.count;
+            double avg_dev = static_cast<double>(info.device_total_us) / info.count;
+
+            os << std::left << std::setw(24) << name << std::setw(10) << info.count << std::setw(18)
+               << info.host_total_us << std::setw(10) << std::fixed << std::setprecision(2) << host_pct << std::setw(20)
+               << info.device_total_us << std::setw(10) << std::fixed << std::setprecision(2) << dev_pct
+               << std::setw(16) << static_cast<int64_t>(avg_host) << std::setw(18) << static_cast<int64_t>(avg_dev)
+               << "\n";
+        }
+    }
+}
+
+void Profiler::Report(const std::string &file_path, SortBy sort_by) const {
+    std::ofstream ofs(file_path);
+    if (!ofs) {
+        LOG(ERROR) << "Failed to open file: " << file_path;
+        return;
+    }
+    Report(ofs, sort_by);
+}
+
+void Profiler::PrintRecords(std::ostream &os) const {
+    os << "\n--- Kernel Call Log ---\n";
+    os << std::left << std::setw(16) << "Tag" << std::setw(8) << "Idx" << std::setw(24) << "Timestamp" << std::setw(24)
+       << "Name" << std::setw(10) << "Device" << std::setw(12) << "Host(us)" << std::setw(12) << "Device(us)"
+       << "\n";
+
+    std::map<std::string, int> tag_counters;
+
+    for (const auto &rec : call_records_) {
+        int idx = tag_counters[rec.tag]++;
+        os << std::left << std::setw(16) << rec.tag << std::setw(8) << idx << std::setw(24) << rec.timestamp
+           << std::setw(24) << rec.name << std::setw(10) << static_cast<int>(rec.device) << std::setw(12) << rec.host_us
+           << std::setw(12) << rec.device_us << "\n";
+    }
+}
+
+void Profiler::PrintRecords(const std::string &file_path) const {
+    std::ofstream ofs(file_path);
+    if (!ofs) {
+        LOG(ERROR) << "Failed to open file: " << file_path;
+        return;
+    }
+    PrintRecords(ofs);
+}
+
+} // namespace infini_train


### PR DESCRIPTION
1. 用 cmake 选项 PROFILE_MODE 来控制要不要进行 profile，对应的是在代码中的 PROFILE_MODE 宏定义，不需要 profile 的话就设置选项为 OFF 然后不编插桩的那部分代码；
2. 插桩的代码插在 Dispatcher::Call 中的调用前后，cpu 端使用 std::chrono::high_resolution_clock 计时，cuda 端使用 cudaEventElapsedTime 计时；
3. Profiler 定义了一个 SetTag()，是想在训练过程种每个 step 都 set 一下 tag，然后后续可以分 step 进行统计数据；
4. 输出有两种类型，一种是带统计数据的 Report（对应 Profiler::Report()），一种是按顺序记录每一个调用数据的 Kernel Call Log（对应 Profiler::PrintRecords()）。Report 中的统计数据会分别按照 tag 进行 groupby 的各自统计，并且可以按某一列从大到小排序；Kernel Call Log 里面就是纯按照执行顺序一行一行打印的了。