### PR TITLE
Optimize bf16

### DIFF
--- a/infini_train/include/common/cpu/common_cpu.h
+++ b/infini_train/include/common/cpu/common_cpu.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include "../common.h"
-#include "infini_train/include/dispatcher.h"
-
 namespace infini_train::common::cpu {
 /**
  * Converts a value between arbitrary types. This offers perfect

--- a/infini_train/include/common/cuda/common_cuda.h
+++ b/infini_train/include/common/cuda/common_cuda.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "cuda.h"
+#include "cuda_runtime.h"
+#ifdef USE_NCCL
+#include "nccl.h"
+#endif
+#include "glog/logging.h"
+
+namespace infini_train::common::cuda {
+
+// Common CUDA Macros
+#define CUDA_CHECK(call)                                                                                               \
+    do {                                                                                                               \
+        cudaError_t status = call;                                                                                     \
+        if (status != cudaSuccess) {                                                                                   \
+            LOG(FATAL) << "CUDA Error: " << cudaGetErrorString(status) << " at " << __FILE__ << ":" << __LINE__;       \
+        }                                                                                                              \
+    } while (0)
+
+#define CUBLAS_CHECK(call)                                                                                             \
+    do {                                                                                                               \
+        cublasStatus_t status = call;                                                                                  \
+        if (status != CUBLAS_STATUS_SUCCESS) {                                                                         \
+            LOG(FATAL) << "CUBLAS Error: " << cublasGetStatusString(status) << " at " << __FILE__ << ":" << __LINE__;  \
+        }                                                                                                              \
+    } while (0)
+
+#define CUDA_DRIVER_CHECK(call)                                                                                        \
+    do {                                                                                                               \
+        CUresult status = call;                                                                                        \
+        if (status != CUresult::CUDA_SUCCESS) {                                                                        \
+            const char *err_str = nullptr;                                                                             \
+            cuGetErrorString(status, &err_str);                                                                        \
+            LOG(FATAL) << "CUDA Driver API error: " << #call << " failed with error (" << status                       \
+                       << "): " << (err_str ? err_str : "Unknown error");                                              \
+        }                                                                                                              \
+    } while (0)
+
+#ifdef USE_NCCL
+#define NCCL_CHECK(expr)                                                                                               \
+    do {                                                                                                               \
+        ncclResult_t _status = (expr);                                                                                 \
+        if (_status != ncclSuccess) {                                                                                  \
+            LOG(FATAL) << "NCCL error: " << ncclGetErrorString(_status) << " at " << __FILE__ << ":" << __LINE__       \
+                       << " (" << #expr << ")";                                                                        \
+        }                                                                                                              \
+    } while (0)
+#endif
+
+} // namespace infini_train::common::cuda

--- a/infini_train/src/device.cc
+++ b/infini_train/src/device.cc
@@ -4,7 +4,7 @@
 #include <vector>
 
 #ifdef USE_CUDA
-#include "infini_train/include/common/cuda/common_cuda.cuh"
+#include "infini_train/include/common/cuda/common_cuda.h"
 #endif
 #ifdef USE_NCCL
 #include "nccl.h"

--- a/infini_train/src/kernels/cpu/cast.cc
+++ b/infini_train/src/kernels/cpu/cast.cc
@@ -1,4 +1,8 @@
+#include <memory>
+
 #include "infini_train/include/common/cpu/common_cpu.h"
+#include "infini_train/include/dispatcher.h"
+#include "infini_train/include/tensor.h"
 
 namespace infini_train::kernels::cpu {
 std::shared_ptr<Tensor> Cast(std::shared_ptr<Tensor> input, DataType dtype) {

--- a/infini_train/src/kernels/cuda/accumulate_grad.cu
+++ b/infini_train/src/kernels/cuda/accumulate_grad.cu
@@ -1,4 +1,9 @@
-#include "infini_train/include/common/cuda/common_cuda.cuh"
+#include <cmath>
+#include <memory>
+
+#include "infini_train/include/common/cuda/kernel_helper.cuh"
+#include "infini_train/include/dispatcher.h"
+#include "infini_train/include/tensor.h"
 
 namespace infini_train::kernels::cuda {
 

--- a/infini_train/src/kernels/cuda/cast.cu
+++ b/infini_train/src/kernels/cuda/cast.cu
@@ -1,4 +1,11 @@
-#include "infini_train/include/common/cuda/common_cuda.cuh"
+#include <memory>
+
+#include "infini_train/include/common/common.h"
+#include "infini_train/include/common/cuda/kernel_helper.cuh"
+#include "infini_train/include/datatype.h"
+#include "infini_train/include/device.h"
+#include "infini_train/include/dispatcher.h"
+#include "infini_train/include/tensor.h"
 
 namespace infini_train::kernels::cuda {
 

--- a/infini_train/src/kernels/cuda/comm_nccl.cu
+++ b/infini_train/src/kernels/cuda/comm_nccl.cu
@@ -10,7 +10,7 @@
 #include "glog/logging.h"
 #include "nccl.h"
 
-#include "infini_train/include/common/cuda/common_cuda.cuh"
+#include "infini_train/include/common/cuda/common_cuda.h"
 #include "infini_train/include/device.h"
 #include "infini_train/include/dispatcher.h"
 #include "infini_train/include/nn/functional.h"

--- a/infini_train/src/kernels/cuda/cross_entropy.cu
+++ b/infini_train/src/kernels/cuda/cross_entropy.cu
@@ -1,10 +1,14 @@
 #include <cmath>
-#include <cub/block/block_reduce.cuh>
-#include <cuda_runtime.h>
 #include <limits>
 #include <numeric>
 
-#include "infini_train/include/common/cuda/common_cuda.cuh"
+#include "cub/block/block_reduce.cuh"
+#include "cuda_runtime.h"
+
+#include "infini_train/include/common/cuda/common_cuda.h"
+#include "infini_train/include/common/cuda/kernel_helper.cuh"
+#include "infini_train/include/dispatcher.h"
+#include "infini_train/include/tensor.h"
 
 namespace infini_train::kernels::cuda {
 namespace {

--- a/infini_train/src/kernels/cuda/embedding.cu
+++ b/infini_train/src/kernels/cuda/embedding.cu
@@ -1,4 +1,8 @@
-#include "infini_train/include/common/cuda/common_cuda.cuh"
+#include <memory>
+
+#include "infini_train/include/common/cuda/common_cuda.h"
+#include "infini_train/include/dispatcher.h"
+#include "infini_train/include/tensor.h"
 
 namespace infini_train::kernels::cuda {
 

--- a/infini_train/src/kernels/cuda/fill.cu
+++ b/infini_train/src/kernels/cuda/fill.cu
@@ -1,4 +1,9 @@
-#include "infini_train/include/common/cuda/common_cuda.cuh"
+#include <cstddef>
+#include <memory>
+
+#include "infini_train/include/device.h"
+#include "infini_train/include/dispatcher.h"
+#include "infini_train/include/tensor.h"
 
 namespace infini_train::kernels::cuda {
 

--- a/infini_train/src/kernels/cuda/layernorm.cu
+++ b/infini_train/src/kernels/cuda/layernorm.cu
@@ -1,6 +1,13 @@
-#include <cub/block/block_reduce.cuh>
+#include <memory>
+#include <tuple>
 
-#include "infini_train/include/common/cuda/common_cuda.cuh"
+#include "cub/block/block_reduce.cuh"
+
+#include "infini_train/include/common/cuda/common_cuda.h"
+#include "infini_train/include/common/cuda/kernel_helper.cuh"
+#include "infini_train/include/device.h"
+#include "infini_train/include/dispatcher.h"
+#include "infini_train/include/tensor.h"
 
 namespace infini_train::kernels::cuda {
 

--- a/infini_train/src/kernels/cuda/linear.cu
+++ b/infini_train/src/kernels/cuda/linear.cu
@@ -1,7 +1,15 @@
-#include "cublas_v2.h"
-#include <cub/block/block_reduce.cuh>
+#include <functional>
+#include <memory>
+#include <numeric>
+#include <vector>
 
-#include "infini_train/include/common/cuda/common_cuda.cuh"
+#include "cub/block/block_reduce.cuh"
+#include "cublas_v2.h"
+
+#include "infini_train/include/common/cuda/common_cuda.h"
+#include "infini_train/include/common/cuda/kernel_helper.cuh"
+#include "infini_train/include/dispatcher.h"
+#include "infini_train/include/tensor.h"
 
 namespace infini_train::kernels::cuda {
 

--- a/infini_train/src/kernels/cuda/outer.cu
+++ b/infini_train/src/kernels/cuda/outer.cu
@@ -1,10 +1,13 @@
 #include <memory>
 #include <tuple>
+#include <vector>
 
 #include "cublas_v2.h"
 #include "glog/logging.h"
 
-#include "infini_train/include/common/cuda/common_cuda.cuh"
+#include "infini_train/include/common/cuda/common_cuda.h"
+#include "infini_train/include/dispatcher.h"
+#include "infini_train/include/tensor.h"
 
 namespace infini_train::kernels::cuda {
 std::shared_ptr<Tensor> OuterForward(const std::shared_ptr<Tensor> &input, const std::shared_ptr<Tensor> &other) {

--- a/infini_train/src/kernels/cuda/reduction.cu
+++ b/infini_train/src/kernels/cuda/reduction.cu
@@ -1,6 +1,9 @@
 #include <cub/cub.cuh>
 
-#include "infini_train/include/common/cuda/common_cuda.cuh"
+#include "infini_train/include/common/cuda/common_cuda.h"
+#include "infini_train/include/common/cuda/kernel_helper.cuh"
+#include "infini_train/include/dispatcher.h"
+#include "infini_train/include/tensor.h"
 
 namespace infini_train::kernels::cuda {
 namespace {

--- a/infini_train/src/kernels/cuda/slice.cu
+++ b/infini_train/src/kernels/cuda/slice.cu
@@ -1,6 +1,11 @@
+#include <cstdint>
+#include <memory>
+
 #include "glog/logging.h"
 
-#include "infini_train/include/common/cuda/common_cuda.cuh"
+#include "infini_train/include/common/cuda/common_cuda.h"
+#include "infini_train/include/dispatcher.h"
+#include "infini_train/include/tensor.h"
 
 namespace infini_train::kernels::cuda {
 

--- a/infini_train/src/kernels/cuda/softmax.cu
+++ b/infini_train/src/kernels/cuda/softmax.cu
@@ -1,10 +1,13 @@
 #include <cmath>
 #include <cstddef>
-#include <cub/block/block_reduce.cuh>
 
+#include "cub/block/block_reduce.cuh"
 #include "glog/logging.h"
 
-#include "infini_train/include/common/cuda/common_cuda.cuh"
+#include "infini_train/include/common/cuda/common_cuda.h"
+#include "infini_train/include/common/cuda/kernel_helper.cuh"
+#include "infini_train/include/dispatcher.h"
+#include "infini_train/include/tensor.h"
 
 namespace infini_train::kernels::cuda {
 template <size_t BLOCK_SIZE, typename T>

--- a/infini_train/src/kernels/cuda/split.cu
+++ b/infini_train/src/kernels/cuda/split.cu
@@ -2,7 +2,9 @@
 #include <numeric>
 #include <vector>
 
-#include "infini_train/include/common/cuda/common_cuda.cuh"
+#include "infini_train/include/common/cuda/common_cuda.h"
+#include "infini_train/include/dispatcher.h"
+#include "infini_train/include/tensor.h"
 
 namespace infini_train::kernels::cuda {
 template <typename T>

--- a/infini_train/src/kernels/cuda/stack.cu
+++ b/infini_train/src/kernels/cuda/stack.cu
@@ -6,7 +6,9 @@
 
 #include "glog/logging.h"
 
-#include "infini_train/include/common/cuda/common_cuda.cuh"
+#include "infini_train/include/common/cuda/common_cuda.h"
+#include "infini_train/include/dispatcher.h"
+#include "infini_train/include/tensor.h"
 
 namespace infini_train::kernels::cuda {
 template <typename T>

--- a/infini_train/src/kernels/cuda/transform.cu
+++ b/infini_train/src/kernels/cuda/transform.cu
@@ -1,4 +1,13 @@
-#include "infini_train/include/common/cuda/common_cuda.cuh"
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <numeric>
+#include <vector>
+
+#include "infini_train/include/common/cuda/common_cuda.h"
+#include "infini_train/include/common/cuda/kernel_helper.cuh"
+#include "infini_train/include/dispatcher.h"
+#include "infini_train/include/tensor.h"
 
 namespace infini_train::kernels::cuda {
 

--- a/infini_train/src/profiler.cc
+++ b/infini_train/src/profiler.cc
@@ -11,7 +11,7 @@
 #include "glog/logging.h"
 
 #ifdef USE_CUDA
-#include "infini_train/include/common/cuda/common_cuda.cuh"
+#include "infini_train/include/common/cuda/common_cuda.h"
 #endif
 #include "infini_train/include/device.h"
 

--- a/infini_train/src/tensor.cc
+++ b/infini_train/src/tensor.cc
@@ -12,7 +12,7 @@
 #include "glog/logging.h"
 
 #ifdef USE_CUDA
-#include "infini_train/include/common/cuda/common_cuda.cuh"
+#include "infini_train/include/common/cuda/common_cuda.h"
 #endif
 #include "infini_train/include/autograd/elementwise.h"
 #include "infini_train/include/autograd/matmul.h"


### PR DESCRIPTION
优化了 BinaryBackward kernel 在 bf16 情况下的性能：
1. 仿照 torch 思路，实现 fastAtomicAdd 优化 bf16 的原子操作性能，将 bf16 拼接成 bfloat162，复用硬件的 32-bit 原子加；
2. 在 bf16 数据类型时将原有的 warp reduce kernel 改造成 block reduce，减少 atomicAdd 次数。