### PR TITLE
[WIP] feat: add automatic precision checking for backward pass

### DIFF
--- a/example/gpt2/net.h
+++ b/example/gpt2/net.h
@@ -23,12 +23,16 @@ struct GPT2Config {
 
 class NewGELU : public infini_train::nn::CloneableModule<NewGELU> {
 public:
+    static constexpr char kType[] = "NewGELU";
+    NewGELU() : CloneableModule(kType) {}
+
     std::vector<std::shared_ptr<infini_train::Tensor>>
     Forward(const std::vector<std::shared_ptr<infini_train::Tensor>> &x) override;
 };
 
 class CausalSelfAttention : public infini_train::nn::CloneableModule<CausalSelfAttention> {
 public:
+    static constexpr char kType[] = "CausalSelfAttention";
     static constexpr char kCAttnLayerName[] = "c_attn";
     static constexpr char kCProjLayerName[] = "c_proj";
 
@@ -49,6 +53,7 @@ private:
 
 class MLP : public infini_train::nn::CloneableModule<MLP> {
 public:
+    static constexpr char kType[] = "MLP";
     static constexpr char kCFcLayerName[] = "c_fc";
     static constexpr char kGeluLayerName[] = "gelu";
     static constexpr char kCProjLayerName[] = "c_proj";
@@ -61,6 +66,7 @@ public:
 
 class Block : public infini_train::nn::CloneableModule<Block> {
 public:
+    static constexpr char kType[] = "Block";
     static constexpr char kLn1LayerName[] = "ln_1";
     static constexpr char kAttnLayerName[] = "attn";
     static constexpr char kLn2LayerName[] = "ln_2";
@@ -74,6 +80,7 @@ public:
 
 class GPT2FirstStage : public infini_train::nn::CloneableModule<GPT2FirstStage> {
 public:
+    static constexpr char kType[] = "GPT2FirstStage";
     static constexpr char kWTELayerName[] = "wte";
     static constexpr char kWPELayerName[] = "wpe";
 
@@ -88,6 +95,7 @@ private:
 
 class GPT2Chunk : public infini_train::nn::CloneableModule<GPT2Chunk> {
 public:
+    static constexpr char kType[] = "GPT2Chunk";
     static constexpr char kHLayerName[] = "h";
 
     GPT2Chunk(const GPT2Config &config, int start_layer, int end_layer);
@@ -101,6 +109,7 @@ private:
 
 class GPT2LastStage : public infini_train::nn::CloneableModule<GPT2LastStage> {
 public:
+    static constexpr char kType[] = "GPT2LastStage";
     static constexpr char kLnFLayerName[] = "ln_f";
     static constexpr char kLMHeadLayerName[] = "lm_head";
 
@@ -115,6 +124,7 @@ private:
 
 class GPT2 : public infini_train::nn::CloneableModule<GPT2> {
 public:
+    static constexpr char kType[] = "GPT2";
     static constexpr char kTransformerLayerName[] = "transformer";
 
     enum class ModelType : int8_t {

--- a/example/llama3/main.cc
+++ b/example/llama3/main.cc
@@ -66,6 +66,9 @@ DEFINE_uint32(pipeline_parallel, 1, "Pipeline Parallel world size, specified the
 DEFINE_uint32(virtual_pipeline_parallel, 1, "Number of chunks in PP stage.");
 // precision
 DEFINE_string(dtype, "float32", "precision used in training (float32/bfloat16)");
+// precision check
+DEFINE_int32(precision_check, 0, "precision check level: 0=off, 1=module, 2=function");
+DEFINE_bool(precision_check_all_ranks, false, "enable precision check for all ranks (default: rank 0 only)");
 
 using namespace infini_train;
 
@@ -273,9 +276,9 @@ void Train(const nn::parallel::Rank &rank) {
 
                 LOG(INFO) << "Rank " << rank.GlobalRank() << ": start forward";
                 // (bs, seq_len, vocab_size)
-                auto logits = model->Forward({x, y})[0];
+                auto logits = (*model)({x, y})[0];
                 LOG(INFO) << "Rank " << rank.GlobalRank() << ": finish model forward, start loss forward";
-                auto loss = loss_fn->Forward({logits, y})[0];
+                auto loss = (*loss_fn)({logits, y})[0];
                 // FIXME(jym): verify gradient accumulation precision
                 loss = loss / grad_accum_steps;
 
@@ -340,7 +343,8 @@ int main(int argc, char *argv[]) {
     google::InitGoogleLogging(argv[0]);
 
     nn::parallel::global::InitAllEnv(FLAGS_nthread_per_process, FLAGS_tensor_parallel, FLAGS_sequence_parallel,
-                                     FLAGS_pipeline_parallel, FLAGS_virtual_pipeline_parallel);
+                                     FLAGS_pipeline_parallel, FLAGS_virtual_pipeline_parallel, FLAGS_precision_check,
+                                     FLAGS_precision_check_all_ranks);
 
     LOG(INFO) << nn::parallel::global::ProcessGroupOverview();
 

--- a/example/llama3/net.h
+++ b/example/llama3/net.h
@@ -42,6 +42,9 @@ struct LLaMA3Config {
 
 class SwiGLU : public infini_train::nn::CloneableModule<SwiGLU> {
 public:
+    static constexpr char kType[] = "SwiGLU";
+    SwiGLU() : CloneableModule(kType) {}
+
     std::vector<std::shared_ptr<infini_train::Tensor>>
     Forward(const std::vector<std::shared_ptr<infini_train::Tensor>> &x) override;
 };
@@ -49,6 +52,7 @@ public:
 // TODO(zbl): implement fused kernel
 class RMSNorm : public infini_train::nn::CloneableModule<RMSNorm> {
 public:
+    static constexpr char kType[] = "RMSNorm";
     static constexpr char kParamWeightName[] = "weight";
 
     explicit RMSNorm(int64_t dim, float eps = 1e-6f,
@@ -63,6 +67,7 @@ private:
 
 class CausalSelfAttention : public infini_train::nn::CloneableModule<CausalSelfAttention> {
 public:
+    static constexpr char kType[] = "CausalSelfAttention";
     static constexpr char kCAttnLayerName[] = "c_attn";
     static constexpr char kCProjLayerName[] = "c_proj";
 
@@ -82,6 +87,7 @@ private:
 
 class MLP : public infini_train::nn::CloneableModule<MLP> {
 public:
+    static constexpr char kType[] = "MLP";
     static constexpr char kCFcLayerName[] = "c_fc";
     static constexpr char kCFc2LayerName[] = "c_fc2";
     static constexpr char kSiluLayerName[] = "silu";
@@ -98,6 +104,7 @@ private:
 
 class Block : public infini_train::nn::CloneableModule<Block> {
 public:
+    static constexpr char kType[] = "Block";
     static constexpr char kLn1LayerName[] = "ln_1";
     static constexpr char kAttnLayerName[] = "attn";
     static constexpr char kLn2LayerName[] = "ln_2";
@@ -111,6 +118,7 @@ public:
 
 class LLaMA3FirstStage : public infini_train::nn::CloneableModule<LLaMA3FirstStage> {
 public:
+    static constexpr char kType[] = "LLaMA3FirstStage";
     static constexpr char kWTELayerName[] = "wte";
 
     explicit LLaMA3FirstStage(const LLaMA3Config &config);
@@ -124,6 +132,7 @@ private:
 
 class LLaMA3Chunk : public infini_train::nn::CloneableModule<LLaMA3Chunk> {
 public:
+    static constexpr char kType[] = "LLaMA3Chunk";
     static constexpr char kHLayerName[] = "h";
     static constexpr char kFreqsCisName[] = "freqs_cis";
 
@@ -138,6 +147,7 @@ private:
 
 class LLaMA3LastStage : public infini_train::nn::CloneableModule<LLaMA3LastStage> {
 public:
+    static constexpr char kType[] = "LLaMA3LastStage";
     static constexpr char kLnFLayerName[] = "ln_f";
     static constexpr char kLMHeadLayerName[] = "lm_head";
 
@@ -152,6 +162,7 @@ private:
 
 class LLaMA3 : public infini_train::nn::CloneableModule<LLaMA3> {
 public:
+    static constexpr char kType[] = "LLaMA3";
     static constexpr char kTransformerLayerName[] = "transformer";
 
     enum class ModelType : int8_t {

--- a/example/mnist/net.cc
+++ b/example/mnist/net.cc
@@ -25,7 +25,7 @@ MNIST::MNIST() {
 std::vector<std::shared_ptr<infini_train::Tensor>>
 MNIST::Forward(const std::vector<std::shared_ptr<infini_train::Tensor>> &x) {
     CHECK_EQ(x.size(), 1);
-    auto x1 = modules_["sequential"]->Forward(x);
-    auto x2 = modules_["linear2"]->Forward(x1);
+    auto x1 = (*modules_["sequential"])(x);
+    auto x2 = (*modules_["linear2"])(x1);
     return x2;
 }

--- a/infini_train/include/autograd/accumulate.h
+++ b/infini_train/include/autograd/accumulate.h
@@ -18,6 +18,8 @@ public:
 
     std::vector<std::shared_ptr<Tensor>> Backward(const std::vector<std::shared_ptr<Tensor>> &) override;
 
+    std::shared_ptr<Tensor> tensor() const { return tensor_; }
+
 private:
     std::shared_ptr<Tensor> tensor_ = nullptr;
     float learning_rate_ = 1.0f;

--- a/infini_train/include/autograd/function.h
+++ b/infini_train/include/autograd/function.h
@@ -42,6 +42,8 @@ public:
     std::shared_ptr<HookHandle> RegisterBackwardPreHook(FunctionBackwardPreHook hook);
     std::shared_ptr<HookHandle> RegisterBackwardPostHook(FunctionBackwardPostHook hook);
 
+    const std::string& type() const { return type_; }
+
 protected:
     std::vector<std::shared_ptr<Tensor>> saved_tensors_;
 
@@ -56,5 +58,6 @@ private:
     std::vector<FunctionForwardPostHook> forward_post_hooks_;
     std::vector<FunctionBackwardPreHook> backward_pre_hooks_;
     std::vector<FunctionBackwardPostHook> backward_post_hooks_;
+    bool precision_check_registered_ = false;
 };
 } // namespace infini_train::autograd

--- a/infini_train/include/autograd/function.h
+++ b/infini_train/include/autograd/function.h
@@ -11,15 +11,16 @@ class Tensor;
 
 namespace infini_train::autograd {
 class HookHandle;
-using FunctionForwardPreHook = std::function<void(class Function*, const std::vector<std::shared_ptr<Tensor>>&)>;
-using FunctionForwardPostHook = std::function<void(class Function*, const std::vector<std::shared_ptr<Tensor>>&,
-                                                    const std::vector<std::shared_ptr<Tensor>>&)>;
-using FunctionBackwardPreHook = std::function<void(class Function*, const std::vector<std::shared_ptr<Tensor>>&)>;
-using FunctionBackwardPostHook = std::function<void(class Function*, const std::vector<std::shared_ptr<Tensor>>&,
-                                                     const std::vector<std::shared_ptr<Tensor>>&)>;
 
 class Function : public std::enable_shared_from_this<Function> {
 public:
+    using FunctionForwardPreHook = std::function<void(Function*, const std::vector<std::shared_ptr<Tensor>>&)>;
+    using FunctionForwardPostHook = std::function<void(Function*, const std::vector<std::shared_ptr<Tensor>>&,
+                                                        const std::vector<std::shared_ptr<Tensor>>&)>;
+    using FunctionBackwardPreHook = std::function<void(Function*, const std::vector<std::shared_ptr<Tensor>>&)>;
+    using FunctionBackwardPostHook = std::function<void(Function*, const std::vector<std::shared_ptr<Tensor>>&,
+                                                         const std::vector<std::shared_ptr<Tensor>>&)>;
+
     static constexpr char kUndefinedType[] = "Undefined";
 
     Function() : type_(kUndefinedType) {}

--- a/infini_train/include/autograd/function_hook.h
+++ b/infini_train/include/autograd/function_hook.h
@@ -41,20 +41,6 @@ private:
     const infini_train::nn::parallel::ProcessGroup *pg_ = nullptr;
 };
 
-// Forward pre-hook: called before forward pass
-using FunctionForwardPreHook = std::function<void(Function*, const std::vector<std::shared_ptr<Tensor>>&)>;
-
-// Forward post-hook: called after forward pass
-using FunctionForwardPostHook = std::function<void(Function*, const std::vector<std::shared_ptr<Tensor>>&,
-                                                    const std::vector<std::shared_ptr<Tensor>>&)>;
-
-// Backward pre-hook: called before backward pass
-using FunctionBackwardPreHook = std::function<void(Function*, const std::vector<std::shared_ptr<Tensor>>&)>;
-
-// Backward post-hook: called after backward pass
-using FunctionBackwardPostHook = std::function<void(Function*, const std::vector<std::shared_ptr<Tensor>>&,
-                                                     const std::vector<std::shared_ptr<Tensor>>&)>;
-
 template <typename HookType>
 class FunctionHookHandleImpl : public HookHandle {
 public:

--- a/infini_train/include/autograd/function_hook.h
+++ b/infini_train/include/autograd/function_hook.h
@@ -16,7 +16,13 @@ class ProcessGroup;
 
 namespace infini_train::autograd {
 class Function;
-class HookHandle;
+
+class HookHandle {
+public:
+    virtual ~HookHandle() = default;
+    virtual void Remove() = 0;
+};
+
 class PostAccumulateGradHook {
 public:
     virtual void operator()(const std::shared_ptr<Tensor> &tensor) = 0;

--- a/infini_train/include/autograd/function_hook.h
+++ b/infini_train/include/autograd/function_hook.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <functional>
 #include <memory>
+#include <vector>
 
 #include "infini_train/include/nn/parallel/reduce_op_type.h"
 
@@ -13,6 +15,8 @@ class ProcessGroup;
 } // namespace infini_train
 
 namespace infini_train::autograd {
+class Function;
+class HookHandle;
 class PostAccumulateGradHook {
 public:
     virtual void operator()(const std::shared_ptr<Tensor> &tensor) = 0;
@@ -29,5 +33,37 @@ public:
 private:
     infini_train::nn::parallel::function::ReduceOpType reduce_op_;
     const infini_train::nn::parallel::ProcessGroup *pg_ = nullptr;
+};
+
+// Forward pre-hook: called before forward pass
+using FunctionForwardPreHook = std::function<void(Function*, const std::vector<std::shared_ptr<Tensor>>&)>;
+
+// Forward post-hook: called after forward pass
+using FunctionForwardPostHook = std::function<void(Function*, const std::vector<std::shared_ptr<Tensor>>&,
+                                                    const std::vector<std::shared_ptr<Tensor>>&)>;
+
+// Backward pre-hook: called before backward pass
+using FunctionBackwardPreHook = std::function<void(Function*, const std::vector<std::shared_ptr<Tensor>>&)>;
+
+// Backward post-hook: called after backward pass
+using FunctionBackwardPostHook = std::function<void(Function*, const std::vector<std::shared_ptr<Tensor>>&,
+                                                     const std::vector<std::shared_ptr<Tensor>>&)>;
+
+template <typename HookType>
+class FunctionHookHandleImpl : public HookHandle {
+public:
+    FunctionHookHandleImpl(std::vector<HookType>* hooks, size_t id) : hooks_(hooks), id_(id) {}
+
+    void Remove() override {
+        if (!removed_ && hooks_ && id_ < hooks_->size()) {
+            (*hooks_)[id_] = nullptr;
+            removed_ = true;
+        }
+    }
+
+private:
+    std::vector<HookType>* hooks_;
+    size_t id_;
+    bool removed_ = false;
 };
 } // namespace infini_train::autograd

--- a/infini_train/include/autograd/tensor_hook.h
+++ b/infini_train/include/autograd/tensor_hook.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace infini_train {
+class Tensor;
+
+namespace autograd {
+
+// Hook handle for removing hooks
+class HookHandle {
+public:
+    virtual ~HookHandle() = default;
+    virtual void Remove() = 0;
+};
+
+// Tensor backward hook: modifies gradient during backward pass
+// Returns modified gradient or nullptr to keep original
+using TensorBackwardHook = std::function<std::shared_ptr<Tensor>(const std::shared_ptr<Tensor>&)>;
+
+class TensorBackwardHookHandle : public HookHandle {
+public:
+    TensorBackwardHookHandle(std::vector<TensorBackwardHook>* hooks, size_t id)
+        : hooks_(hooks), id_(id) {}
+
+    void Remove() override;
+
+private:
+    std::vector<TensorBackwardHook>* hooks_;
+    size_t id_;
+    bool removed_ = false;
+};
+
+} // namespace autograd
+} // namespace infini_train

--- a/infini_train/include/nn/module_hook.h
+++ b/infini_train/include/nn/module_hook.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace infini_train {
+class Tensor;
+
+namespace nn {
+class Module;
+
+// Forward pre-hook: called before forward pass
+// Args: (module, input_tensors)
+using ForwardPreHook = std::function<void(Module*, const std::vector<std::shared_ptr<Tensor>>&)>;
+
+// Forward post-hook: called after forward pass
+// Args: (module, input_tensors, output_tensors)
+using ForwardPostHook = std::function<void(Module*, const std::vector<std::shared_ptr<Tensor>>&,
+                                           const std::vector<std::shared_ptr<Tensor>>&)>;
+
+// Backward pre-hook: called before backward pass
+// Args: (module, grad_output)
+using BackwardPreHook = std::function<void(Module*, const std::vector<std::shared_ptr<Tensor>>&)>;
+
+// Backward post-hook: called after backward pass
+// Args: (module, grad_input, grad_output)
+using BackwardPostHook = std::function<void(Module*, const std::vector<std::shared_ptr<Tensor>>&,
+                                            const std::vector<std::shared_ptr<Tensor>>&)>;
+
+class ModuleHookHandle {
+public:
+    virtual ~ModuleHookHandle() = default;
+    virtual void Remove() = 0;
+};
+
+template <typename HookType>
+class ModuleHookHandleImpl : public ModuleHookHandle {
+public:
+    ModuleHookHandleImpl(std::vector<HookType>* hooks, size_t id) : hooks_(hooks), id_(id) {}
+
+    void Remove() override {
+        if (!removed_ && hooks_ && id_ < hooks_->size()) {
+            (*hooks_)[id_] = nullptr;
+            removed_ = true;
+        }
+    }
+
+private:
+    std::vector<HookType>* hooks_;
+    size_t id_;
+    bool removed_ = false;
+};
+
+} // namespace nn
+} // namespace infini_train

--- a/infini_train/include/nn/modules/activations.h
+++ b/infini_train/include/nn/modules/activations.h
@@ -12,7 +12,8 @@ class Tensor;
 namespace infini_train::nn {
 class Sigmoid : public CloneableModule<Sigmoid> {
 public:
-    Sigmoid() = default;
+    static constexpr char kType[] = "Sigmoid";
+    Sigmoid() : CloneableModule(kType) {}
     std::vector<std::shared_ptr<Tensor>> Forward(const std::vector<std::shared_ptr<Tensor>> &input_tensors) override;
 };
 } // namespace infini_train::nn

--- a/infini_train/include/nn/modules/container.h
+++ b/infini_train/include/nn/modules/container.h
@@ -13,6 +13,7 @@ class Tensor;
 namespace infini_train::nn {
 class Sequential : public CloneableModule<Sequential> {
 public:
+    static constexpr char kType[] = "Sequential";
     // TODO(dcj): Use better ctor signature later.
     explicit Sequential(std::vector<std::shared_ptr<Module>> &&layers);
 
@@ -21,6 +22,7 @@ public:
 
 class ModuleDict : public CloneableModule<ModuleDict> {
 public:
+    static constexpr char kType[] = "ModuleDict";
     // TODO(dcj): in torch, there is a dict with the order of insertion
     explicit ModuleDict(std::unordered_map<std::string, std::shared_ptr<Module>> modules);
 

--- a/infini_train/include/nn/modules/loss.h
+++ b/infini_train/include/nn/modules/loss.h
@@ -8,7 +8,8 @@
 namespace infini_train::nn {
 class CrossEntropyLoss : public CloneableModule<CrossEntropyLoss> {
 public:
-    CrossEntropyLoss() = default;
+    static constexpr char kType[] = "CrossEntropyLoss";
+    CrossEntropyLoss() : CloneableModule(kType) {}
 
     std::vector<std::shared_ptr<Tensor>> Forward(const std::vector<std::shared_ptr<Tensor>> &input_tensors) override;
 };

--- a/infini_train/include/nn/modules/module.h
+++ b/infini_train/include/nn/modules/module.h
@@ -88,6 +88,7 @@ protected:
     std::vector<ForwardPostHook> forward_post_hooks_;
     std::vector<BackwardPreHook> backward_pre_hooks_;
     std::vector<BackwardPostHook> backward_post_hooks_;
+    bool precision_check_registered_ = false;
 
 private:
     std::unordered_map<std::string, std::shared_ptr<Module>>

--- a/infini_train/include/nn/modules/normalization.h
+++ b/infini_train/include/nn/modules/normalization.h
@@ -13,6 +13,7 @@ class Device;
 namespace infini_train::nn {
 class LayerNorm : public CloneableModule<LayerNorm> {
 public:
+    static constexpr char kType[] = "LayerNorm";
     static constexpr char kParamWeightName[] = "weight";
     static constexpr char kParamBiasName[] = "bias";
 

--- a/infini_train/include/nn/parallel/global.h
+++ b/infini_train/include/nn/parallel/global.h
@@ -29,6 +29,10 @@ public:
     void Init(int threads_per_process, int tensor_parallel_size, bool sequence_parallel_enabled,
               int pipeline_parallel_size, int virtual_pipeline_parallel_size);
 
+    enum class PrecisionCheckLevel { NONE, FUNCTION, MODULE };
+    void SetPrecisionCheckLevel(PrecisionCheckLevel level);
+    PrecisionCheckLevel GetPrecisionCheckLevel() const;
+
     int nnodes() const;
 
     int nproc_per_node() const;
@@ -83,6 +87,7 @@ private:
     bool initialized_ = false;
 
     Layout layout_;
+    PrecisionCheckLevel precision_check_level_ = PrecisionCheckLevel::NONE;
 };
 
 inline void InitAllEnv(int nthread_per_process, int tensor_parallel_size, bool sequence_parallel_enabled,

--- a/infini_train/include/nn/parallel/global.h
+++ b/infini_train/include/nn/parallel/global.h
@@ -27,11 +27,13 @@ public:
     static GlobalEnv &Instance();
 
     void Init(int threads_per_process, int tensor_parallel_size, bool sequence_parallel_enabled,
-              int pipeline_parallel_size, int virtual_pipeline_parallel_size);
+              int pipeline_parallel_size, int virtual_pipeline_parallel_size, int precision_check_level = 0,
+              bool precision_check_all_ranks = false);
 
     enum class PrecisionCheckLevel { NONE, FUNCTION, MODULE };
     void SetPrecisionCheckLevel(PrecisionCheckLevel level);
     PrecisionCheckLevel GetPrecisionCheckLevel() const;
+    bool GetPrecisionCheckAllRanks() const;
 
     int nnodes() const;
 
@@ -88,14 +90,16 @@ private:
 
     Layout layout_;
     PrecisionCheckLevel precision_check_level_ = PrecisionCheckLevel::NONE;
+    bool precision_check_all_ranks_ = false;
 };
 
 inline void InitAllEnv(int nthread_per_process, int tensor_parallel_size, bool sequence_parallel_enabled,
-                       int pipeline_parallel_size, int virtual_pipeline_parallel) {
+                       int pipeline_parallel_size, int virtual_pipeline_parallel, int precision_check_level = 0,
+                       bool precision_check_all_ranks = false) {
     GlobalEnv::Instance().Init(nthread_per_process, tensor_parallel_size, sequence_parallel_enabled,
-                               pipeline_parallel_size, virtual_pipeline_parallel);
+                               pipeline_parallel_size, virtual_pipeline_parallel, precision_check_level,
+                               precision_check_all_ranks);
 }
-
 inline int GetNnodes() { return GlobalEnv::Instance().nnodes(); }
 inline int GetWorldSize() { return GlobalEnv::Instance().world_size(); }
 inline int GetNprocPerNode() { return GlobalEnv::Instance().nproc_per_node(); }

--- a/infini_train/include/nn/parallel/tensor_parallel.h
+++ b/infini_train/include/nn/parallel/tensor_parallel.h
@@ -103,8 +103,9 @@ private:
 
 class VocabParallelCrossEntropyLoss : public nn::CloneableModule<VocabParallelCrossEntropyLoss> {
 public:
+    static constexpr char kType[] = "VocabParallelCrossEntropyLoss";
     VocabParallelCrossEntropyLoss(int64_t vocab_size_original = 0, float label_smoothing = 0.f)
-        : vocab_size_original_(vocab_size_original), label_smoothing_(label_smoothing){};
+        : CloneableModule(kType), vocab_size_original_(vocab_size_original), label_smoothing_(label_smoothing){};
 
     std::vector<std::shared_ptr<Tensor>> Forward(const std::vector<std::shared_ptr<Tensor>> &input_tensors) override;
 

--- a/infini_train/include/utils/precision_checker.h
+++ b/infini_train/include/utils/precision_checker.h
@@ -27,15 +27,17 @@ public:
         bool abort_on_error = false;
     };
 
-    static void RegisterForFunction(autograd::Function* func, const std::string& name = "",
-                                    const Config& config = Config());
+    static const Config& DefaultConfig() {
+        static Config default_config;
+        return default_config;
+    }
 
-    static void RegisterForAllFunctions(const std::vector<std::shared_ptr<autograd::Function>>& functions,
-                                       const Config& config = Config());
+    static void RegisterForFunction(autograd::Function* func, const std::string& name = "",
+                                    const Config& config = DefaultConfig());
 
     // Register hooks for a Module (checks forward inputs/outputs)
     static void RegisterForModule(nn::Module* module, const std::string& name = "",
-                                 const Config& config = Config());
+                                 const Config& config = DefaultConfig());
 
 private:
     static void CheckTensors(const std::string& stage, const std::string& name,

--- a/infini_train/include/utils/precision_checker.h
+++ b/infini_train/include/utils/precision_checker.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace infini_train {
+class Tensor;
+
+namespace autograd {
+class Function;
+class HookHandle;
+} // namespace autograd
+
+namespace nn {
+class Module;
+} // namespace nn
+
+namespace utils {
+
+class PrecisionChecker {
+public:
+    struct Config {
+        bool check_nan = true;
+        bool check_inf = true;
+        bool print_stats = true;
+        bool abort_on_error = false;
+    };
+
+    static void RegisterForFunction(autograd::Function* func, const std::string& name = "",
+                                    const Config& config = Config());
+
+    static void RegisterForAllFunctions(const std::vector<std::shared_ptr<autograd::Function>>& functions,
+                                       const Config& config = Config());
+
+    // Register hooks for a Module (checks forward inputs/outputs)
+    static void RegisterForModule(nn::Module* module, const std::string& name = "",
+                                 const Config& config = Config());
+
+private:
+    static void CheckTensors(const std::string& stage, const std::string& name,
+                           const std::vector<std::shared_ptr<Tensor>>& tensors,
+                           const Config& config);
+};
+
+} // namespace utils
+} // namespace infini_train

--- a/infini_train/src/nn/modules/container.cc
+++ b/infini_train/src/nn/modules/container.cc
@@ -7,7 +7,7 @@
 #include "infini_train/include/tensor.h"
 
 namespace infini_train::nn {
-Sequential::Sequential(std::vector<std::shared_ptr<Module>> &&layers) {
+Sequential::Sequential(std::vector<std::shared_ptr<Module>> &&layers) : CloneableModule(kType) {
     int idx = 0;
     for (auto &layer : layers) {
         modules_[std::to_string(idx)] = std::move(layer);
@@ -17,11 +17,11 @@ Sequential::Sequential(std::vector<std::shared_ptr<Module>> &&layers) {
 
 std::vector<std::shared_ptr<Tensor>> Sequential::Forward(const std::vector<std::shared_ptr<Tensor>> &input_tensors) {
     auto &x = const_cast<std::vector<std::shared_ptr<Tensor>> &>(input_tensors);
-    for (int idx = 0; idx < modules_.size(); ++idx) { x = modules_[std::to_string(idx)]->Forward(x); }
+    for (int idx = 0; idx < modules_.size(); ++idx) { x = (*modules_[std::to_string(idx)])(x); }
     return x;
 }
 
-ModuleDict::ModuleDict(std::unordered_map<std::string, std::shared_ptr<Module>> modules) {
+ModuleDict::ModuleDict(std::unordered_map<std::string, std::shared_ptr<Module>> modules) : CloneableModule(kType) {
     for (auto &[name, layer] : modules) { modules_[name] = std::move(layer); }
 }
 

--- a/infini_train/src/nn/modules/normalization.cc
+++ b/infini_train/src/nn/modules/normalization.cc
@@ -9,7 +9,8 @@
 #include "infini_train/include/tensor.h"
 
 namespace infini_train::nn {
-LayerNorm::LayerNorm(const std::vector<int64_t> &normalized_shape, float eps, const Device *device) : eps_(eps) {
+LayerNorm::LayerNorm(const std::vector<int64_t> &normalized_shape, float eps, const Device *device)
+    : CloneableModule(kType), eps_(eps) {
     device_ = device ? device : DeviceManager::Instance()->GetDefaultDevice();
 
     parameters_[kParamWeightName]

--- a/infini_train/src/nn/parallel/data_parallel.cc
+++ b/infini_train/src/nn/parallel/data_parallel.cc
@@ -31,7 +31,7 @@ ParallelApply(const std::vector<std::shared_ptr<Module>> &modules,
     auto worker = [&](const std::shared_ptr<Module> &module, const std::vector<std::shared_ptr<Tensor>> &inputs,
                       const Device *device, int idx) {
         device->SetDevice();
-        auto output = module->Forward(inputs);
+        auto output = (*module)(inputs);
         results[idx] = output;
     };
 
@@ -86,7 +86,7 @@ std::vector<std::shared_ptr<Tensor>> DataParallel::Forward(const std::vector<std
     auto scattered_inputs = function::Scatter(input_tensors, devices_, dim_);
 
     if (devices_.size() == 1) {
-        return module->Forward(scattered_inputs[0]);
+        return (*module)(scattered_inputs[0]);
     }
 
     auto replicas = function::Replicate(module, devices_);

--- a/infini_train/src/nn/parallel/distributed_data_parallel.cc
+++ b/infini_train/src/nn/parallel/distributed_data_parallel.cc
@@ -50,7 +50,7 @@ DistributedDataParallel::DistributedDataParallel(std::shared_ptr<nn::Module> mod
 
 std::vector<std::shared_ptr<Tensor>>
 DistributedDataParallel::Forward(const std::vector<std::shared_ptr<Tensor>> &input_tensors) {
-    auto outputs = modules_[kModuleName]->Forward(input_tensors);
+    auto outputs = (*modules_[kModuleName])(input_tensors);
     if (reducer_) {
         reducer_->PrepareForBackward();
     }

--- a/infini_train/src/nn/parallel/pp/pipeline_schedule.cc
+++ b/infini_train/src/nn/parallel/pp/pipeline_schedule.cc
@@ -244,7 +244,7 @@ float PipelineSchedule::StepMicroBatches(const std::vector<std::shared_ptr<Tenso
                     infini_train::AutocastGuard autocast_guard(stage_->device()->Type(), dtype);
 
                     auto target_on_device = target->To(activations[task.local_chunk_idx][mb][0]->GetDevice());
-                    loss = loss_fn->Forward(
+                    loss = (*loss_fn)(
                         {activations[task.local_chunk_idx][mb][0], std::make_shared<Tensor>(target_on_device)})[0];
                     loss = loss / n;
                 }

--- a/infini_train/src/nn/parallel/pp/pipeline_stage.cc
+++ b/infini_train/src/nn/parallel/pp/pipeline_stage.cc
@@ -25,7 +25,7 @@ std::vector<std::shared_ptr<Tensor>> PipelineStage::ForwardOneChunk(const std::v
         LOG(FATAL) << "PipelineStage::ForwardOneChunk: local_chunk_idx=" << local_chunk_idx << " out of range [0, "
                    << chunks_.size() << ")";
     }
-    return chunks_[local_chunk_idx]->Forward(inputs);
+    return (*chunks_[local_chunk_idx])(inputs);
 }
 
 bool PipelineStage::IsFirstStage() const { return stage_index_ == 0; }

--- a/infini_train/src/nn/parallel/tensor_parallel.cc
+++ b/infini_train/src/nn/parallel/tensor_parallel.cc
@@ -269,8 +269,8 @@ std::vector<std::shared_ptr<Tensor>> GatherFromSPRegionFunc(const std::shared_pt
 
 ColumnParallelLinear::ColumnParallelLinear(int64_t in_features, int64_t out_features, bool bias, bool gather_output,
                                            bool input_is_parallel, bool skip_bias_add, bool sequence_parallel)
-    : bias_(bias), gather_output_(gather_output), input_is_parallel_(input_is_parallel), skip_bias_add_(skip_bias_add),
-      sequence_parallel_(sequence_parallel) {
+    : CloneableModule(kType), bias_(bias), gather_output_(gather_output), input_is_parallel_(input_is_parallel),
+      skip_bias_add_(skip_bias_add), sequence_parallel_(sequence_parallel) {
     auto tp_size = global::GetTensorParallelSize();
     CHECK_GT(tp_size, 0) << "No available devices found";
     CHECK_EQ(out_features % tp_size, 0) << "out_features must be divisible by TP world size for ColumnParallel";
@@ -315,8 +315,8 @@ ColumnParallelLinear::Forward(const std::vector<std::shared_ptr<Tensor>> &input_
 
 RowParallelLinear::RowParallelLinear(int64_t in_features, int64_t out_features, bool bias, bool reduce_output,
                                      bool input_is_parallel, bool skip_bias_add, bool sequence_parallel)
-    : bias_(bias), reduce_output_(reduce_output), input_is_parallel_(input_is_parallel), skip_bias_add_(skip_bias_add),
-      sequence_parallel_(sequence_parallel) {
+    : CloneableModule(kType), bias_(bias), reduce_output_(reduce_output), input_is_parallel_(input_is_parallel),
+      skip_bias_add_(skip_bias_add), sequence_parallel_(sequence_parallel) {
     auto tp_size = global::GetTensorParallelSize();
     CHECK_GT(tp_size, 0) << "No available devices found";
     CHECK_EQ(in_features % tp_size, 0) << "in_features must be divisible by TP world size for RowParallel";
@@ -362,7 +362,7 @@ RowParallelLinear::Forward(const std::vector<std::shared_ptr<Tensor>> &input_ten
 
 VocabParallelEmbedding::VocabParallelEmbedding(int64_t num_embeddings, int64_t embedding_dim,
                                                bool reduce_scatter_embeddings)
-    : vocab_size_global_(num_embeddings), embedding_dim_(embedding_dim),
+    : CloneableModule(kType), vocab_size_global_(num_embeddings), embedding_dim_(embedding_dim),
       reduce_scatter_embeddings_(reduce_scatter_embeddings) {
     auto tp_size = global::GetTensorParallelSize();
     CHECK_GT(tp_size, 0) << "No available devices found for VocabParallelEmbedding";

--- a/infini_train/src/utils/precision_checker.cc
+++ b/infini_train/src/utils/precision_checker.cc
@@ -1,0 +1,125 @@
+#include "infini_train/include/utils/precision_checker.h"
+
+#include <cmath>
+#include <iostream>
+#include <limits>
+
+#include "infini_train/include/autograd/function.h"
+#include "infini_train/include/nn/modules/module.h"
+#include "infini_train/include/tensor.h"
+
+namespace infini_train::utils {
+
+void PrecisionChecker::CheckTensors(const std::string& stage, const std::string& name,
+                                   const std::vector<std::shared_ptr<Tensor>>& tensors,
+                                   const Config& config) {
+    for (size_t i = 0; i < tensors.size(); ++i) {
+        if (!tensors[i]) continue;
+
+        auto& tensor = tensors[i];
+        const float* data = static_cast<const float*>(tensor->DataPtr());
+        size_t size = tensor->NumElements();
+
+        bool has_nan = false;
+        bool has_inf = false;
+        float min_val = std::numeric_limits<float>::max();
+        float max_val = std::numeric_limits<float>::lowest();
+        double sum = 0.0;
+
+        for (size_t j = 0; j < size; ++j) {
+            float val = data[j];
+            if (std::isnan(val)) has_nan = true;
+            if (std::isinf(val)) has_inf = true;
+            if (!std::isnan(val) && !std::isinf(val)) {
+                min_val = std::min(min_val, val);
+                max_val = std::max(max_val, val);
+                sum += val;
+            }
+        }
+
+        bool has_error = (config.check_nan && has_nan) || (config.check_inf && has_inf);
+
+        if (has_error || config.print_stats) {
+            std::cout << "[PrecisionCheck] " << stage << " " << name
+                     << " tensor[" << i << "]";
+
+            if (has_nan) std::cout << " NaN detected!";
+            if (has_inf) std::cout << " Inf detected!";
+
+            if (config.print_stats) {
+                std::cout << " min=" << min_val
+                         << " max=" << max_val
+                         << " mean=" << (sum / size);
+            }
+            std::cout << std::endl;
+        }
+
+        if (has_error && config.abort_on_error) {
+            std::cerr << "Precision check failed, aborting!" << std::endl;
+            std::abort();
+        }
+    }
+}
+
+void PrecisionChecker::RegisterForFunction(autograd::Function* func, const std::string& name,
+                                          const Config& config) {
+    std::string func_name = name.empty() ? "Function" : name;
+
+    func->RegisterForwardPreHook([func_name, config](autograd::Function*,
+                                                      const std::vector<std::shared_ptr<Tensor>>& inputs) {
+        CheckTensors("Forward Input", func_name, inputs, config);
+    });
+
+    func->RegisterForwardPostHook([func_name, config](autograd::Function*,
+                                                       const std::vector<std::shared_ptr<Tensor>>&,
+                                                       const std::vector<std::shared_ptr<Tensor>>& outputs) {
+        CheckTensors("Forward Output", func_name, outputs, config);
+    });
+
+    func->RegisterBackwardPreHook([func_name, config](autograd::Function*,
+                                                       const std::vector<std::shared_ptr<Tensor>>& grad_outputs) {
+        CheckTensors("Backward Input", func_name, grad_outputs, config);
+    });
+
+    func->RegisterBackwardPostHook([func_name, config](autograd::Function*,
+                                                        const std::vector<std::shared_ptr<Tensor>>& grad_inputs,
+                                                        const std::vector<std::shared_ptr<Tensor>>&) {
+        CheckTensors("Backward Output", func_name, grad_inputs, config);
+    });
+}
+
+void PrecisionChecker::RegisterForAllFunctions(const std::vector<std::shared_ptr<autograd::Function>>& functions,
+                                              const Config& config) {
+    for (size_t i = 0; i < functions.size(); ++i) {
+        RegisterForFunction(functions[i].get(), "Function_" + std::to_string(i), config);
+    }
+}
+
+void PrecisionChecker::RegisterForModule(nn::Module* module, const std::string& name,
+                                        const Config& config) {
+    std::string module_name = name.empty() ? module->type() : name;
+
+    // module->RegisterForwardPreHook([module_name, config](nn::Module*,
+    //                                                       const std::vector<std::shared_ptr<Tensor>>& inputs) {
+    //     CheckTensors("Module Forward Input", module_name, inputs, config);
+    // });
+
+    module->RegisterForwardPostHook([module_name, config](nn::Module*,
+                                                           const std::vector<std::shared_ptr<Tensor>>&,
+                                                           const std::vector<std::shared_ptr<Tensor>>& outputs) {
+        CheckTensors("Module Forward Output", module_name, outputs, config);
+    });
+
+    // module->RegisterBackwardPreHook([module_name, config](nn::Module*,
+    //                                                        const std::vector<std::shared_ptr<Tensor>>& grad_outputs) {
+    //     CheckTensors("Module Backward Input", module_name, grad_outputs, config);
+    // });
+
+    module->RegisterBackwardPostHook([module_name, config](nn::Module*,
+                                                            const std::vector<std::shared_ptr<Tensor>>& grad_inputs,
+                                                            const std::vector<std::shared_ptr<Tensor>>&) {
+        CheckTensors("Module Backward Output", module_name, grad_inputs, config);
+    });
+}
+
+} // namespace infini_train::utils


### PR DESCRIPTION
Add automatic precision checking for backward pass via INFINI_PRECISION_CHECK environment variable. Hooks are registered on gradient functions to detect NaN/Inf and monitor gradient statistics during backpropagation.
<img width="1416" height="375" alt="image" src="https://github.com/user-attachments/assets/4a0fbc34-7adb-4648-b542-9ea3de1f83b4" />
