### PR TITLE
fix: resolve GPU memory leak in pipeline parallel training

### DIFF
--- a/infini_train/src/nn/parallel/pp/pipeline_schedule.cc
+++ b/infini_train/src/nn/parallel/pp/pipeline_schedule.cc
@@ -50,6 +50,13 @@ std::vector<std::shared_ptr<Tensor>> PipelineSchedule::ReceiveFromPrev(int peer_
         // FIXME(jym): The data type between stages is not float32, which will cause a crash
         auto tensor = std::make_shared<Tensor>(shapes[i], DataType::kFLOAT32, stage_->device());
         tensor->set_requires_grad(true);
+
+        // Mark as non-leaf to prevent the autograd engine from creating an AccumulateGrad
+        // for this tensor. Otherwise, IRecv's next_functions_ would hold AccumulateGrad,
+        // which holds a shared_ptr back to this tensor, forming a reference cycle:
+        //   tensor -> grad_fn_(IRecv) -> next_functions_ -> AccumulateGrad -> tensor
+        // This cycle prevents the autograd graph from being released after backward.
+        tensor->set_is_leaf(false);
         recv_tensors.push_back(tensor);
     }
 


### PR DESCRIPTION
### 原因：
ReceiveFromPrev 中创建的接收 tensor 形成了 autograd 引用环：
```recv_tensors → grad_fn(IRecv) → IRecv.next_functions → AccumulateGrad.tensor_ → recv_tensors```

  1. ReceiveFromPrev 创建 tensor，默认 is_leaf=true
  2. 调用 IRecv::Apply 时，由于 is_leaf=true，autograd 引擎为其创建了 AccumulateGrad 并挂入 IRecv 的 next_functions_
  3. 同时，IRecv::Apply 将该 tensor 的 grad_fn_ 设为 IRecv 本身
  4. 这样就形成了闭环：tensor 通过 grad_fn_ 指向 IRecv，IRecv 通过 next_functions_ 指向 AccumulateGrad，AccumulateGrad 又通过 tensor_ 指回 tensor

  正常情况下 autograd graph 是 DAG，backward 完成后函数对象会级联销毁。但环的存在导致环中对象的 ref count 永远无法降到 0，整个 graph 无法释放，每一步都残留一个闭环，used 显存持续增长。

### 修复方案：
  创建用于在PP chunk之间接收通信数据的 tensor 时将其标记为非 leaf， ``set_is_leaf(false)``。这样 IRecv::Apply 中不会创建
  AccumulateGrad，闭环在源头被切断，graph 可以正常销毁。
