### PR TITLE
fix: correct LoRA initialization and forward pass under tensor parallelism

### DIFF
--- a/docs/lora_usage_guide.md
+++ b/docs/lora_usage_guide.md
@@ -145,10 +145,13 @@ void LoadLoRAWeights(std::shared_ptr<Module> model,
 - `MergeLoRAWeights` 将 `W += (alpha / rank) * B @ A` 写回基础权重，并冻结 LoRA 参数。
 - `UnmergeLoRAWeights` 撤销一次已合并的 LoRA 增量，并恢复 LoRA 参数可训练。
 - `MergeAndUnload` 会先合并，再把 LoRA 模块替换回普通 `Linear` / TP Linear，并解冻返回模型参数。
-- `SaveLoRAWeights` 只保存名字包含 `lora_A` / `lora_B` 的参数。
+- `SaveLoRAWeights` 只保存名字包含 `lora_A` / `lora_B` 的参数；TP 下会先把分片参数 gather 成
+  full/unsharded tensor，再由主 TP rank 写文件。
 - LoRA 权重文件是二进制文件，包含 magic `"LORA"`、version `1`、tensor 名称、维度和 float 数据。
 - 加载前模型必须已经用相同目标层注入 LoRA；找不到的 LoRA 参数会打印 warning。
-- 加载时如果文件里的 tensor 和当前参数同形状，会直接拷贝；如果当前参数是 TP 分片，会按第一个不同维度用 `parallel::tp_rank` 切片后再拷贝。
+- 加载时如果输入 tensor 和当前参数同形状，会直接拷贝；如果当前参数是 TP 分片，会按当前 `tp_rank`
+  切片后再拷贝。`c_attn.lora_B` 会按 packed QKV 的 `[Q | K | V]` 布局特殊处理，加载为本 rank 的
+  `[Qi | Ki | Vi]`，和 attention QKV 权重加载方式保持一致。
 
 ### 统计和解析工具
 
@@ -175,7 +178,10 @@ ParseLoRATargetModules(const std::string &targets);
 如果模型用了 TP，不需要手动创建 `LoRAColumnParallelLinear` 或 `LoRARowParallelLinear`；
 只要正常调用 `GetLoRAModel(model, config)`，注入逻辑会根据基础层类型自动选择对应的 LoRA 实现。
 
-加载 LoRA 权重时，如果文件里保存的是完整 tensor，而当前模型在 TP 下只需要某个 rank 的分片，加载函数会自动按当前 `tp_rank` 切片。
+加载 LoRA 权重时，如果文件里保存的是完整 tensor，而当前模型在 TP 下只需要某个 rank 的分片，加载函数会自动按当前
+`tp_rank` 切片；attention 的 `c_attn.lora_B` 会按 Q/K/V 三段分别切片后再拼接。
+保存 LoRA 权重时，文件里的 tensor 默认也是完整 tensor；attention 的 `c_attn.lora_B` 会从各 rank 的
+`[Qi | Ki | Vi]` 还原成 `[Q | K | V]` 后写入。
 
 ## 命令行示例
 
@@ -294,8 +300,10 @@ ctest --test-dir build -R LoRATest --output-on-failure
 - 直接用 `GetLoRAModel` 就好；现在没有单独的 `LoRAModel` 类，也没有 `lora_model.h`。
 - `LoRAConfig` 先默认创建再填字段；如果想一行构造，需要传完整的 4 个参数。
 - 保存和加载传的是具体文件名，比如 `gpt2_lora.bin`，不是目录。
-- LoRA 文件只存 `lora_A` / `lora_B`，不会保存基础模型权重。
-- TP 运行时加载 LoRA 权重，如果文件里是完整 tensor、当前 rank 只需要分片，加载函数会自动按当前 `tp_rank` 切一段。
+- LoRA 文件只存 `lora_A` / `lora_B`，不会保存基础模型权重；TP 下文件里保存的是可移植的完整 tensor，
+  不是某个 rank 的 local shard。
+- TP 运行时加载 LoRA 权重，如果文件里是完整 tensor、当前 rank 只需要分片，加载函数会自动按当前 `tp_rank`
+  切片；`c_attn.lora_B` 会按 Q/K/V 三段分别切片后再拼接。
 - `MergeLoRAWeights` 适合推理前用；如果还要继续训练，先调用 `UnmergeLoRAWeights`。
 - `MergeAndUnload` 会把 LoRA 模块变回普通 Linear，之后模型里就没有 `lora_A` / `lora_B` 了。
 - 现在一次只支持一套 LoRA adapter，不支持多个 adapter 叠加。

--- a/docs/lora_usage_guide.md
+++ b/docs/lora_usage_guide.md
@@ -1,715 +1,301 @@
 # LoRA 使用说明
 
-本文档介绍如何在 InfiniTrain 中使用 LoRA (Low-Rank Adaptation) 进行高效微调。
-
-## 目录
-
-1. [快速开始](#快速开始)
-2. [核心概念](#核心概念)
-3. [命令行使用](#命令行使用-gpt2-示例)
-4. [LoRAModel 包装器](#lora模型-包装器-推荐模式)
-5. [API 参考](#api-参考)
-6. [使用示例](#使用示例)
-7. [最佳实践](#最佳实践)
-8. [常见问题](#常见问题)
+本文档描述 InfiniTrain 当前 LoRA 实现的实际用法。当前实现采用 PEFT-style **原地注入**：
+`GetLoRAModel(model, config)` 会替换匹配的 Linear 模块、冻结非 LoRA 参数，并返回修改后的
+`std::shared_ptr<Module>`。仓库里没有独立的 `LoRAModel` 包装器类或 `lora_model.h`。
 
 ## 快速开始
 
-### 头文件引入
+### 头文件
 
 ```cpp
-#include "nn/lora/lora_config.h"
-#include "nn/lora/lora_linear.h"
-#include "nn/lora/lora_utils.h"
-// 如果使用张量并行
-#include "nn/lora/lora_parallel_linear.h"
-// 如果使用 LoRAModel 包装器
-#include "nn/lora/lora_model.h"
+#include "infini_train/include/nn/lora/lora_config.h"
+#include "infini_train/include/nn/lora/lora_linear.h"
+#include "infini_train/include/nn/lora/lora_parallel_linear.h"
+#include "infini_train/include/nn/lora/lora_utils.h"
 ```
 
-### 最简示例
+### 最小示例
 
 ```cpp
 using namespace infini_train::nn::lora;
 
-// 1. 创建 LoRA 配置
 LoRAConfig config;
-config.rank = 8;       // 低秩维度
-config.alpha = 16.0f;  // 缩放因子
+config.rank = 8;
+config.alpha = 16.0f;
+config.target_modules = ParseLoRATargetModules("c_attn,attn.c_proj");
 
-// 2. 获取 LoRA 模型 (原地修改，自动冻结基础模型)
-auto lora_model = GetLoRAModel(model, config);
+// 原地注入 LoRA，并冻结非 LoRA 参数。
+model = GetLoRAModel(model, config);
+PrintLoRASummary(model);
 
-// 3. 获取可训练参数用于优化器
-auto trainable_params = nn::lora::GetLoRAParameters(lora_model);
-auto optimizer = std::make_shared<Adam>(trainable_params, lr);
+auto params = GetLoRAParameters(model);
+auto optimizer = optimizers::Adam::Create(/*learning_rate=*/1e-4)(params);
 
-// 4. 训练循环
 for (int step = 0; step < num_steps; ++step) {
-    auto loss = (*lora_model)(inputs);
+    optimizer->ZeroGrad();
+    auto logits = (*model)({input})[0];
+    auto loss = (*loss_fn)({logits, labels})[0];
     loss->Backward();
     optimizer->Step();
-    optimizer->ZeroGrad();
 }
 
-// 5. 保存 LoRA 权重
-SaveLoRAWeights(lora_model, "lora_weights.bin");
+SaveLoRAWeights(model, "adapter_lora.bin");
 ```
 
-## 核心概念
+## 核心行为
 
-### LoRA 原理
+LoRA 对 Linear 层追加低秩增量：
 
-LoRA 通过低秩分解来近似权重更新：
-
-```
-原始: y = Wx + b
-LoRA: y = Wx + b + (α/r) × x × A^T × B^T
+```text
+y = x @ W^T + b + (alpha / rank) * x @ A^T @ B^T
 ```
 
-其中：
-- `W` 是冻结的原始权重
-- `A` 是形状为 `[rank, in_features]` 的可训练矩阵
-- `B` 是形状为 `[out_features, rank]` 的可训练矩阵
-- `α/r` 是缩放因子
+- `W` 和 `bias` 来自原基础层，注入后默认冻结。
+- `lora_A` 形状为 `[rank, in_features]`，默认 Kaiming uniform 初始化。
+- `lora_B` 形状为 `[out_features, rank]`，零初始化，因此注入初始时不改变基础模型输出。
+- LoRA 参数当前固定创建为 `float32`。
+- `dropout` 字段存在于 `LoRAConfig`，当前未实现。
 
-### 参数效率
+`GetLoRAModel` 会遍历 `NamedModules()`，按 `target_modules` 匹配模块路径：
 
-假设原始 Linear 层参数量为 `in × out`，LoRA 只需训练 `rank × (in + out)` 个参数。
-
-例如：`in=4096, out=4096, rank=8`
-- 原始参数：16,777,216
-- LoRA 参数：65,536 (仅 0.39%)
-
-## LoRAModel 包装器类
-
-### LoRAModel
-
-遵循 PEFT 模式的 LoRA 包装器，封装基础模型和 LoRA 配置。使用 `NamedModules()` 自动遍历模型层次结构。
-
-```cpp
-class LoRAModel : public Module {
-public:
-    // 构造函数 - 自动遍历模型层次结构
-    LoRAModel(std::shared_ptr<Module> base_model,
-              const LoRAConfig &config);
-
-    // 获取所有参数
-    std::vector<std::shared_ptr<Tensor>> Parameters() const override;
-
-    // LoRA 权重管理
-    void SaveLoRA(const std::string &filepath) const;
-    void LoadLoRA(const std::string &filepath);
-    void Merge();
-    void Unmerge();
-    bool IsMerged() const;
-
-    // 打印摘要
-    void PrintSummary() const;
-
-    // 访问基础模型
-    std::shared_ptr<Module> base_model() const;
-
-    // 获取 LoRA 配置
-    const LoRAConfig &config() const;
-};
-```
-
-### 工厂函数
-
-```cpp
-template <typename ModelType, typename ConfigType>
-std::shared_ptr<LoRAModel> CreateLoRAModel(
-    const ConfigType &model_config,
-    const LoRAConfig &lora_config) {
-    auto base_model = std::make_shared<ModelType>(model_config);
-    return std::make_shared<LoRAModel>(base_model, lora_config);
-}
-```
+- 匹配规则是完整组件后缀匹配，例如 `attn.c_proj` 可匹配
+  `transformer.h.0.attn.c_proj`。
+- `c_proj` 会同时匹配 attention 和 MLP 中名为 `c_proj` 的层。
+- `attn.c_proj` 只匹配 attention output projection。
+- 若根模块本身匹配，返回值可能是新的 LoRA 模块，因此应使用返回的 `model`。
 
 ## API 参考
 
-### LoRAConfig - 配置结构
+### LoRAConfig
 
 ```cpp
 struct LoRAConfig {
-    int64_t rank = 8;       // 低秩维度 r
-    float alpha = 16.0f;   // 缩放因子 α
-    float dropout = 0.0f;  // Dropout 概率（暂未实现）
-
-    // 目标模块名称（默认只对 attention 层应用）
-    // 注意：匹配模块名的后缀，而非完整路径
+    int64_t rank = 8;
+    float alpha = 16.0f;
+    float dropout = 0.0f; // not implemented
     std::unordered_set<std::string> target_modules = {"c_attn", "c_proj"};
+    bool use_kaiming_a = true;
+    float kaiming_a_param = sqrtf(5.0f);
 
-    // 初始化参数
-    bool use_kaiming_a = true;           // A 矩阵使用 Kaiming 初始化
-    float kaiming_a_param = sqrtf(5.0f); // Kaiming 初始化参数 (默认值与 PyTorch 一致)
+    LoRAConfig() = default;
+    LoRAConfig(int64_t r, float a, float d,
+               const std::unordered_set<std::string> &targets);
 
-    // 计算缩放因子
-    float Scaling() const;  // 返回 alpha / rank
-
-    // 检查模块是否应该应用 LoRA
-    // 匹配规则：模块名以 target_modules 中的任意一个结尾
+    float Scaling() const;
     bool ShouldApplyLoRA(const std::string &module_name) const;
 };
 ```
 
-### 模型应用函数
-
-#### GetLoRAModel
-
-PEFT-style 运行时包装器，使用 `NamedModules()` 自动遍历模型层次结构，创建 LoRA 模型。
+推荐用法：
 
 ```cpp
-std::shared_ptr<Module> GetLoRAModel(
-    std::shared_ptr<Module> model,           // 目标模型
-    const LoRAConfig &config                 // LoRA 配置
-);
-```
-
-**参数说明：**
-- `model`: 要包装的模型
-- `config`: LoRA 配置（包含 `target_modules` 指定目标层）
-
-**返回值：** `std::shared_ptr<Module>`，返回原地修改后的模型（已注入 LoRA 层并冻结基础模型）
-
-**使用示例：**
-```cpp
-// 配置 LoRA
-LoRAConfig config{8, 16.0f};
-// 使用 ParseLoRATargetModules 解析逗号分隔的字符串
-config.target_modules = ParseLoRATargetModules("c_attn,c_proj");  // 只对 attention
-// config.target_modules = ParseLoRATargetModules("c_attn,c_proj,c_fc,c_proj");  // 包含 MLP
-
-// 一行启用 LoRA (原地修改，自动冻结基础模型)
-auto lora_model = nn::lora::GetLoRAModel(model, config);
-```
-
-#### InjectLoRALayers
-
-使用 `NamedModules()` 自动遍历模型层次结构，将 LoRA 注入到所有匹配的层中。
-
-```cpp
-void InjectLoRALayers(
-    std::shared_ptr<Module> model,           // 目标模型
-    const LoRAConfig &config                 // LoRA 配置
-);
-```
-
-**参数说明：**
-- `model`: 要注入 LoRA 的模型
-- `config`: LoRA 配置（通过 `target_modules` 指定目标层）
-
-### 参数管理函数
-
-#### FreezeBaseModel / UnfreezeModel
-
-```cpp
-// 冻结基础模型所有参数
-void FreezeBaseModel(std::shared_ptr<Module> model);
-
-// 解冻所有参数
-void UnfreezeModel(std::shared_ptr<Module> model);
-```
-
-#### GetLoRAParameters / GetBaseParameters
-
-```cpp
-// 获取 LoRA 参数（用于优化器）
-std::vector<std::shared_ptr<Tensor>> GetLoRAParameters(
-    const std::shared_ptr<Module> &model);
-
-// 获取基础模型参数
-std::vector<std::shared_ptr<Tensor>> GetBaseParameters(
-    const std::shared_ptr<Module> &model);
-```
-
-### 权重合并函数
-
-#### MergeLoRAWeights / UnmergeLoRAWeights
-
-```cpp
-// 合并 LoRA 权重到基础权重: W' = W + (α/r) × B × A
-void MergeLoRAWeights(std::shared_ptr<Module> model);
-
-// 恢复原始基础权重
-void UnmergeLoRAWeights(std::shared_ptr<Module> model);
-
-// 合并权重并卸载 LoRA 模块，返回纯基础模型
-std::shared_ptr<Module> MergeAndUnload(std::shared_ptr<Module> model);
-```
-
-**使用场景：**
-- 推理时合并权重可以消除额外计算开销
-- 导出模型时合并权重得到标准模型格式
-- `MergeAndUnload`: 导出完整的标准模型，替换所有 LoRA 模块为普通 Linear 层
-
-### 保存/加载函数
-
-```cpp
-// 保存 LoRA 权重到文件
-void SaveLoRAWeights(const std::shared_ptr<Module> &model,
-                     const std::string &filepath);
-
-// 从文件加载 LoRA 权重
-void LoadLoRAWeights(std::shared_ptr<Module> model,
-                     const std::string &filepath);
-
-// 获取 LoRA 状态字典
-std::unordered_map<std::string, std::shared_ptr<Tensor>>
-LoRAStateDict(const std::shared_ptr<Module> &model);
-
-// 加载 LoRA 状态字典
-void LoadLoRAStateDict(
-    std::shared_ptr<Module> model,
-    const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict);
-```
-
-### 统计函数
-
-```cpp
-// 打印 LoRA 模型摘要
-void PrintLoRASummary(const std::shared_ptr<Module> &model);
-
-// 统计可训练参数数量
-int64_t CountTrainableParameters(const std::shared_ptr<Module> &model);
-
-// 统计总参数数量
-int64_t CountTotalParameters(const std::shared_ptr<Module> &model);
-```
-
-### 工具函数
-
-```cpp
-// 解析逗号分隔的目标模块字符串
-std::unordered_set<std::string> ParseLoRATargetModules(const std::string &targets);
-
-// 示例: "c_attn,c_proj" -> {"c_attn", "c_proj"}
-```
-
-### 张量并行 LoRA 类
-
-当使用张量并行 (TP) 时，`GetLoRAModel` 会自动检测并使用对应的 LoRA 包装器：
-
-```cpp
-// LoRA for ColumnParallelLinear (e.g., QKV projection)
-// LoRA A: [rank, in_features] - replicated across TP ranks
-// LoRA B: [out_features_per_partition, rank] - sharded like base weight
-class LoRAColumnParallelLinear;
-
-// LoRA for RowParallelLinear (e.g., output projection)
-// LoRA A: [rank, in_features_per_partition] - sharded like base weight
-// LoRA B: [out_features, rank] - replicated across TP ranks
-class LoRARowParallelLinear;
-```
-
-**注意**: 使用张量并行时无需手动创建这些类，`GetLoRAModel` 会自动处理。
-
-### TP=1 自动退化
-
-`ColumnParallelLinear` 和 `RowParallelLinear` 在 TP=1 时会自动退化为普通 Linear，无需在模型代码中条件分支：
-
-```cpp
-// 模型代码可以统一使用 ColumnParallelLinear/RowParallelLinear
-// TP=1 时自动走 fast-path，等价于普通 Linear
-modules_["c_attn"] = std::make_shared<nn::parallel::ColumnParallelLinear>(...);
-modules_["c_proj"] = std::make_shared<nn::parallel::RowParallelLinear>(...);
-```
-
-这使得 LoRA 包装可以统一工作，无论是否使用张量并行。
-
-## 使用示例
-
-### 示例 1: GPT2 微调
-
-```cpp
-#include "example/gpt2/gpt2.h"
-#include "nn/lora/lora_utils.h"
-
-using namespace infini_train::nn::lora;
-
-int main() {
-    // 创建 GPT2 模型
-    auto model = std::make_shared<GPT2>(config);
-    model->LoadWeights("gpt2_weights.bin");
-
-    // 配置 LoRA
-    LoRAConfig lora_config;
-    lora_config.rank = 8;
-    lora_config.alpha = 16.0f;
-    lora_config.target_modules = ParseLoRATargetModules("c_attn,c_proj");  // 只对 attention 层
-
-    // 获取 LoRA 模型 (原地修改，自动冻结基础模型)
-    auto lora_model = GetLoRAModel(model, lora_config);
-
-    // 打印参数统计
-    PrintLoRASummary(lora_model);
-    // 输出示例:
-    // ========== LoRA Model Summary ==========
-    // Total parameters:     124,439,808
-    // Trainable parameters: 294,912 (0.24%)
-    // Frozen parameters:    124,144,896
-    // =========================================
-
-    // 创建优化器（只优化 LoRA 参数）
-    auto trainable_params = nn::lora::GetLoRAParameters(lora_model);
-    auto optimizer = std::make_shared<Adam>(trainable_params, /*lr=*/1e-4);
-
-    // 训练循环
-    for (int step = 0; step < num_steps; ++step) {
-        auto [loss, logits] = (*lora_model)({input_ids});
-        loss->Backward();
-        optimizer->Step();
-        optimizer->ZeroGrad();
-
-        if (step % 100 == 0) {
-            std::cout << "Step " << step << ", Loss: " << loss->Item<float>() << std::endl;
-        }
-    }
-
-    // 保存 LoRA 权重（仅几 MB）
-    SaveLoRAWeights(lora_model, "gpt2_lora.bin");
-
-    return 0;
-}
-```
-
-### 示例 2: LLaMA3 分布式微调
-
-```cpp
-#include "example/llama3/llama3.h"
-#include "nn/lora/lora_utils.h"
-#include "nn/parallel/process_group.h"
-
-using namespace infini_train::nn::lora;
-
-int main(int argc, char **argv) {
-    // 初始化分布式环境
-    InitDistributed(argc, argv);
-
-    // 创建 LLaMA3 模型（带张量并行）
-    LLaMA3Config config;
-    config.n_layers = 32;
-    config.tensor_parallel = 2;
-
-    auto model = std::make_shared<LLaMA3>(config);
-    model->LoadWeights("llama3_weights/");
-
-    // 配置 LoRA（包含 MLP 层以获得更好效果）
-    LoRAConfig lora_config{16, 32.0f};
-    lora_config.target_modules = ParseLoRATargetModules("c_attn,c_proj,c_fc,c_fc2,c_proj");
-
-    // 获取 LoRA 模型（原地修改，自动冻结基础模型）
-    auto lora_model = GetLoRAModel(model, lora_config);
-
-    PrintLoRASummary(lora_model);
-
-    // 训练...
-
-    // 保存
-    if (GetRank() == 0) {
-        SaveLoRAWeights(lora_model, "llama3_lora.bin");
-    }
-
-    return 0;
-}
-```
-
-### 示例 3: 推理时合并权重
-
-```cpp
-// 加载基础模型
-auto model = std::make_shared<GPT2>(config);
-model->LoadWeights("gpt2_weights.bin");
-
-// 配置并获取 LoRA 模型
-LoRAConfig lora_config;
-lora_config.rank = 8;
-lora_config.alpha = 16.0f;
-lora_config.target_modules = ParseLoRATargetModules("c_attn,c_proj");
-auto lora_model = GetLoRAModel(model, lora_config);
-
-// 加载 LoRA 权重
-LoadLoRAWeights(lora_model, "gpt2_lora.bin");
-
-// 合并权重（推理时无额外开销）
-MergeLoRAWeights(lora_model);
-
-// 现在可以像普通模型一样推理
-auto output = (*lora_model)({input_ids});
-
-// 如果需要继续训练，先解除合并
-UnmergeLoRAWeights(lora_model);
-```
-
-### 示例 4: 导出标准模型 (MergeAndUnload)
-
-使用 `MergeAndUnload` 将 LoRA 模型转换为标准模型，可以直接保存为普通模型文件：
-
-```cpp
-// 加载基础模型并应用 LoRA
-auto model = std::make_shared<GPT2>(config);
-model->LoadWeights("gpt2_weights.bin");
-
-LoRAConfig lora_config;
-lora_config.rank = 8;
-lora_config.alpha = 16.0f;
-lora_config.target_modules = ParseLoRATargetModules("c_attn,c_proj");
-auto lora_model = GetLoRAModel(model, lora_config);
-
-// 训练...
-// ...
-
-// 加载训练好的 LoRA 权重
-LoadLoRAWeights(lora_model, "gpt2_lora.bin");
-
-// 合并并卸载 LoRA，返回标准模型
-// lora_model 中的所有 LoRALinear 都被替换为普通 Linear
-auto merged_model = MergeAndUnload(lora_model);
-
-// 保存为标准模型（与原始模型格式相同）
-merged_model->SaveWeights("gpt2_finetuned.bin");
-
-// 现在 merged_model 是一个普通模型，无需 LoRA 即可推理
-auto output = (*merged_model)({input_ids});
-```
-
-### 示例 5: 自定义目标层
-
-```cpp
-// 对所有线性层应用
 LoRAConfig config;
 config.rank = 8;
 config.alpha = 16.0f;
-config.target_modules = ParseLoRATargetModules("c_attn,c_proj,c_fc,c_proj,lm_head");
-
-// 获取 LoRA 模型
-auto lora_model = GetLoRAModel(model, config);
+config.target_modules = ParseLoRATargetModules("c_attn,attn.c_proj");
 ```
 
-## 最佳实践
-
-### 1. 选择合适的 rank
-
-| 任务类型 | 推荐 rank | 说明 |
-|---------|----------|------|
-| 简单分类任务 | 4-8 | 参数少，训练快 |
-| 文本生成微调 | 8-16 | 平衡效果和效率 |
-| 复杂任务适配 | 16-64 | 更强表达能力 |
-
-### 2. alpha 设置
-
-- 通常设置 `alpha = 2 × rank`
-- 较大的 alpha 会增加 LoRA 的影响
-- 可以通过调整 alpha 来控制微调强度
-
-### 3. 目标层选择
+### 注入与参数管理
 
 ```cpp
-// 推荐：只对 attention 层（参数效率最高）
-config.target_modules = ParseLoRATargetModules("c_attn,c_proj");
+std::shared_ptr<Module> GetLoRAModel(std::shared_ptr<Module> model,
+                                     const LoRAConfig &config);
 
-// 可选：包含 MLP 层（效果可能更好，但参数更多）
-config.target_modules = ParseLoRATargetModules("c_attn,c_proj,c_fc,c_fc2,c_proj");
+std::shared_ptr<Module> InjectLoRALayers(std::shared_ptr<Module> model,
+                                         const LoRAConfig &config);
+
+void FreezeBaseModel(std::shared_ptr<Module> model);
+void UnfreezeModel(std::shared_ptr<Module> model);
+
+std::vector<std::shared_ptr<Tensor>>
+GetLoRAParameters(const std::shared_ptr<Module> &model);
+
+std::vector<std::shared_ptr<Tensor>>
+GetBaseParameters(const std::shared_ptr<Module> &model);
 ```
 
-### 4. 学习率
+- `GetLoRAModel` = 注入 + 冻结基础参数 + 重新打开 LoRA 参数。
+- `InjectLoRALayers` 只做结构替换，不冻结参数。
+- 示例训练入口在启用 LoRA 时只把 `GetLoRAParameters(model)` 传给优化器。
+- 对 merged 状态的 LoRA 模块调用 `GetLoRAParameters` 会触发检查；继续训练前先
+  `UnmergeLoRAWeights(model)`。
 
-- LoRA 通常使用比全量微调更高的学习率
-- 推荐范围：1e-4 到 1e-3
-- 可以使用学习率预热和衰减
-
-### 5. 内存优化
+### 合并、卸载、保存和加载
 
 ```cpp
-// 只保存 LoRA 权重（几 MB vs 几 GB）
-SaveLoRAWeights(model, "lora.bin");
+void MergeLoRAWeights(std::shared_ptr<Module> model);
+void UnmergeLoRAWeights(std::shared_ptr<Module> model);
+std::shared_ptr<Module> MergeAndUnload(std::shared_ptr<Module> model);
 
-// 推理时合并权重，消除额外计算
-MergeLoRAWeights(model);
+std::unordered_map<std::string, std::shared_ptr<Tensor>>
+LoRAStateDict(const std::shared_ptr<Module> &model);
+
+void LoadLoRAStateDict(
+    std::shared_ptr<Module> model,
+    const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict);
+
+void SaveLoRAWeights(const std::shared_ptr<Module> &model,
+                     const std::string &filepath);
+
+void LoadLoRAWeights(std::shared_ptr<Module> model,
+                     const std::string &filepath);
 ```
 
-## 模型层名称参考
+- `MergeLoRAWeights` 将 `W += (alpha / rank) * B @ A` 写回基础权重，并冻结 LoRA 参数。
+- `UnmergeLoRAWeights` 撤销一次已合并的 LoRA 增量，并恢复 LoRA 参数可训练。
+- `MergeAndUnload` 会先合并，再把 LoRA 模块替换回普通 `Linear` / TP Linear，并解冻返回模型参数。
+- `SaveLoRAWeights` 只保存名字包含 `lora_A` / `lora_B` 的参数。
+- LoRA 权重文件是二进制文件，包含 magic `"LORA"`、version `1`、tensor 名称、维度和 float 数据。
+- 加载前模型必须已经用相同目标层注入 LoRA；找不到的 LoRA 参数会打印 warning。
+- 加载时如果文件里的 tensor 和当前参数同形状，会直接拷贝；如果当前参数是 TP 分片，会按第一个不同维度用 `parallel::tp_rank` 切片后再拷贝。
 
-### GPT2 模型结构
+### 统计和解析工具
 
-```
-transformer.wte          # Token Embedding
-transformer.wpe          # Position Embedding
-transformer.h.{i}.ln_1   # LayerNorm 1
-transformer.h.{i}.attn.c_attn   # QKV 投影 (ColumnParallel)
-transformer.h.{i}.attn.c_proj   # Output 投影 (RowParallel)
-transformer.h.{i}.ln_2   # LayerNorm 2
-transformer.h.{i}.mlp.c_fc      # MLP 第一层 (ColumnParallel)
-transformer.h.{i}.mlp.c_proj    # MLP 第二层 (RowParallel)
-transformer.ln_f         # Final LayerNorm
-lm_head                  # Language Model Head
-```
+```cpp
+int64_t CountTrainableParameters(const std::shared_ptr<Module> &model);
+int64_t CountTotalParameters(const std::shared_ptr<Module> &model);
+void PrintLoRASummary(const std::shared_ptr<Module> &model,
+                      int global_rank = -1);
 
-### LLaMA3 模型结构
-
-```
-transformer.tok_emb      # Token Embedding
-transformer.h.{i}.attn_norm     # RMSNorm (attention)
-transformer.h.{i}.attn.c_attn   # QKV 投影 (ColumnParallel)
-transformer.h.{i}.attn.c_proj   # Output 投影 (RowParallel)
-transformer.h.{i}.ffn_norm      # RMSNorm (FFN)
-transformer.h.{i}.mlp.c_fc      # FFN gate (ColumnParallel)
-transformer.h.{i}.mlp.c_fc2     # FFN up (ColumnParallel)
-transformer.h.{i}.mlp.c_proj    # FFN down (RowParallel)
-transformer.norm         # Final RMSNorm
-lm_head                  # Language Model Head
+std::unordered_set<std::string>
+ParseLoRATargetModules(const std::string &targets);
 ```
 
-## 命令行使用 (GPT2 示例)
+`ParseLoRATargetModules("c_attn, attn.c_proj")` 会去掉空白并忽略空项。
 
-### 启用 LoRA 训练
+## 支持的模块
+
+`GetLoRAModel` 会自动替换匹配到的线性层，目前支持：
+
+- `nn::Linear`
+- `parallel::ColumnParallelLinear`
+- `parallel::RowParallelLinear`
+
+如果模型用了 TP，不需要手动创建 `LoRAColumnParallelLinear` 或 `LoRARowParallelLinear`；
+只要正常调用 `GetLoRAModel(model, config)`，注入逻辑会根据基础层类型自动选择对应的 LoRA 实现。
+
+加载 LoRA 权重时，如果文件里保存的是完整 tensor，而当前模型在 TP 下只需要某个 rank 的分片，加载函数会自动按当前 `tp_rank` 切片。
+
+## 命令行示例
+
+GPT2 和 Llama3 示例都通过 `--lora_rank > 0` 启用 LoRA，并在训练结束时按需保存。
+
+### GPT2
 
 ```bash
 ./build/gpt2 \
-    --device cuda \
-    --input_bin data/train.bin \
-    --llmc_filepath data/gpt2_124M.bin \
-    --batch_size 4 \
-    --sequence_length 64 \
-    --num_iteration 10 \
-    --learning_rate 1e-5 \
-    --lora_rank 8 \
-    --lora_alpha 16.0 \
-    --lora_target_modules "c_attn,c_proj" \
-    --lora_save_path data/lora_weights
+  --device cuda \
+  --input_bin data/train.bin \
+  --llmc_filepath data/gpt2_124M.bin \
+  --batch_size 4 \
+  --sequence_length 64 \
+  --num_iteration 10 \
+  --learning_rate 1e-4 \
+  --lora_rank 8 \
+  --lora_alpha 16.0 \
+  --lora_target_modules "c_attn,attn.c_proj" \
+  --lora_save_path gpt2_lora.bin
 ```
 
-### 命令行参数
+GPT2 默认 LoRA target 是 `"c_attn,c_proj"`。
 
-| 参数 | 默认值 | 说明 |
-|------|--------|------|
-| `--lora_rank` | 0 | LoRA 秩 (0 = 禁用) |
-| `--lora_alpha` | 16.0 | LoRA 缩放因子 |
-| `--lora_target_modules` | "c_attn,c_proj" | 目标模块 (逗号分隔: c_attn,c_proj,c_fc,c_proj) |
-| `--lora_load_path` | "" | 加载已有 LoRA 权重 |
-| `--lora_save_path` | "" | 保存 LoRA 权重路径 |
+### Llama3
+
+```bash
+./build/llama3 \
+  --device cuda \
+  --input_bin data/train.bin \
+  --llmc_filepath data/llama3.bin \
+  --batch_size 4 \
+  --sequence_length 64 \
+  --num_iteration 10 \
+  --learning_rate 1e-4 \
+  --lora_rank 8 \
+  --lora_alpha 16.0 \
+  --lora_target_modules "c_attn,c_proj,c_fc,c_fc2" \
+  --lora_save_path llama3_lora.bin
+```
+
+Llama3 默认 LoRA target 是 `"c_attn,c_proj,c_fc,c_fc2"`。
 
 ### 加载已有 LoRA 权重
 
 ```bash
 ./build/gpt2 \
-    ...
-    --lora_rank 8 \
-    --lora_alpha 16.0 \
-    --lora_load_path data/lora_weights
+  --device cuda \
+  --input_bin data/train.bin \
+  --llmc_filepath data/gpt2_124M.bin \
+  --lora_rank 8 \
+  --lora_alpha 16.0 \
+  --lora_target_modules "c_attn,attn.c_proj" \
+  --lora_load_path gpt2_lora.bin
 ```
 
-## LoRAModel 包装器 (推荐模式)
+加载时请保持 `rank` 和 `lora_target_modules` 与保存这份 LoRA 权重时一致。
 
-### 概述
+### 参数表
 
-`LoRAModel` 是一个包装器类，遵循 PEFT 设计模式，将 LoRA 作为包装器应用于基础模型，而不是直接修改模型代码。
+| 参数 | 默认值 | 说明 |
+| --- | --- | --- |
+| `--lora_rank` | `0` | LoRA rank；`0` 表示禁用 LoRA |
+| `--lora_alpha` | `16.0` | LoRA scaling 分子，实际缩放为 `alpha / rank` |
+| `--lora_target_modules` | 模型相关 | 逗号分隔的目标模块后缀 |
+| `--lora_load_path` | `""` | 启动时加载 LoRA 权重文件 |
+| `--lora_save_path` | `""` | 训练结束后保存 LoRA 权重文件 |
 
-### 优势
+示例入口在启用 LoRA 后会：
 
-- **透明性**: 训练循环无需修改，直接使用 `(*model)(inputs)`
-- **参数管理**: 自动获取可训练参数
-- **权重管理**: 内置 Save/Load/Merge 方法
+1. 构造 `LoRAConfig{rank, alpha, 0.0f, ParseLoRATargetModules(...)}`。
+2. 调用 `model = GetLoRAModel(model, lora_config)`。
+3. 如果设置 `--lora_load_path`，调用 `LoadLoRAWeights`。
+4. 使用 `GetLoRAParameters(model)` 构建优化器参数列表。
+5. 如果设置 `--lora_save_path`，训练结束后调用 `SaveLoRAWeights`。
 
-### 使用示例
+## 目标模块建议
+
+常用配置：
 
 ```cpp
-#include "infini_train/include/nn/lora/lora_model.h"
+// GPT2 attention QKV + attention output projection.
+config.target_modules = ParseLoRATargetModules("c_attn,attn.c_proj");
 
-using namespace infini_train::nn::lora;
+// GPT2/Llama3 覆盖所有名为 c_proj 的层，包括 attention 和 MLP output。
+config.target_modules = ParseLoRATargetModules("c_attn,c_proj");
 
-int main() {
-    // 1. 创建基础模型
-    auto base_model = std::make_shared<GPT2>(config);
-    base_model->LoadWeights("gpt2_weights.bin");
-
-    // 2. 创建 LoRA 配置
-    LoRAConfig lora_config{8, 16.0f};
-    lora_config.target_modules = ParseLoRATargetModules("c_attn,c_proj");  // 只对 attention 层
-
-    // 3. 创建 LoRA 包装器 (一行代码)
-    auto lora_model = std::make_shared<LoRAModel>(base_model, lora_config);
-
-    // 4. 获取可训练参数用于优化器
-    auto trainable_params = nn::lora::GetLoRAParameters(lora_model);
-    auto optimizer = std::make_shared<Adam>(trainable_params, 1e-5);
-
-    // 5. 打印摘要
-    lora_model->PrintSummary();
-    // 输出:
-    // ========== LoRA Model Summary ==========
-    // Total parameters:     176062464
-    // Trainable parameters: 442368 (0.251256%)
-    // Frozen parameters:    175620096
-    // =========================================
-
-    // 6. 训练循环 (无需修改)
-    for (int step = 0; step < num_steps; ++step) {
-        auto logits = (*lora_model)({x, y})[0];
-        auto loss = (*loss_fn)({logits, y})[0];
-        loss->Backward();
-        optimizer->Step();
-        optimizer->ZeroGrad();
-    }
-
-    // 7. 保存 LoRA 权重
-    lora_model->SaveLoRA("lora_weights.bin");
-
-    return 0;
-}
+// 包含 MLP 层。
+config.target_modules = ParseLoRATargetModules("c_attn,attn.c_proj,c_fc,c_fc2");
 ```
 
-### 工厂函数
+注意 `c_proj` 是宽匹配，`attn.c_proj` 是更精确匹配。若只想命中 attention output
+projection，不要只写 `c_proj`。
 
-对于任意模型类型，可以使用模板工厂函数：
+## 测试
 
-```cpp
-#include "infini_train/include/nn/lora/lora_model.h"
+LoRA 单元测试位于 `tests/lora/test_lora.cc`，覆盖：
 
-auto lora_model = CreateLoRAModel<GPT2, GPT2Config>(
-    model_config,           // GPT2 模型配置
-    lora_config             // LoRA 配置
-);
+- `LoRAConfig::Scaling` 和 target 后缀匹配。
+- `LoRALinear` 注入、forward、merge/unmerge。
+- `GetLoRAParameters`、参数统计、freeze/unfreeze。
+- `LoRAStateDict` 和 `MergeAndUnload`。
+
+构建并运行：
+
+```bash
+cmake -S . -B build -DBUILD_TEST=ON -DUSE_CUDA=ON -DUSE_NCCL=ON
+cmake --build build -j
+ctest --test-dir build -R LoRATest --output-on-failure
 ```
 
-### 两种使用方式的区别
+`scripts/test_config.json` 还包含 `lora` 测试组，覆盖 fp32/bfloat16、LoRA 权重加载，以及 DP、TP、SP、PP 组合。
 
-| 特性 | `GetLoRAModel` | `LoRAModel` 包装器 |
-|------|---------------|-------------------|
-| 返回类型 | `std::shared_ptr<Module>` | `std::shared_ptr<LoRAModel>` |
-| 修改方式 | 原地修改模型 | 创建新包装器 |
-| 自动冻结 | 是 | 是 |
-| 适用场景 | 简单场景，直接修改原模型 | 需要更精细控制 |
+## 常见注意事项
 
-### 推荐场景
-
-- **使用 `GetLoRAModel`**: 想要最小化代码改动，直接在原模型上启用 LoRA
-- **使用 `LoRAModel`**: 需要更灵活的 API（如 `Merge()`/`Unmerge()` 方法），或者需要保留原始模型的引用
-
-## 常见问题
-
-### Q: LoRA 权重文件有多大？
-
-A: 取决于 rank 和目标层数量。以 GPT2-small (12层) 为例：
-- rank=8, attention only: ~1.2 MB
-- rank=16, attention + MLP: ~4.8 MB
-
-### Q: 如何在不同任务间切换 LoRA？
-
-A: 保存和加载不同的 LoRA 权重文件：
-```cpp
-// 任务 A
-LoadLoRAWeights(model, "task_a_lora.bin");
-// 推理...
-
-// 任务 B
-LoadLoRAWeights(model, "task_b_lora.bin");
-// 推理...
-```
-
-### Q: 可以同时使用多个 LoRA 吗？
-
-A: 当前实现不支持多 LoRA 组合。如需此功能，可以：
-1. 合并多个 LoRA 权重后加载
-2. 扩展实现支持 LoRA 堆叠
+- 直接用 `GetLoRAModel` 就好；现在没有单独的 `LoRAModel` 类，也没有 `lora_model.h`。
+- `LoRAConfig` 先默认创建再填字段；如果想一行构造，需要传完整的 4 个参数。
+- 保存和加载传的是具体文件名，比如 `gpt2_lora.bin`，不是目录。
+- LoRA 文件只存 `lora_A` / `lora_B`，不会保存基础模型权重。
+- TP 运行时加载 LoRA 权重，如果文件里是完整 tensor、当前 rank 只需要分片，加载函数会自动按当前 `tp_rank` 切一段。
+- `MergeLoRAWeights` 适合推理前用；如果还要继续训练，先调用 `UnmergeLoRAWeights`。
+- `MergeAndUnload` 会把 LoRA 模块变回普通 Linear，之后模型里就没有 `lora_A` / `lora_B` 了。
+- 现在一次只支持一套 LoRA adapter，不支持多个 adapter 叠加。

--- a/docs/lora_usage_guide.md
+++ b/docs/lora_usage_guide.md
@@ -10,9 +10,9 @@
 
 ```cpp
 #include "infini_train/include/nn/lora/lora_config.h"
-#include "infini_train/include/nn/lora/lora_linear.h"
-#include "infini_train/include/nn/lora/lora_parallel_linear.h"
 #include "infini_train/include/nn/lora/lora_utils.h"
+#include "infini_train/include/optimizer.h"
+#include "infini_train/include/tensor.h"
 ```
 
 ### 最小示例
@@ -30,7 +30,7 @@ model = GetLoRAModel(model, config);
 PrintLoRASummary(model);
 
 auto params = GetLoRAParameters(model);
-auto optimizer = optimizers::Adam::Create(/*learning_rate=*/1e-4)(params);
+auto optimizer = infini_train::optimizers::Adam::Create(/*learning_rate=*/1e-4)(params);
 
 for (int step = 0; step < num_steps; ++step) {
     optimizer->ZeroGrad();
@@ -52,9 +52,10 @@ y = x @ W^T + b + (alpha / rank) * x @ A^T @ B^T
 ```
 
 - `W` 和 `bias` 来自原基础层，注入后默认冻结。
-- `lora_A` 形状为 `[rank, in_features]`，默认 Kaiming uniform 初始化。
-- `lora_B` 形状为 `[out_features, rank]`，零初始化，因此注入初始时不改变基础模型输出。
-- LoRA 参数当前固定创建为 `float32`。
+- 普通 `Linear` 的 `lora_A` / `lora_B` 形状分别为 `[rank, in_features]` / `[out_features, rank]`；
+  TP 下 ColumnParallel 的 B 和 RowParallel 的 A 是 local shard。
+- A 默认 Kaiming uniform 初始化，B 零初始化，因此注入初始时不改变模型输出。
+- LoRA 参数创建为 `float32`，当前 adapter 保存/加载也要求保持 `float32`。
 - `dropout` 字段存在于 `LoRAConfig`，当前未实现。
 
 `GetLoRAModel` 会遍历 `NamedModules()`，按 `target_modules` 匹配模块路径：
@@ -96,6 +97,8 @@ config.alpha = 16.0f;
 config.target_modules = ParseLoRATargetModules("c_attn,attn.c_proj");
 ```
 
+C++ API 要求 `rank > 0`；命令行中的 `--lora_rank=0` 表示不启用 LoRA。
+
 ### 注入与参数管理
 
 ```cpp
@@ -116,7 +119,8 @@ GetBaseParameters(const std::shared_ptr<Module> &model);
 ```
 
 - `GetLoRAModel` = 注入 + 冻结基础参数 + 重新打开 LoRA 参数。
-- `InjectLoRALayers` 只做结构替换，不冻结参数。
+- `InjectLoRALayers` 替换目标层并冻结其基础 weight/bias，但不冻结未命中的模块；`GetLoRAModel` 会进一步
+  冻结所有非 LoRA 参数。
 - 示例训练入口在启用 LoRA 时只把 `GetLoRAParameters(model)` 传给优化器。
 - 对 merged 状态的 LoRA 模块调用 `GetLoRAParameters` 会触发检查；继续训练前先
   `UnmergeLoRAWeights(model)`。
@@ -145,13 +149,18 @@ void LoadLoRAWeights(std::shared_ptr<Module> model,
 - `MergeLoRAWeights` 将 `W += (alpha / rank) * B @ A` 写回基础权重，并冻结 LoRA 参数。
 - `UnmergeLoRAWeights` 撤销一次已合并的 LoRA 增量，并恢复 LoRA 参数可训练。
 - `MergeAndUnload` 会先合并，再把 LoRA 模块替换回普通 `Linear` / TP Linear，并解冻返回模型参数。
-- `SaveLoRAWeights` 只保存名字包含 `lora_A` / `lora_B` 的参数；TP 下会先把分片参数 gather 成
-  full/unsharded tensor，再由主 TP rank 写文件。
-- LoRA 权重文件是二进制文件，包含 magic `"LORA"`、version `1`、tensor 名称、维度和 float 数据。
-- 加载前模型必须已经用相同目标层注入 LoRA；找不到的 LoRA 参数会打印 warning。
+- `LoRAStateDict` 中被 TP 分片的参数仍是当前 rank 的 local shard；直接对 DDP wrapper 调用时，key 带
+  `module.` 前缀。跨 TP 保存请用 `SaveLoRAWeights`。
+- TP 保存要求 `dp=0, pp=0` group 内所有 TP ranks 调用 `SaveLoRAWeights`，只有 `(dp=0, tp=0, pp=0)`
+  写文件。只在 writer rank 调用会卡在 collective；由全局所有 ranks 调用是安全的。
+- `pipeline_parallel > 1` 时不会聚合其他 PP stages，因此当前只支持在 `pipeline_parallel=1` 下保存 adapter。
+- 文件是原生二进制格式：magic `0x4C4F5241`、version `1`、名称、维度和 float32 数据；不包含 LoRA config、
+  基础模型或 dtype 信息。
+- 加载时应使用相同的基础模型、`rank`、`alpha` 和目标层。文件中多出的 key 会 warning，文件缺少的模型
+  参数则保留初始化值。
 - 加载时如果输入 tensor 和当前参数同形状，会直接拷贝；如果当前参数是 TP 分片，会按当前 `tp_rank`
-  切片后再拷贝。`c_attn.lora_B` 会按 packed QKV 的 `[Q | K | V]` 布局特殊处理，加载为本 rank 的
-  `[Qi | Ki | Vi]`，和 attention QKV 权重加载方式保持一致。
+  切片后再拷贝。`CausalSelfAttention` 中由 `LoRAColumnParallelLinear` 实现的 `c_attn.lora_B` 会按
+  packed QKV 的 `[Q | K | V]` 布局特殊处理，加载为本 rank 的 `[Qi | Ki | Vi]`。
 
 ### 统计和解析工具
 
@@ -178,10 +187,16 @@ ParseLoRATargetModules(const std::string &targets);
 如果模型用了 TP，不需要手动创建 `LoRAColumnParallelLinear` 或 `LoRARowParallelLinear`；
 只要正常调用 `GetLoRAModel(model, config)`，注入逻辑会根据基础层类型自动选择对应的 LoRA 实现。
 
-加载 LoRA 权重时，如果文件里保存的是完整 tensor，而当前模型在 TP 下只需要某个 rank 的分片，加载函数会自动按当前
-`tp_rank` 切片；attention 的 `c_attn.lora_B` 会按 Q/K/V 三段分别切片后再拼接。
-保存 LoRA 权重时，文件里的 tensor 默认也是完整 tensor；attention 的 `c_attn.lora_B` 会从各 rank 的
-`[Qi | Ki | Vi]` 还原成 `[Q | K | V]` 后写入。
+在 `pipeline_parallel=1` 时，TP adapter 使用完整 tensor：加载时自动切分，保存时自动 gather；
+`c_attn.lora_B` 还会处理 Q/K/V 顺序。目标 TP size 必须能整除相应维度。
+
+### 并行调用顺序与限制
+
+并行构造顺序应为：device/dtype 转换 -> LoRA 注入 -> adapter 加载 -> PP/DDP。DDP 只为构造时已有的参数注册通信；
+`LoadLoRAWeights` 也不会解包 DDP。`SaveLoRAWeights` 可解包根部 DDP，但不支持完整 PP adapter 导出。
+
+DDP 当前没有构造后的参数 broadcast，因此 fresh LoRA 初始化不保证 DP replicas 一致；在 DDP 前加载同一份完整
+adapter 可以覆盖该初值差异。
 
 ## 命令行示例
 
@@ -238,7 +253,8 @@ Llama3 默认 LoRA target 是 `"c_attn,c_proj,c_fc,c_fc2"`。
   --lora_load_path gpt2_lora.bin
 ```
 
-加载时请保持 `rank` 和 `lora_target_modules` 与保存这份 LoRA 权重时一致。
+加载时请使用相同的基础模型，并保持 `lora_rank`、`lora_alpha` 和 `lora_target_modules` 与保存该 adapter 时一致。
+当前文件格式不保存或校验这些配置元数据。
 
 ### 参数表
 
@@ -248,15 +264,13 @@ Llama3 默认 LoRA target 是 `"c_attn,c_proj,c_fc,c_fc2"`。
 | `--lora_alpha` | `16.0` | LoRA scaling 分子，实际缩放为 `alpha / rank` |
 | `--lora_target_modules` | 模型相关 | 逗号分隔的目标模块后缀 |
 | `--lora_load_path` | `""` | 启动时加载 LoRA 权重文件 |
-| `--lora_save_path` | `""` | 训练结束后保存 LoRA 权重文件 |
+| `--lora_save_path` | `""` | 训练结束后保存 LoRA 权重文件；当前要求 `pipeline_parallel=1` |
 
-示例入口在启用 LoRA 后会：
+示例入口会先注入并按需加载 LoRA，再构造并行 wrapper；优化器只接收 `GetLoRAParameters(model)`，保存时由所有
+ranks 调用 `SaveLoRAWeights`。
 
-1. 构造 `LoRAConfig{rank, alpha, 0.0f, ParseLoRATargetModules(...)}`。
-2. 调用 `model = GetLoRAModel(model, lora_config)`。
-3. 如果设置 `--lora_load_path`，调用 `LoadLoRAWeights`。
-4. 使用 `GetLoRAParameters(model)` 构建优化器参数列表。
-5. 如果设置 `--lora_save_path`，训练结束后调用 `SaveLoRAWeights`。
+`--lora_load_path` 只加载 adapter，`--load` 恢复训练 checkpoint 且执行得更晚，可能覆盖 adapter 或因结构不匹配
+而失败，因此不要同时设置。
 
 ## 目标模块建议
 
@@ -290,20 +304,16 @@ LoRA 单元测试位于 `tests/lora/test_lora.cc`，覆盖：
 ```bash
 cmake -S . -B build -DBUILD_TEST=ON -DUSE_CUDA=ON -DUSE_NCCL=ON
 cmake --build build -j
-ctest --test-dir build -R LoRATest --output-on-failure
+ctest --test-dir build -R 'LoRATest|test_lora_cuda' --output-on-failure
 ```
 
-`scripts/test_config.json` 还包含 `lora` 测试组，覆盖 fp32/bfloat16、LoRA 权重加载，以及 DP、TP、SP、PP 组合。
+`scripts/test_config.json` 的 `lora` 组还覆盖 fp32/bfloat16、权重加载及 DP/TP/SP/PP 训练；PP 用例不覆盖 adapter 保存。
 
 ## 常见注意事项
 
 - 直接用 `GetLoRAModel` 就好；现在没有单独的 `LoRAModel` 类，也没有 `lora_model.h`。
 - `LoRAConfig` 先默认创建再填字段；如果想一行构造，需要传完整的 4 个参数。
-- 保存和加载传的是具体文件名，比如 `gpt2_lora.bin`，不是目录。
-- LoRA 文件只存 `lora_A` / `lora_B`，不会保存基础模型权重；TP 下文件里保存的是可移植的完整 tensor，
-  不是某个 rank 的 local shard。
-- TP 运行时加载 LoRA 权重，如果文件里是完整 tensor、当前 rank 只需要分片，加载函数会自动按当前 `tp_rank`
-  切片；`c_attn.lora_B` 会按 Q/K/V 三段分别切片后再拼接。
+- 保存和加载传的是具体文件名，比如 `gpt2_lora.bin`，不是目录；保存函数不会自动创建父目录。
 - `MergeLoRAWeights` 适合推理前用；如果还要继续训练，先调用 `UnmergeLoRAWeights`。
 - `MergeAndUnload` 会把 LoRA 模块变回普通 Linear，之后模型里就没有 `lora_A` / `lora_B` 了。
 - 现在一次只支持一套 LoRA adapter，不支持多个 adapter 叠加。

--- a/infini_train/include/nn/lora/lora_utils.h
+++ b/infini_train/include/nn/lora/lora_utils.h
@@ -18,6 +18,18 @@ class Module;
 
 namespace infini_train::nn::lora {
 
+namespace detail {
+
+// Internal helper for packed QKV tensors stored as [Q | K | V] along dim 0.
+std::shared_ptr<Tensor> SlicePackedQKVRowsForTensorParallel(const std::shared_ptr<Tensor> &full_tensor, int64_t q_rows,
+                                                            int tp_rank, int tp_size);
+
+// Internal helper for TP-gathered packed QKV shards stored rank-major as [Q_i | K_i | V_i].
+std::shared_ptr<Tensor> RestorePackedQKVRowsFromTensorParallel(const std::shared_ptr<Tensor> &gathered_tensor,
+                                                               int64_t q_rows, int tp_size);
+
+} // namespace detail
+
 /**
  * Apply LoRA to a model (PEFT-style injection).
  *
@@ -88,23 +100,29 @@ void UnmergeLoRAWeights(std::shared_ptr<Module> model);
 std::shared_ptr<Module> MergeAndUnload(std::shared_ptr<Module> model);
 
 /**
- * Return a state dict containing only LoRA parameters.
+ * Return a state dict containing only LoRA parameters from the current model.
+ *
+ * Under TP this returns the current rank's local shards for sharded LoRA tensors.
+ * Use SaveLoRAWeights() for a portable adapter file with full/unsharded tensors.
  */
 std::unordered_map<std::string, std::shared_ptr<Tensor>> LoRAStateDict(const std::shared_ptr<Module> &model);
 
 /**
- * Load LoRA parameters from a state dict.
+ * Load LoRA parameters from a state dict. Full tensors are sliced for TP-local
+ * parameters when the current model stores shards.
  */
 void LoadLoRAStateDict(std::shared_ptr<Module> model,
                        const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict);
 
 /**
- * Save only LoRA parameters to file.
+ * Save only LoRA parameters to file. TP-sharded LoRA tensors are exported as
+ * full/unsharded tensors so the file can be loaded with a different TP rank.
  */
 void SaveLoRAWeights(const std::shared_ptr<Module> &model, const std::string &filepath);
 
 /**
- * Load LoRA parameters from file.
+ * Load LoRA parameters from file. Packed QKV LoRA-B tensors are split as
+ * [Qi | Ki | Vi] for the current TP rank.
  */
 void LoadLoRAWeights(std::shared_ptr<Module> model, const std::string &filepath);
 

--- a/infini_train/include/nn/parallel/ddp/distributed_data_parallel.h
+++ b/infini_train/include/nn/parallel/ddp/distributed_data_parallel.h
@@ -17,12 +17,19 @@ class Rank;
 
 namespace infini_train::nn::parallel {
 
+namespace {
+constexpr char kModuleName[] = "module";
+
+} // namespace
+
 class DistributedDataParallel : public nn::Module {
 public:
     DistributedDataParallel(std::shared_ptr<nn::Module> module, const Rank &rank,
                             DistributedDataParallelConfig ddp_config);
 
     std::vector<std::shared_ptr<Tensor>> Forward(const std::vector<std::shared_ptr<Tensor>> &input_tensors) override;
+
+    std::shared_ptr<nn::Module> module() const;
 
     DistributedDataParallelConfig ddp_config() const { return ddp_config_; }
 

--- a/infini_train/include/nn/parallel/process_group.h
+++ b/infini_train/include/nn/parallel/process_group.h
@@ -52,6 +52,15 @@ public:
                                                 function::ReduceOpType reduce_op = function::ReduceOpType::kSum,
                                                 bool async_op = false) const;
 
+    // root_rank_in_group is ProcessGroup-local rank. Broadcast updates tensors in place.
+    virtual std::shared_ptr<Work> Broadcast(const std::vector<std::shared_ptr<Tensor>> &tensors, int root_rank_in_group,
+                                            bool async_op = false) const;
+
+    // Root provides rank-major input_tensors: rank * output_tensors.size() + tensor_index.
+    virtual std::shared_ptr<Work> Scatter(const std::vector<std::shared_ptr<Tensor>> &output_tensors,
+                                          const std::vector<std::shared_ptr<Tensor>> &input_tensors,
+                                          int root_rank_in_group, bool async_op = false) const;
+
     virtual std::shared_ptr<Work> Send(std::vector<std::shared_ptr<Tensor>> tensors, int dest_rank,
                                        bool async_op = false) const;
 
@@ -60,13 +69,13 @@ public:
 
     // Legacy communication APIs (Single-stream)
     virtual std::vector<std::shared_ptr<Tensor>>
-    BroadCast(const std::vector<std::shared_ptr<Tensor>> &input_tensors) const;
+    BroadCast_(const std::vector<std::shared_ptr<Tensor>> &input_tensors) const;
 
     virtual std::vector<std::shared_ptr<Tensor>>
     ReduceAddCoalesced(const std::vector<std::vector<std::shared_ptr<Tensor>>> &grads, Device destination) const;
 
-    virtual std::vector<std::shared_ptr<Tensor>> Scatter(const std::shared_ptr<Tensor> &tensor,
-                                                         std::vector<Device> devices, int64_t dim) const;
+    virtual std::vector<std::shared_ptr<Tensor>> Scatter_(const std::shared_ptr<Tensor> &tensor,
+                                                          std::vector<Device> devices, int64_t dim) const;
 
     virtual std::shared_ptr<Tensor> Gather(const std::vector<std::shared_ptr<Tensor>> &tensors, Device destination,
                                            int64_t dim) const;

--- a/infini_train/include/nn/parallel/process_group.h
+++ b/infini_train/include/nn/parallel/process_group.h
@@ -68,6 +68,8 @@ public:
                                        bool async_op = false) const;
 
     // Legacy communication APIs (Single-stream)
+    // FIXME(dcj): BroadCast_ and Scatter_ are temporarily retained with trailing underscores for existing DP callers.
+    // Replace direct DP usage with a higher-level communication abstraction.
     virtual std::vector<std::shared_ptr<Tensor>>
     BroadCast_(const std::vector<std::shared_ptr<Tensor>> &input_tensors) const;
 

--- a/infini_train/include/nn/parallel/utils.h
+++ b/infini_train/include/nn/parallel/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -22,6 +23,8 @@ std::vector<int> GetTensorParallelGroupRanks(int global_rank);
 std::vector<int> GetPipelineParallelGroupRanks(int global_rank);
 
 // TP/SP Communication Helper Functions
+std::shared_ptr<Tensor> GatherTensorParallelShard(const std::shared_ptr<Tensor> &tensor, int64_t dim);
+
 std::vector<std::shared_ptr<Tensor>> GatherFromTPRegionFunc(const std::shared_ptr<Tensor> &input);
 std::vector<std::shared_ptr<Tensor>> ReduceScatterToSPRegionFunc(const std::shared_ptr<Tensor> &input);
 std::vector<std::shared_ptr<Tensor>> GatherFromSPRegionFunc(const std::shared_ptr<Tensor> &input);

--- a/infini_train/src/autograd/comm.cc
+++ b/infini_train/src/autograd/comm.cc
@@ -18,7 +18,7 @@ Scatter::Scatter(const std::vector<Device> &target_gpus, int64_t dim,
 std::vector<std::shared_ptr<Tensor>> Scatter::Forward(const std::vector<std::shared_ptr<Tensor>> &input_tensors) {
     const auto &input = input_tensors[0];
     std::vector<std::shared_ptr<Tensor>> output_tensors;
-    output_tensors = pg_->Scatter(input, target_gpus_, dim_);
+    output_tensors = pg_->Scatter_(input, target_gpus_, dim_);
     return output_tensors;
 }
 
@@ -82,7 +82,7 @@ std::vector<std::shared_ptr<Tensor>> Broadcast::Forward(const std::vector<std::s
     }
 
     // TODO(dcj): mark non differentiable
-    return pg_->BroadCast(input_tensors);
+    return pg_->BroadCast_(input_tensors);
 }
 
 void Broadcast::SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_tensors,

--- a/infini_train/src/nn/lora/lora_parallel_linear.cc
+++ b/infini_train/src/nn/lora/lora_parallel_linear.cc
@@ -11,6 +11,7 @@
 #include "infini_train/include/nn/init.h"
 #include "infini_train/include/nn/modules/linear.h"
 #include "infini_train/include/nn/parallel/global.h"
+#include "infini_train/include/nn/parallel/process_group.h"
 #include "infini_train/include/nn/parallel/tensor_parallel.h"
 #include "infini_train/include/nn/parallel/utils.h"
 #include "infini_train/include/tensor.h"
@@ -89,22 +90,38 @@ LoRAColumnParallelLinear::LoRAColumnParallelLinear(std::shared_ptr<parallel::Col
 }
 
 void LoRAColumnParallelLinear::InitLoRAWeights() {
-    // LoRA weights stored directly in parameters_
-    // Following PEFT pattern conceptually:
-    // lora_A: [rank, in_features] - replicated
+    // lora_A: [rank, in_features] - replicated across TP ranks
     // lora_B: [out_features_per_partition, rank] - sharded like base weight
-
-    // lora_A: [rank, in_features]
     parameters_[kParamLoraAName]
         = std::make_shared<Tensor>(std::vector<int64_t>{config_.rank, in_features_}, DataType::kFLOAT32, device_)
               ->RequiresGrad();
-    if (config_.use_kaiming_a) {
-        init::KaimingUniform(parameters_[kParamLoraAName], config_.kaiming_a_param);
+
+    if (parallel::global::GetTensorParallelSize() > 1) {
+        const auto global_rank = device_.Rank().GlobalRank();
+        auto *tp_group = parallel::ProcessGroupFactory::Instance(device_.type())
+                             ->Get(parallel::GetTensorParallelProcessGroupName(global_rank));
+        const int tp_rank = tp_group->GetGroupRank(global_rank);
+
+        // Only TP rank 0 generates random values; others zero-init.
+        // AllReduce(sum) then broadcasts rank-0's values to all TP ranks.
+        if (tp_rank == 0) {
+            if (config_.use_kaiming_a) {
+                init::KaimingUniform(parameters_[kParamLoraAName], config_.kaiming_a_param);
+            } else {
+                init::Normal(parameters_[kParamLoraAName], 0.0f, 0.02f);
+            }
+        } else {
+            init::Zeros(parameters_[kParamLoraAName]);
+        }
+        tp_group->AllReduce(parameters_[kParamLoraAName]);
     } else {
-        init::Normal(parameters_[kParamLoraAName], 0.0f, 0.02f);
+        if (config_.use_kaiming_a) {
+            init::KaimingUniform(parameters_[kParamLoraAName], config_.kaiming_a_param);
+        } else {
+            init::Normal(parameters_[kParamLoraAName], 0.0f, 0.02f);
+        }
     }
 
-    // lora_B: [out_per_partition, rank] - sharded like base weight
     parameters_[kParamLoraBName]
         = std::make_shared<Tensor>(std::vector<int64_t>{out_features_per_partition_, config_.rank}, DataType::kFLOAT32,
                                    device_)

--- a/infini_train/src/nn/lora/lora_parallel_linear.cc
+++ b/infini_train/src/nn/lora/lora_parallel_linear.cc
@@ -102,18 +102,14 @@ void LoRAColumnParallelLinear::InitLoRAWeights() {
                              ->Get(parallel::GetTensorParallelProcessGroupName(global_rank));
         const int tp_rank = tp_group->GetGroupRank(global_rank);
 
-        // Only TP rank 0 generates random values; others zero-init.
-        // AllReduce(sum) then broadcasts rank-0's values to all TP ranks.
         if (tp_rank == 0) {
             if (config_.use_kaiming_a) {
                 init::KaimingUniform(parameters_[kParamLoraAName], config_.kaiming_a_param);
             } else {
                 init::Normal(parameters_[kParamLoraAName], 0.0f, 0.02f);
             }
-        } else {
-            init::Zeros(parameters_[kParamLoraAName]);
         }
-        tp_group->AllReduce(parameters_[kParamLoraAName]);
+        tp_group->Broadcast({parameters_[kParamLoraAName]}, 0);
     } else {
         if (config_.use_kaiming_a) {
             init::KaimingUniform(parameters_[kParamLoraAName], config_.kaiming_a_param);
@@ -307,10 +303,30 @@ void LoRARowParallelLinear::InitLoRAWeights() {
         = std::make_shared<Tensor>(std::vector<int64_t>{config_.rank, in_features_per_partition_}, DataType::kFLOAT32,
                                    device_)
               ->RequiresGrad();
-    if (config_.use_kaiming_a) {
-        init::KaimingUniform(parameters_[kParamLoraAName], config_.kaiming_a_param);
+    if (parallel::global::GetTensorParallelSize() > 1) {
+        const auto global_rank = device_.Rank().GlobalRank();
+        auto *tp_group = parallel::ProcessGroupFactory::Instance(device_.type())
+                             ->Get(parallel::GetTensorParallelProcessGroupName(global_rank));
+        const int tp_rank = tp_group->GetGroupRank(global_rank);
+
+        std::vector<std::shared_ptr<Tensor>> scatter_inputs;
+        if (tp_rank == 0) {
+            auto full_lora_A = std::make_shared<Tensor>(std::vector<int64_t>{config_.rank, in_features_},
+                                                        DataType::kFLOAT32, device_);
+            if (config_.use_kaiming_a) {
+                init::KaimingUniform(full_lora_A, config_.kaiming_a_param);
+            } else {
+                init::Normal(full_lora_A, 0.0f, 0.02f);
+            }
+            scatter_inputs = full_lora_A->Split(in_features_per_partition_, 1);
+        }
+        tp_group->Scatter({parameters_[kParamLoraAName]}, scatter_inputs, 0);
     } else {
-        init::Normal(parameters_[kParamLoraAName], 0.0f, 0.02f);
+        if (config_.use_kaiming_a) {
+            init::KaimingUniform(parameters_[kParamLoraAName], config_.kaiming_a_param);
+        } else {
+            init::Normal(parameters_[kParamLoraAName], 0.0f, 0.02f);
+        }
     }
 
     // lora_B: [out_features, rank]

--- a/infini_train/src/nn/lora/lora_parallel_linear.cc
+++ b/infini_train/src/nn/lora/lora_parallel_linear.cc
@@ -126,39 +126,35 @@ LoRAColumnParallelLinear::Forward(const std::vector<std::shared_ptr<Tensor>> &in
         << "Forward() on merged LoRA with requires_grad=true. Call UnmergeWeights() before training.";
 
     if (!merged_) {
-        // 1. Compute base output via parent class
-        auto base_result = ColumnParallelLinear::Forward(input_tensors);
-        auto base_output = base_result[0];
-
-        // 2. Compute LoRA output using the SAME input that base module uses
-        // Match base input path exactly: use direct input if input_is_parallel_ or sequence_parallel_,
-        // otherwise copy to TP region
-        auto lora_input = (input_is_parallel_ || sequence_parallel_)
-                            ? input_tensors[0]
-                            : parallel::CopyToTPRegionFunc(input_tensors[0])[0];
+        // Inline base + LoRA matmuls, add locally, then single collective op.
+        // This avoids 2 separate AllGather ops which cause floating-point divergence.
+        auto input = (input_is_parallel_ || sequence_parallel_) ? input_tensors[0]
+                                                                : parallel::CopyToTPRegionFunc(input_tensors[0])[0];
         if (sequence_parallel_) {
-            // Base uses GatherFromSPRegionFunc to gather sequence dimension
-            lora_input = parallel::GatherFromSPRegionFunc(lora_input)[0];
+            input = parallel::GatherFromSPRegionFunc(input)[0];
         }
 
-        // Compute LoRA: lora_A: [rank, in_features], lora_B: [out_per_partition, rank]
-        auto lora_proj = std::make_shared<autograd::Linear>()->Apply({lora_input, parameters_[kParamLoraAName]})[0];
+        // Base matmul (bias folded in when applicable, matching ColumnParallelLinear::Forward)
+        auto base_shard = std::make_shared<autograd::Linear>()->Apply(
+            (bias_ && !skip_bias_add_)
+                ? std::vector<std::shared_ptr<Tensor>>{input, parameters_.at(kParamWeightName),
+                                                       parameters_[kParamBiasName]}
+                : std::vector<std::shared_ptr<Tensor>>{input, parameters_.at(kParamWeightName)})[0];
+
+        // LoRA matmul (local)
+        // Wrap replicated lora_A through CopyToTPRegion so its gradient gets AllReduced in backward
+        auto lora_A = parallel::CopyToTPRegionFunc(parameters_[kParamLoraAName])[0];
+        auto lora_proj = std::make_shared<autograd::Linear>()->Apply({input, lora_A})[0];
         auto lora_output = std::make_shared<autograd::Linear>()->Apply({lora_proj, parameters_[kParamLoraBName]})[0];
 
-        // Match base output layout (gather if base gathers)
-        if (gather_output_) {
-            lora_output = parallel::GatherFromTPRegionFunc(lora_output)[0];
-        }
+        // Local add before collective
+        auto combined = base_shard->Add(lora_output->Mul(config_.Scaling()));
 
-        auto scaled_lora = lora_output->Mul(config_.Scaling());
+        // Single collective op
+        auto output = gather_output_ ? parallel::GatherFromTPRegionFunc(combined)[0] : combined;
 
-        // 3. Add LoRA contribution to base output
-        // Both should now have the same sequence dimension
-        auto output = base_output->Add(scaled_lora);
-
-        // Return in same format as base module
         return skip_bias_add_
-                 ? std::vector<std::shared_ptr<Tensor>>{output, bias_ ? parameters_[kParamBiasName] : nullptr}
+                 ? std::vector<std::shared_ptr<Tensor>>{output, bias_ ? parameters_.at(kParamBiasName) : nullptr}
                  : std::vector<std::shared_ptr<Tensor>>{output};
     }
 
@@ -321,42 +317,32 @@ LoRARowParallelLinear::Forward(const std::vector<std::shared_ptr<Tensor>> &input
         << "Forward() on merged LoRA with requires_grad=true. Call UnmergeWeights() before training.";
 
     if (!merged_) {
-        // Get effective input - match what base module uses
-        auto effective_input = input_tensors[0];
-        const int64_t in_dim = effective_input->Dims().back();
+        // Inline base + LoRA matmuls, add locally, then single collective op.
+        // This avoids 2 separate AllReduce ops which cause floating-point divergence.
+        auto input = input_is_parallel_ ? input_tensors[0] : parallel::ScatterToTPRegionFunc(input_tensors[0])[0];
 
-        if (!input_is_parallel_) {
-            // base would scatter; lora must match
-            effective_input = parallel::ScatterToTPRegionFunc(effective_input)[0];
-            CHECK_EQ(effective_input->Dims().back(), in_features_per_partition_);
-        } else {
-            // input_is_parallel_=true means caller promised shard input
-            CHECK_EQ(in_dim, in_features_per_partition_)
-                << "RowParallel expects sharded input when input_is_parallel_=true. "
-                << "Got full in_dim=" << in_dim << " (likely upstream gathered TP output).";
+        // Base matmul (no bias — RowParallel adds bias AFTER collective)
+        auto base_shard = std::make_shared<autograd::Linear>()->Apply({input, parameters_.at(kParamWeightName)})[0];
+
+        // LoRA matmul (local)
+        // Wrap replicated lora_B through CopyToTPRegion so its gradient gets AllReduced in backward
+        auto lora_proj = std::make_shared<autograd::Linear>()->Apply({input, parameters_[kParamLoraAName]})[0];
+        auto lora_B = parallel::CopyToTPRegionFunc(parameters_[kParamLoraBName])[0];
+        auto lora_output = std::make_shared<autograd::Linear>()->Apply({lora_proj, lora_B})[0];
+
+        // Local add before collective
+        auto combined = base_shard->Add(lora_output->Mul(config_.Scaling()));
+
+        // Single collective op
+        auto output = reduce_output_ ? (sequence_parallel_ ? parallel::ReduceScatterToSPRegionFunc(combined)[0]
+                                                           : parallel::ReduceFromTPRegionFunc(combined)[0])
+                                     : combined;
+
+        // Bias after collective (matching RowParallelLinear::Forward)
+        if (bias_ && !skip_bias_add_) {
+            output = output->Add(parameters_[kParamBiasName]);
         }
 
-        // 1) base output - use effective_input
-        auto base_result = RowParallelLinear::Forward({effective_input});
-        auto base_output = base_result[0];
-
-        // 2) lora branch uses the SAME effective_input
-        auto lora_proj
-            = std::make_shared<autograd::Linear>()->Apply({effective_input, parameters_[kParamLoraAName]})[0];
-        auto lora_output = std::make_shared<autograd::Linear>()->Apply({lora_proj, parameters_[kParamLoraBName]})[0];
-
-        // 3) apply same reduction as base
-        auto lora_out = lora_output;
-        if (reduce_output_) {
-            lora_out = sequence_parallel_ ? parallel::ReduceScatterToSPRegionFunc(lora_out)[0]
-                                          : parallel::ReduceFromTPRegionFunc(lora_out)[0];
-        }
-
-        auto scaled_lora = lora_out->Mul(config_.Scaling());
-        CHECK_EQ(base_output->NumElements(), scaled_lora->NumElements());
-        auto output = base_output->Add(scaled_lora);
-
-        // Return in same format as base module
         return skip_bias_add_
                  ? std::vector<std::shared_ptr<Tensor>>{output, bias_ ? parameters_[kParamBiasName] : nullptr}
                  : std::vector<std::shared_ptr<Tensor>>{output};

--- a/infini_train/src/nn/lora/lora_parallel_linear.cc
+++ b/infini_train/src/nn/lora/lora_parallel_linear.cc
@@ -102,6 +102,10 @@ void LoRAColumnParallelLinear::InitLoRAWeights() {
                              ->Get(parallel::GetTensorParallelProcessGroupName(global_rank));
         const int tp_rank = tp_group->GetGroupRank(global_rank);
 
+        // FIXME: Each TP group's root initializes independently, so corresponding DP replicas are not guaranteed to
+        // start with identical parameters. They may currently match only because every rank uses the same default RNG
+        // seed. DDP should perform a generic parameter broadcast after model construction and before the first forward,
+        // rather than adding a LoRA-specific DP broadcast here.
         if (tp_rank == 0) {
             if (config_.use_kaiming_a) {
                 init::KaimingUniform(parameters_[kParamLoraAName], config_.kaiming_a_param);

--- a/infini_train/src/nn/lora/lora_utils.cc
+++ b/infini_train/src/nn/lora/lora_utils.cc
@@ -15,6 +15,7 @@
 #include "infini_train/include/nn/lora/lora_parallel_linear.h"
 #include "infini_train/include/nn/modules/linear.h"
 #include "infini_train/include/nn/modules/module.h"
+#include "infini_train/include/nn/parallel/global.h"
 #include "infini_train/include/nn/parallel/tensor_parallel.h"
 #include "infini_train/include/tensor.h"
 
@@ -392,10 +393,30 @@ void LoadLoRAWeights(std::shared_ptr<Module> model, const std::string &filepath)
         auto cpu_tensor = std::make_shared<Tensor>(dims, DataType::kFLOAT32, Device(Device::DeviceType::kCPU, 0));
         file.read(reinterpret_cast<char *>(cpu_tensor->DataPtr()), num_elements * sizeof(float));
 
-        // Load into model
+        // Load into model, slicing sharded tensors by tp_rank if shapes differ
         auto it = model_state_dict.find(name);
         if (it != model_state_dict.end()) {
-            it->second->CopyFrom(cpu_tensor);
+            auto &dst = it->second;
+            const auto &dst_dims = dst->Dims();
+            if (dst_dims == dims) {
+                dst->CopyFrom(cpu_tensor);
+            } else {
+                // Determine which dim is sharded: find first dim where sizes differ
+                int shard_dim = -1;
+                for (int d = 0; d < static_cast<int>(dims.size()); ++d) {
+                    if (d < static_cast<int>(dst_dims.size()) && dst_dims[d] != dims[d]) {
+                        shard_dim = d;
+                        break;
+                    }
+                }
+                CHECK(shard_dim >= 0) << "LoadLoRAWeights: shape mismatch for " << name
+                                      << " but no differing dim found";
+                int tp_size = parallel::global::GetTensorParallelSize();
+                int64_t shard_size = dims[shard_dim] / tp_size;
+                int64_t start = parallel::tp_rank * shard_size;
+                auto sliced = cpu_tensor->Slice(shard_dim, start, start + shard_size);
+                dst->CopyFrom(sliced);
+            }
         } else {
             LOG(WARNING) << "LoRA parameter not found in model: " << name;
         }

--- a/infini_train/src/nn/lora/lora_utils.cc
+++ b/infini_train/src/nn/lora/lora_utils.cc
@@ -18,6 +18,7 @@
 #include "infini_train/include/nn/modules/linear.h"
 #include "infini_train/include/nn/modules/module.h"
 #include "infini_train/include/nn/modules/transformer/causal_self_attention.h"
+#include "infini_train/include/nn/parallel/ddp/distributed_data_parallel.h"
 #include "infini_train/include/nn/parallel/global.h"
 #include "infini_train/include/nn/parallel/process_group.h"
 #include "infini_train/include/nn/parallel/tensor_parallel.h"
@@ -42,6 +43,34 @@ enum class LoRATensorSharding {
 
 bool EndsWith(const std::string &value, const std::string &suffix) {
     return value.size() >= suffix.size() && value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+std::string ConsumeDDPModulePrefixIfPresent(const std::string &name) {
+    const auto module_name_len = std::char_traits<char>::length(parallel::kModuleName);
+    if (name.size() > module_name_len && name.compare(0, module_name_len, parallel::kModuleName) == 0
+        && name[module_name_len] == '.') {
+        return name.substr(module_name_len + 1);
+    }
+    return name;
+}
+
+std::string ResolveLoRAStateDictKey(const std::string &name,
+                                    const std::unordered_map<std::string, std::shared_ptr<Tensor>> &model_state_dict) {
+    if (model_state_dict.find(name) != model_state_dict.end()) {
+        return name;
+    }
+
+    const auto unwrapped_name = ConsumeDDPModulePrefixIfPresent(name);
+    if (unwrapped_name != name && model_state_dict.find(unwrapped_name) != model_state_dict.end()) {
+        return unwrapped_name;
+    }
+
+    return name;
+}
+
+std::shared_ptr<Module> UnwrapDistributedDataParallel(const std::shared_ptr<Module> &model) {
+    auto ddp_model = std::dynamic_pointer_cast<parallel::DistributedDataParallel>(model);
+    return ddp_model ? ddp_model->module() : model;
 }
 
 std::string LoraANameForLoraB(const std::string &name) {
@@ -608,13 +637,17 @@ void LoadLoRAStateDict(std::shared_ptr<Module> model,
     auto model_state_dict = model->StateDict();
     auto shardings = BuildLoRATensorShardings(model);
 
-    for (auto &[name, param] : state_dict) { LoadLoRATensorIntoModel(name, param, model_state_dict, shardings); }
+    for (auto &[name, param] : state_dict) {
+        const auto resolved_name = ResolveLoRAStateDictKey(name, model_state_dict);
+        LoadLoRATensorIntoModel(resolved_name, param, model_state_dict, shardings);
+    }
 }
 
 void SaveLoRAWeights(const std::shared_ptr<Module> &model, const std::string &filepath) {
-    auto lora_state_dict = LoRAStateDict(model);
+    auto adapter_model = UnwrapDistributedDataParallel(model);
+    auto lora_state_dict = LoRAStateDict(adapter_model);
     auto sorted_names = SortedLoRAStateDictNames(lora_state_dict);
-    auto shardings = BuildLoRATensorShardings(model);
+    auto shardings = BuildLoRATensorShardings(adapter_model);
 
     // TP ranks in the primary DP/PP group must all run the gather loop below.
     // Only TP rank 0 writes the file after receiving full tensors.
@@ -727,7 +760,8 @@ void LoadLoRAWeights(std::shared_ptr<Module> model, const std::string &filepath)
         auto cpu_tensor = std::make_shared<Tensor>(dims, DataType::kFLOAT32, Device(Device::DeviceType::kCPU, 0));
         file.read(reinterpret_cast<char *>(cpu_tensor->DataPtr()), num_elements * sizeof(float));
 
-        LoadLoRATensorIntoModel(name, cpu_tensor, model_state_dict, shardings);
+        const auto resolved_name = ResolveLoRAStateDictKey(name, model_state_dict);
+        LoadLoRATensorIntoModel(resolved_name, cpu_tensor, model_state_dict, shardings);
     }
 
     file.close();

--- a/infini_train/src/nn/lora/lora_utils.cc
+++ b/infini_train/src/nn/lora/lora_utils.cc
@@ -1,5 +1,6 @@
 #include "infini_train/include/nn/lora/lora_utils.h"
 
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -11,15 +12,321 @@
 #include "glog/logging.h"
 
 #include "infini_train/include/device.h"
+#include "infini_train/include/nn/functional.h"
 #include "infini_train/include/nn/lora/lora_linear.h"
 #include "infini_train/include/nn/lora/lora_parallel_linear.h"
 #include "infini_train/include/nn/modules/linear.h"
 #include "infini_train/include/nn/modules/module.h"
+#include "infini_train/include/nn/modules/transformer/causal_self_attention.h"
 #include "infini_train/include/nn/parallel/global.h"
+#include "infini_train/include/nn/parallel/process_group.h"
 #include "infini_train/include/nn/parallel/tensor_parallel.h"
+#include "infini_train/include/nn/parallel/utils.h"
 #include "infini_train/include/tensor.h"
 
 namespace infini_train::nn::lora {
+
+namespace {
+
+enum class LoRATensorSharding {
+    // The tensor is identical on every TP rank, so save/load can copy it as-is.
+    kReplicated,
+    // LoRA-B for a ColumnParallelLinear: local shape is [out/tp, rank].
+    kColumnParallelDim0,
+    // Attention QKV LoRA-B: dim0-sharded like ColumnParallel, but each local
+    // shard is packed as [Qi | Ki | Vi] instead of a simple contiguous slice.
+    kPackedQKVColumnParallelDim0,
+    // LoRA-A for a RowParallelLinear: local shape is [rank, in/tp].
+    kRowParallelDim1,
+};
+
+bool EndsWith(const std::string &value, const std::string &suffix) {
+    return value.size() >= suffix.size() && value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+std::string LoraANameForLoraB(const std::string &name) {
+    const std::string lora_b = LoRAColumnParallelLinear::kParamLoraBName;
+    CHECK(EndsWith(name, lora_b)) << "Expected LoRA B parameter name, got " << name;
+    return name.substr(0, name.size() - lora_b.size()) + LoRAColumnParallelLinear::kParamLoraAName;
+}
+
+std::string QualifiedParamName(const std::string &module_name, const std::string &param_name) {
+    return module_name.empty() ? param_name : module_name + "." + param_name;
+}
+
+std::vector<std::string>
+SortedLoRAStateDictNames(const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict) {
+    std::vector<std::string> names;
+    names.reserve(state_dict.size());
+    for (const auto &[name, _] : state_dict) { names.push_back(name); }
+    std::sort(names.begin(), names.end());
+    return names;
+}
+
+std::unordered_map<std::string, LoRATensorSharding> BuildLoRATensorShardings(const std::shared_ptr<Module> &model) {
+    std::unordered_map<std::string, LoRATensorSharding> shardings;
+
+    // Sharding metadata is keyed by the same qualified parameter names used by
+    // LoRAStateDict(), so save can decide whether a local tensor must be gathered.
+    auto named_modules = model->NamedModules(/*memory=*/nullptr, /*prefix=*/"", /*remove_duplicate=*/false);
+    for (const auto &[module_name, module] : named_modules) {
+        if (dynamic_cast<LoRAColumnParallelLinear *>(module.get())) {
+            shardings[QualifiedParamName(module_name, LoRAColumnParallelLinear::kParamLoraAName)]
+                = LoRATensorSharding::kReplicated;
+            shardings[QualifiedParamName(module_name, LoRAColumnParallelLinear::kParamLoraBName)]
+                = LoRATensorSharding::kColumnParallelDim0;
+        } else if (dynamic_cast<LoRARowParallelLinear *>(module.get())) {
+            shardings[QualifiedParamName(module_name, LoRARowParallelLinear::kParamLoraAName)]
+                = LoRATensorSharding::kRowParallelDim1;
+            shardings[QualifiedParamName(module_name, LoRARowParallelLinear::kParamLoraBName)]
+                = LoRATensorSharding::kReplicated;
+        } else if (dynamic_cast<LoRALinear *>(module.get())) {
+            shardings[QualifiedParamName(module_name, LoRALinear::kParamLoraAName)] = LoRATensorSharding::kReplicated;
+            shardings[QualifiedParamName(module_name, LoRALinear::kParamLoraBName)] = LoRATensorSharding::kReplicated;
+        }
+    }
+
+    // Packed QKV is a property of the attention module topology, not the
+    // parameter name. Mark the LoRA-B of the attention QKV projection explicitly.
+    for (const auto &[module_name, module] : named_modules) {
+        if (!dynamic_cast<CausalSelfAttention *>(module.get())) {
+            continue;
+        }
+
+        auto qkv_projection = module->mutable_module(CausalSelfAttention::kCAttnLayerName);
+        if (!dynamic_cast<LoRAColumnParallelLinear *>(qkv_projection.get())) {
+            continue;
+        }
+
+        const auto qkv_module_name = QualifiedParamName(module_name, CausalSelfAttention::kCAttnLayerName);
+        shardings[QualifiedParamName(qkv_module_name, LoRAColumnParallelLinear::kParamLoraBName)]
+            = LoRATensorSharding::kPackedQKVColumnParallelDim0;
+    }
+
+    return shardings;
+}
+
+LoRATensorSharding GetLoRATensorSharding(const std::unordered_map<std::string, LoRATensorSharding> &shardings,
+                                         const std::string &name) {
+    auto it = shardings.find(name);
+    return it == shardings.end() ? LoRATensorSharding::kReplicated : it->second;
+}
+
+std::shared_ptr<Tensor> GatherTensorParallelShard(const std::shared_ptr<Tensor> &tensor, int64_t dim) {
+    const int tp_size = parallel::global::GetTensorParallelSize();
+    CHECK_GT(tp_size, 0);
+    if (tp_size == 1) {
+        return tensor;
+    }
+
+    if (dim < 0) {
+        dim += static_cast<int64_t>(tensor->Dims().size());
+    }
+    CHECK_GE(dim, 0);
+    CHECK_LT(dim, static_cast<int64_t>(tensor->Dims().size()));
+
+    auto device = tensor->GetDevice();
+    auto *tp_group = parallel::ProcessGroupFactory::Instance(device.type())
+                         ->Get(parallel::GetTensorParallelProcessGroupName(device.Rank().GlobalRank()));
+
+    std::vector<int64_t> gathered_dims = tensor->Dims();
+    gathered_dims[0] *= tp_size;
+    auto gathered = std::make_shared<Tensor>(gathered_dims, tensor->Dtype(), device);
+    tp_group->AllGather(gathered, tensor, false);
+
+    if (dim == 0) {
+        return gathered;
+    }
+
+    // AllGather stacks shards along dim 0. For tensors sharded on another dim,
+    // split rank-major rows back into per-rank tensors and concatenate on dim.
+    auto rank_major_shards = gathered->Split(tensor->Dims()[0], 0);
+    return nn::function::Concat(rank_major_shards, dim)->Contiguous();
+}
+
+bool IsPrimarySaveTPGroupRank() {
+    int dp = 0;
+    int tp = 0;
+    int pp = 0;
+    parallel::global::GetCoordOf(parallel::global::thread_global_rank, dp, tp, pp);
+    return dp == 0 && pp == 0;
+}
+
+bool IsSaveWriterRank() {
+    int dp = 0;
+    int tp = 0;
+    int pp = 0;
+    parallel::global::GetCoordOf(parallel::global::thread_global_rank, dp, tp, pp);
+    return dp == 0 && tp == 0 && pp == 0;
+}
+
+std::shared_ptr<Tensor>
+ExportLoRATensorForSave(const std::string &name, const std::shared_ptr<Tensor> &tensor,
+                        const std::unordered_map<std::string, std::shared_ptr<Tensor>> &local_state_dict,
+                        const std::unordered_map<std::string, LoRATensorSharding> &shardings) {
+    const auto sharding = GetLoRATensorSharding(shardings, name);
+    switch (sharding) {
+    case LoRATensorSharding::kReplicated:
+        return tensor;
+    case LoRATensorSharding::kPackedQKVColumnParallelDim0:
+        // Packed QKV is still dim0-sharded like ColumnParallel; it only needs
+        // an extra Q/K/V reorder after the common gather below.
+    case LoRATensorSharding::kColumnParallelDim0: {
+        auto gathered = GatherTensorParallelShard(tensor, 0);
+        if (sharding != LoRATensorSharding::kPackedQKVColumnParallelDim0) {
+            return gathered;
+        }
+
+        const auto lora_a_name = LoraANameForLoraB(name);
+        auto lora_a_it = local_state_dict.find(lora_a_name);
+        CHECK(lora_a_it != local_state_dict.end())
+            << "SaveLoRAWeights: cannot infer packed QKV shape without " << lora_a_name;
+        const auto &lora_a_dims = lora_a_it->second->Dims();
+        CHECK_EQ(lora_a_dims.size(), 2) << "SaveLoRAWeights: unexpected lora_A shape for " << lora_a_name;
+        // Packed QKV LoRA-B is stored locally as [Qi | Ki | Vi], but adapter files
+        // use the full packed order [Q | K | V] to match base QKV checkpoints.
+        return detail::RestorePackedQKVRowsFromTensorParallel(gathered, /*q_rows=*/lora_a_dims[1],
+                                                              parallel::global::GetTensorParallelSize());
+    }
+    case LoRATensorSharding::kRowParallelDim1:
+        return GatherTensorParallelShard(tensor, 1);
+    }
+    LOG(FATAL) << "Unknown LoRA tensor sharding";
+    return tensor;
+}
+
+void LoadLoRATensorIntoModel(const std::string &name, const std::shared_ptr<Tensor> &src,
+                             const std::unordered_map<std::string, std::shared_ptr<Tensor>> &model_state_dict,
+                             const std::unordered_map<std::string, LoRATensorSharding> &shardings) {
+    auto it = model_state_dict.find(name);
+    if (it == model_state_dict.end()) {
+        LOG(WARNING) << "LoRA parameter not found in model: " << name;
+        return;
+    }
+
+    auto &dst = it->second;
+    const auto &src_dims = src->Dims();
+    const auto &dst_dims = dst->Dims();
+    if (dst_dims == src_dims) {
+        dst->CopyFrom(src);
+        return;
+    }
+
+    const int tp_size = parallel::global::GetTensorParallelSize();
+    const auto sharding = GetLoRATensorSharding(shardings, name);
+    if (sharding == LoRATensorSharding::kPackedQKVColumnParallelDim0) {
+        const auto lora_a_name = LoraANameForLoraB(name);
+        auto lora_a_it = model_state_dict.find(lora_a_name);
+        CHECK(lora_a_it != model_state_dict.end())
+            << "LoadLoRATensorIntoModel: cannot infer packed QKV shape without " << lora_a_name;
+        const auto &lora_a_dims = lora_a_it->second->Dims();
+        CHECK_EQ(lora_a_dims.size(), 2) << "LoadLoRATensorIntoModel: unexpected lora_A shape for " << lora_a_name;
+
+        // Full adapter files store packed QKV LoRA-B as [Q | K | V]. Each TP rank
+        // needs the matching local packed layout [Qi | Ki | Vi].
+        auto sliced
+            = detail::SlicePackedQKVRowsForTensorParallel(src, /*q_rows=*/lora_a_dims[1], parallel::tp_rank, tp_size);
+        CHECK(sliced->Dims() == dst_dims) << "LoadLoRATensorIntoModel: packed QKV shard shape mismatch for " << name;
+        dst->CopyFrom(sliced);
+        return;
+    }
+
+    CHECK_EQ(src_dims.size(), dst_dims.size()) << "LoadLoRATensorIntoModel: rank mismatch for " << name;
+    int shard_dim = -1;
+    for (int d = 0; d < static_cast<int>(src_dims.size()); ++d) {
+        if (dst_dims[d] != src_dims[d]) {
+            shard_dim = d;
+            break;
+        }
+    }
+    CHECK(shard_dim >= 0) << "LoadLoRATensorIntoModel: shape mismatch for " << name << " but no differing dim found";
+    CHECK_EQ(src_dims[shard_dim] % tp_size, 0)
+        << "LoadLoRATensorIntoModel: sharded dimension is not divisible by TP size for " << name;
+
+    const int64_t shard_size = src_dims[shard_dim] / tp_size;
+    const int64_t start = static_cast<int64_t>(parallel::tp_rank) * shard_size;
+    auto sliced = src->Slice(shard_dim, start, start + shard_size);
+    CHECK(sliced->Dims() == dst_dims) << "LoadLoRATensorIntoModel: shard shape mismatch for " << name;
+    dst->CopyFrom(sliced);
+}
+
+} // namespace
+
+namespace detail {
+
+std::shared_ptr<Tensor> SlicePackedQKVRowsForTensorParallel(const std::shared_ptr<Tensor> &full_tensor, int64_t q_rows,
+                                                            int tp_rank, int tp_size) {
+    CHECK(full_tensor != nullptr);
+
+    const auto &dims = full_tensor->Dims();
+    CHECK_GE(dims.size(), 1);
+    CHECK_GT(tp_size, 0);
+    CHECK_GE(tp_rank, 0);
+    CHECK_LT(tp_rank, tp_size);
+    CHECK_GT(q_rows, 0);
+
+    const int64_t total_rows = dims[0];
+    CHECK_GT(total_rows, q_rows) << "Packed QKV tensor must contain Q, K, and V rows";
+    CHECK_EQ((total_rows - q_rows) % 2, 0) << "Packed QKV K/V rows must be balanced";
+
+    const int64_t kv_rows = (total_rows - q_rows) / 2;
+    CHECK_GT(kv_rows, 0);
+    CHECK_EQ(q_rows % tp_size, 0) << "Q rows must be divisible by TP size";
+    CHECK_EQ(kv_rows % tp_size, 0) << "K/V rows must be divisible by TP size";
+
+    const int64_t q_local_rows = q_rows / tp_size;
+    const int64_t kv_local_rows = kv_rows / tp_size;
+    CHECK_GT(q_local_rows, 0);
+    CHECK_GT(kv_local_rows, 0);
+
+    auto q_shard = full_tensor->Slice(0, static_cast<int64_t>(tp_rank) * q_local_rows,
+                                      static_cast<int64_t>(tp_rank + 1) * q_local_rows);
+    auto k_shard = full_tensor->Slice(0, q_rows + static_cast<int64_t>(tp_rank) * kv_local_rows,
+                                      q_rows + static_cast<int64_t>(tp_rank + 1) * kv_local_rows);
+    auto v_shard = full_tensor->Slice(0, q_rows + kv_rows + static_cast<int64_t>(tp_rank) * kv_local_rows,
+                                      q_rows + kv_rows + static_cast<int64_t>(tp_rank + 1) * kv_local_rows);
+
+    return infini_train::nn::function::Concat({q_shard, k_shard, v_shard}, 0);
+}
+
+std::shared_ptr<Tensor> RestorePackedQKVRowsFromTensorParallel(const std::shared_ptr<Tensor> &gathered_tensor,
+                                                               int64_t q_rows, int tp_size) {
+    CHECK(gathered_tensor != nullptr);
+
+    const auto &dims = gathered_tensor->Dims();
+    CHECK_GE(dims.size(), 1);
+    CHECK_GT(tp_size, 0);
+    CHECK_GT(q_rows, 0);
+    CHECK_EQ(dims[0] % tp_size, 0) << "Gathered packed QKV rows must be divisible by TP size";
+
+    const int64_t local_rows = dims[0] / tp_size;
+    CHECK_EQ(q_rows % tp_size, 0) << "Q rows must be divisible by TP size";
+    const int64_t q_local_rows = q_rows / tp_size;
+    CHECK_GT(local_rows, q_local_rows) << "Gathered packed QKV tensor must contain local Q, K, and V rows";
+    CHECK_EQ((local_rows - q_local_rows) % 2, 0) << "Local packed QKV K/V rows must be balanced";
+    const int64_t kv_local_rows = (local_rows - q_local_rows) / 2;
+    CHECK_GT(kv_local_rows, 0);
+
+    std::vector<std::shared_ptr<Tensor>> reordered_shards;
+    reordered_shards.reserve(static_cast<size_t>(tp_size) * 3);
+    for (int rank = 0; rank < tp_size; ++rank) {
+        const int64_t base = static_cast<int64_t>(rank) * local_rows;
+        reordered_shards.push_back(gathered_tensor->Slice(0, base, base + q_local_rows));
+    }
+    for (int rank = 0; rank < tp_size; ++rank) {
+        const int64_t base = static_cast<int64_t>(rank) * local_rows;
+        reordered_shards.push_back(gathered_tensor->Slice(0, base + q_local_rows, base + q_local_rows + kv_local_rows));
+    }
+    for (int rank = 0; rank < tp_size; ++rank) {
+        const int64_t base = static_cast<int64_t>(rank) * local_rows;
+        reordered_shards.push_back(
+            gathered_tensor->Slice(0, base + q_local_rows + kv_local_rows, base + q_local_rows + 2 * kv_local_rows));
+    }
+
+    return nn::function::Concat(reordered_shards, 0);
+}
+
+} // namespace detail
 
 std::shared_ptr<Module> GetLoRAModel(std::shared_ptr<Module> model, const LoRAConfig &config) {
     // In-place injection: modify the module tree directly
@@ -283,6 +590,8 @@ std::shared_ptr<Module> MergeAndUnload(std::shared_ptr<Module> model) {
 std::unordered_map<std::string, std::shared_ptr<Tensor>> LoRAStateDict(const std::shared_ptr<Module> &model) {
     std::unordered_map<std::string, std::shared_ptr<Tensor>> lora_state_dict;
 
+    // This is intentionally the local model state. Under TP, sharded LoRA
+    // parameters remain local shards; SaveLoRAWeights() exports portable tensors.
     for (auto &[name, param] : model->StateDict()) {
         // Only include LoRA parameters
         if (name.find(LoRALinear::kParamLoraAName) != std::string::npos
@@ -297,18 +606,42 @@ std::unordered_map<std::string, std::shared_ptr<Tensor>> LoRAStateDict(const std
 void LoadLoRAStateDict(std::shared_ptr<Module> model,
                        const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict) {
     auto model_state_dict = model->StateDict();
+    auto shardings = BuildLoRATensorShardings(model);
 
-    for (auto &[name, param] : state_dict) {
-        if (model_state_dict.find(name) != model_state_dict.end()) {
-            model_state_dict[name]->CopyFrom(param);
-        } else {
-            LOG(WARNING) << "LoRA parameter not found in model: " << name;
-        }
-    }
+    for (auto &[name, param] : state_dict) { LoadLoRATensorIntoModel(name, param, model_state_dict, shardings); }
 }
 
 void SaveLoRAWeights(const std::shared_ptr<Module> &model, const std::string &filepath) {
     auto lora_state_dict = LoRAStateDict(model);
+    auto sorted_names = SortedLoRAStateDictNames(lora_state_dict);
+    auto shardings = BuildLoRATensorShardings(model);
+
+    // TP ranks in the primary DP/PP group must all run the gather loop below.
+    // Only TP rank 0 writes the file after receiving full tensors.
+    //
+    // TODO: PP save needs a per-stage or aggregated adapter format. The current
+    // path only writes from pp=0, so it is not a complete PP checkpoint.
+    if (!IsPrimarySaveTPGroupRank()) {
+        LOG(INFO) << "Skip saving LoRA weights on non-primary DP/PP rank.";
+        return;
+    }
+
+    const bool is_writer = IsSaveWriterRank();
+    std::vector<std::pair<std::string, std::shared_ptr<Tensor>>> exported_tensors;
+    if (is_writer) {
+        exported_tensors.reserve(sorted_names.size());
+    }
+
+    for (const auto &name : sorted_names) {
+        auto exported = ExportLoRATensorForSave(name, lora_state_dict.at(name), lora_state_dict, shardings);
+        if (is_writer) {
+            exported_tensors.emplace_back(name, exported);
+        }
+    }
+
+    if (!is_writer) {
+        return;
+    }
 
     std::ofstream file(filepath, std::ios::binary);
     CHECK(file.is_open()) << "Failed to open file for writing: " << filepath;
@@ -322,11 +655,11 @@ void SaveLoRAWeights(const std::shared_ptr<Module> &model, const std::string &fi
     file.write(reinterpret_cast<const char *>(&version), sizeof(version));
 
     // Write number of tensors
-    uint32_t num_tensors = static_cast<uint32_t>(lora_state_dict.size());
+    uint32_t num_tensors = static_cast<uint32_t>(exported_tensors.size());
     file.write(reinterpret_cast<const char *>(&num_tensors), sizeof(num_tensors));
 
     // Write each tensor
-    for (const auto &[name, tensor] : lora_state_dict) {
+    for (const auto &[name, tensor] : exported_tensors) {
         // Write name length and name
         uint32_t name_len = static_cast<uint32_t>(name.length());
         file.write(reinterpret_cast<const char *>(&name_len), sizeof(name_len));
@@ -370,6 +703,7 @@ void LoadLoRAWeights(std::shared_ptr<Module> model, const std::string &filepath)
     file.read(reinterpret_cast<char *>(&num_tensors), sizeof(num_tensors));
 
     auto model_state_dict = model->StateDict();
+    auto shardings = BuildLoRATensorShardings(model);
 
     // Read each tensor
     for (uint32_t i = 0; i < num_tensors; ++i) {
@@ -393,33 +727,7 @@ void LoadLoRAWeights(std::shared_ptr<Module> model, const std::string &filepath)
         auto cpu_tensor = std::make_shared<Tensor>(dims, DataType::kFLOAT32, Device(Device::DeviceType::kCPU, 0));
         file.read(reinterpret_cast<char *>(cpu_tensor->DataPtr()), num_elements * sizeof(float));
 
-        // Load into model, slicing sharded tensors by tp_rank if shapes differ
-        auto it = model_state_dict.find(name);
-        if (it != model_state_dict.end()) {
-            auto &dst = it->second;
-            const auto &dst_dims = dst->Dims();
-            if (dst_dims == dims) {
-                dst->CopyFrom(cpu_tensor);
-            } else {
-                // Determine which dim is sharded: find first dim where sizes differ
-                int shard_dim = -1;
-                for (int d = 0; d < static_cast<int>(dims.size()); ++d) {
-                    if (d < static_cast<int>(dst_dims.size()) && dst_dims[d] != dims[d]) {
-                        shard_dim = d;
-                        break;
-                    }
-                }
-                CHECK(shard_dim >= 0) << "LoadLoRAWeights: shape mismatch for " << name
-                                      << " but no differing dim found";
-                int tp_size = parallel::global::GetTensorParallelSize();
-                int64_t shard_size = dims[shard_dim] / tp_size;
-                int64_t start = parallel::tp_rank * shard_size;
-                auto sliced = cpu_tensor->Slice(shard_dim, start, start + shard_size);
-                dst->CopyFrom(sliced);
-            }
-        } else {
-            LOG(WARNING) << "LoRA parameter not found in model: " << name;
-        }
+        LoadLoRATensorIntoModel(name, cpu_tensor, model_state_dict, shardings);
     }
 
     file.close();

--- a/infini_train/src/nn/lora/lora_utils.cc
+++ b/infini_train/src/nn/lora/lora_utils.cc
@@ -20,7 +20,6 @@
 #include "infini_train/include/nn/modules/transformer/causal_self_attention.h"
 #include "infini_train/include/nn/parallel/ddp/distributed_data_parallel.h"
 #include "infini_train/include/nn/parallel/global.h"
-#include "infini_train/include/nn/parallel/process_group.h"
 #include "infini_train/include/nn/parallel/tensor_parallel.h"
 #include "infini_train/include/nn/parallel/utils.h"
 #include "infini_train/include/tensor.h"
@@ -141,38 +140,6 @@ LoRATensorSharding GetLoRATensorSharding(const std::unordered_map<std::string, L
     return it == shardings.end() ? LoRATensorSharding::kReplicated : it->second;
 }
 
-std::shared_ptr<Tensor> GatherTensorParallelShard(const std::shared_ptr<Tensor> &tensor, int64_t dim) {
-    const int tp_size = parallel::global::GetTensorParallelSize();
-    CHECK_GT(tp_size, 0);
-    if (tp_size == 1) {
-        return tensor;
-    }
-
-    if (dim < 0) {
-        dim += static_cast<int64_t>(tensor->Dims().size());
-    }
-    CHECK_GE(dim, 0);
-    CHECK_LT(dim, static_cast<int64_t>(tensor->Dims().size()));
-
-    auto device = tensor->GetDevice();
-    auto *tp_group = parallel::ProcessGroupFactory::Instance(device.type())
-                         ->Get(parallel::GetTensorParallelProcessGroupName(device.Rank().GlobalRank()));
-
-    std::vector<int64_t> gathered_dims = tensor->Dims();
-    gathered_dims[0] *= tp_size;
-    auto gathered = std::make_shared<Tensor>(gathered_dims, tensor->Dtype(), device);
-    tp_group->AllGather(gathered, tensor, false);
-
-    if (dim == 0) {
-        return gathered;
-    }
-
-    // AllGather stacks shards along dim 0. For tensors sharded on another dim,
-    // split rank-major rows back into per-rank tensors and concatenate on dim.
-    auto rank_major_shards = gathered->Split(tensor->Dims()[0], 0);
-    return nn::function::Concat(rank_major_shards, dim)->Contiguous();
-}
-
 bool IsPrimarySaveTPGroupRank() {
     int dp = 0;
     int tp = 0;
@@ -201,7 +168,7 @@ ExportLoRATensorForSave(const std::string &name, const std::shared_ptr<Tensor> &
         // Packed QKV is still dim0-sharded like ColumnParallel; it only needs
         // an extra Q/K/V reorder after the common gather below.
     case LoRATensorSharding::kColumnParallelDim0: {
-        auto gathered = GatherTensorParallelShard(tensor, 0);
+        auto gathered = parallel::GatherTensorParallelShard(tensor, 0);
         if (sharding != LoRATensorSharding::kPackedQKVColumnParallelDim0) {
             return gathered;
         }
@@ -218,7 +185,7 @@ ExportLoRATensorForSave(const std::string &name, const std::shared_ptr<Tensor> &
                                                               parallel::global::GetTensorParallelSize());
     }
     case LoRATensorSharding::kRowParallelDim1:
-        return GatherTensorParallelShard(tensor, 1);
+        return parallel::GatherTensorParallelShard(tensor, 1);
     }
     LOG(FATAL) << "Unknown LoRA tensor sharding";
     return tensor;
@@ -283,6 +250,8 @@ void LoadLoRATensorIntoModel(const std::string &name, const std::shared_ptr<Tens
 
 namespace detail {
 
+// TODO: Reuse this packed-QKV sharding logic in TP checkpoint loading once the checkpoint infrastructure is stable.
+// The current TP loader reads rank-local weights directly by file offset instead of slicing a materialized full tensor.
 std::shared_ptr<Tensor> SlicePackedQKVRowsForTensorParallel(const std::shared_ptr<Tensor> &full_tensor, int64_t q_rows,
                                                             int tp_rank, int tp_size) {
     CHECK(full_tensor != nullptr);

--- a/infini_train/src/nn/parallel/ddp/distributed_data_parallel.cc
+++ b/infini_train/src/nn/parallel/ddp/distributed_data_parallel.cc
@@ -17,10 +17,6 @@
 #include "infini_train/include/tensor.h"
 
 namespace infini_train::nn::parallel {
-namespace {
-constexpr char kModuleName[] = "module";
-
-} // namespace
 
 DistributedDataParallel::DistributedDataParallel(std::shared_ptr<nn::Module> module, const Rank &rank,
                                                  const DistributedDataParallelConfig ddp_config)
@@ -216,4 +212,6 @@ DistributedDataParallel::Forward(const std::vector<std::shared_ptr<Tensor>> &inp
     }
     return outputs;
 }
+
+std::shared_ptr<nn::Module> DistributedDataParallel::module() const { return modules_.at(kModuleName); }
 } // namespace infini_train::nn::parallel

--- a/infini_train/src/nn/parallel/process_group.cc
+++ b/infini_train/src/nn/parallel/process_group.cc
@@ -194,6 +194,116 @@ std::shared_ptr<Work> ProcessGroup::ReduceScatter(const std::shared_ptr<Tensor> 
     }
 }
 
+std::shared_ptr<Work> ProcessGroup::Broadcast(const std::vector<std::shared_ptr<Tensor>> &tensors,
+                                              int root_rank_in_group, bool async_op) const {
+    CHECK_GE(root_rank_in_group, 0);
+    CHECK_LT(root_rank_in_group, world_size_);
+    CHECK_GT(tensors.size(), 0);
+    CHECK_NOTNULL(tensors[0]);
+
+    auto device = tensors[0]->GetDevice();
+    auto group_rank = GetGroupRank(device.Rank().GlobalRank());
+    core::DeviceGuard guard(device);
+    auto *compute_stream = runtime_impl_->GetStream(device);
+    auto *comm_stream = device_stream_map_.at(device.index());
+    auto comm = device_comm_map_.at(device.index());
+
+    auto work = std::make_shared<Work>(device, comm);
+    runtime_impl_->EventRecord(work->ready_event(), compute_stream);
+    runtime_impl_->StreamWaitEvent(comm_stream, work->ready_event(), 0);
+    for (const auto &tensor : tensors) {
+        CHECK_NOTNULL(tensor);
+        CHECK_EQ(device, tensor->GetDevice());
+        const void *send_buffer = (group_rank == root_rank_in_group) ? tensor->DataPtr() : nullptr;
+        ccl_impl_->Broadcast(send_buffer, tensor->DataPtr(), tensor->NumElements(), tensor->Dtype(), root_rank_in_group,
+                             comm, comm_stream);
+    }
+    runtime_impl_->EventRecord(work->done_event(), comm_stream);
+
+    if (async_op) {
+        return work;
+    } else {
+        work->WaitNonBlocking();
+        return nullptr;
+    }
+}
+
+std::shared_ptr<Work> ProcessGroup::Scatter(const std::vector<std::shared_ptr<Tensor>> &output_tensors,
+                                            const std::vector<std::shared_ptr<Tensor>> &input_tensors,
+                                            int root_rank_in_group, bool async_op) const {
+    CHECK_GE(root_rank_in_group, 0);
+    CHECK_LT(root_rank_in_group, world_size_);
+    CHECK_GT(output_tensors.size(), 0);
+    CHECK_NOTNULL(output_tensors[0]);
+
+    auto device = output_tensors[0]->GetDevice();
+    auto group_rank = GetGroupRank(device.Rank().GlobalRank());
+    core::DeviceGuard guard(device);
+    auto *compute_stream = runtime_impl_->GetStream(device);
+    auto *comm_stream = device_stream_map_.at(device.index());
+    auto comm = device_comm_map_.at(device.index());
+
+    for (const auto &output_tensor : output_tensors) {
+        CHECK_NOTNULL(output_tensor);
+        CHECK_EQ(device, output_tensor->GetDevice());
+    }
+
+    const bool is_root = group_rank == root_rank_in_group;
+    const size_t num_outputs = output_tensors.size();
+    if (is_root) {
+        CHECK_EQ(input_tensors.size(), static_cast<size_t>(world_size_) * num_outputs)
+            << "Root rank must provide rank-major input tensors for every rank.";
+        for (const auto &input_tensor : input_tensors) {
+            CHECK_NOTNULL(input_tensor);
+            CHECK_EQ(device, input_tensor->GetDevice());
+        }
+        for (size_t tensor_idx = 0; tensor_idx < num_outputs; ++tensor_idx) {
+            const auto &local_input = input_tensors[static_cast<size_t>(group_rank) * num_outputs + tensor_idx];
+            CHECK(local_input->Dtype() == output_tensors[tensor_idx]->Dtype());
+            CHECK(local_input->Dims() == output_tensors[tensor_idx]->Dims());
+        }
+    } else {
+        CHECK(input_tensors.empty()) << "Only root rank should provide scatter input tensors.";
+    }
+
+    auto work = std::make_shared<Work>(device, comm);
+    runtime_impl_->EventRecord(work->ready_event(), compute_stream);
+    runtime_impl_->StreamWaitEvent(comm_stream, work->ready_event(), 0);
+    if (is_root) {
+        for (size_t tensor_idx = 0; tensor_idx < num_outputs; ++tensor_idx) {
+            const auto &input_tensor = input_tensors[static_cast<size_t>(group_rank) * num_outputs + tensor_idx];
+            runtime_impl_->MemcpyAsync(output_tensors[tensor_idx]->DataPtr(), input_tensor->DataPtr(),
+                                       input_tensor->SizeInBytes(), core::MemcpyKind::kD2D, comm_stream);
+        }
+
+        core::CclGroupGuard ccl_group_guard(device.type());
+        for (int rank = 0; rank < world_size_; ++rank) {
+            if (rank == group_rank) {
+                continue;
+            }
+            for (size_t tensor_idx = 0; tensor_idx < num_outputs; ++tensor_idx) {
+                const auto &input_tensor = input_tensors[static_cast<size_t>(rank) * num_outputs + tensor_idx];
+                ccl_impl_->Send(input_tensor->DataPtr(), input_tensor->NumElements(), input_tensor->Dtype(), rank, comm,
+                                comm_stream);
+            }
+        }
+    } else {
+        core::CclGroupGuard ccl_group_guard(device.type());
+        for (const auto &output_tensor : output_tensors) {
+            ccl_impl_->Recv(output_tensor->DataPtr(), output_tensor->NumElements(), output_tensor->Dtype(),
+                            root_rank_in_group, comm, comm_stream);
+        }
+    }
+    runtime_impl_->EventRecord(work->done_event(), comm_stream);
+
+    if (async_op) {
+        return work;
+    } else {
+        work->WaitNonBlocking();
+        return nullptr;
+    }
+}
+
 std::shared_ptr<Work> ProcessGroup::Send(std::vector<std::shared_ptr<Tensor>> tensors, int dest_rank,
                                          bool async_op) const {
     CHECK_GT(tensors.size(), 0);
@@ -249,7 +359,7 @@ std::shared_ptr<Work> ProcessGroup::Recv(std::vector<std::shared_ptr<Tensor>> te
 }
 
 std::vector<std::shared_ptr<Tensor>>
-ProcessGroup::BroadCast(const std::vector<std::shared_ptr<Tensor>> &input_tensors) const {
+ProcessGroup::BroadCast_(const std::vector<std::shared_ptr<Tensor>> &input_tensors) const {
     std::vector<std::shared_ptr<Tensor>> outputs;
     std::vector<core::Stream *> streams;
     std::vector<core::CclComm *> comms;
@@ -329,8 +439,8 @@ ProcessGroup::ReduceAddCoalesced(const std::vector<std::vector<std::shared_ptr<T
     return outputs;
 }
 
-std::vector<std::shared_ptr<Tensor>> ProcessGroup::Scatter(const std::shared_ptr<Tensor> &tensor,
-                                                           std::vector<Device> devices, int64_t dim) const {
+std::vector<std::shared_ptr<Tensor>> ProcessGroup::Scatter_(const std::shared_ptr<Tensor> &tensor,
+                                                            std::vector<Device> devices, int64_t dim) const {
     std::vector<std::shared_ptr<Tensor>> outputs;
     auto split_tensors = tensor->Split(tensor->Dims()[dim] / devices.size(), dim);
     std::vector<core::Stream *> streams;

--- a/infini_train/src/nn/parallel/tensor_parallel.cc
+++ b/infini_train/src/nn/parallel/tensor_parallel.cc
@@ -26,48 +26,11 @@ thread_local int tp_rank = 0;
 namespace {
 // Comm Kernel Call Functions
 std::shared_ptr<Tensor> GatherAlongFirstDim(const std::shared_ptr<Tensor> &tensor) {
-    int world_size = global::GetTensorParallelSize();
-    CHECK_GT(world_size, 0) << "Tensor Parallel group not initialized";
-    if (world_size == 1) {
-        // Bypass the function if we are using only 1 GPU.
-        return tensor;
-    }
-
-    auto device = tensor->GetDevice();
-    auto tp_group = ProcessGroupFactory::Instance(device.type())
-                        ->Get(GetTensorParallelProcessGroupName(device.Rank().GlobalRank()));
-
-    std::vector<int64_t> output_shape = tensor->Dims();
-    output_shape[0] *= world_size;
-    auto gathered_output = std::make_shared<Tensor>(output_shape, tensor->Dtype(), device);
-
-    tp_group->AllGather(gathered_output, tensor, false);
-    return gathered_output;
+    return GatherTensorParallelShard(tensor, 0);
 }
 
 std::shared_ptr<Tensor> GatherAlongLastDim(const std::shared_ptr<Tensor> &tensor) {
-    int world_size = global::GetTensorParallelSize();
-    CHECK_GT(world_size, 0) << "Tensor Parallel group not initialized";
-    if (world_size == 1) {
-        // Bypass the function if we are using only 1 GPU.
-        return tensor;
-    }
-
-    auto device = tensor->GetDevice();
-    auto tp_group = ProcessGroupFactory::Instance(device.type())
-                        ->Get(GetTensorParallelProcessGroupName(device.Rank().GlobalRank()));
-
-    std::vector<int64_t> output_shape = tensor->Dims();
-    output_shape[0] *= world_size;
-    auto gathered_output = std::make_shared<Tensor>(output_shape, tensor->Dtype(), device);
-
-    tp_group->AllGather(gathered_output, tensor, false);
-
-    // AllGather gather along dim 0 by default
-    auto output_list = gathered_output->Split(tensor->Dims()[0], 0);
-    auto output = nn::function::Concat(output_list, -1)->Contiguous();
-
-    return output;
+    return GatherTensorParallelShard(tensor, -1);
 }
 
 std::shared_ptr<Tensor> SplitAlongLastDim(const std::shared_ptr<Tensor> &tensor) {

--- a/infini_train/src/nn/parallel/utils.cc
+++ b/infini_train/src/nn/parallel/utils.cc
@@ -1,6 +1,11 @@
 #include "infini_train/include/nn/parallel/utils.h"
 
+#include "glog/logging.h"
+
+#include "infini_train/include/nn/functional.h"
 #include "infini_train/include/nn/parallel/global.h"
+#include "infini_train/include/nn/parallel/process_group.h"
+#include "infini_train/include/tensor.h"
 
 namespace infini_train::nn::parallel {
 
@@ -22,6 +27,37 @@ std::vector<int> GetTensorParallelGroupRanks(int global_rank) { return global::G
 
 std::vector<int> GetPipelineParallelGroupRanks(int global_rank) {
     return global::GetGroupRanks(global::PP, global_rank);
+}
+
+std::shared_ptr<Tensor> GatherTensorParallelShard(const std::shared_ptr<Tensor> &tensor, int64_t dim) {
+    const int tp_size = global::GetTensorParallelSize();
+    CHECK_GT(tp_size, 0) << "Tensor Parallel group not initialized";
+    if (tp_size == 1) {
+        return tensor;
+    }
+
+    if (dim < 0) {
+        dim += static_cast<int64_t>(tensor->Dims().size());
+    }
+    CHECK_GE(dim, 0);
+    CHECK_LT(dim, static_cast<int64_t>(tensor->Dims().size()));
+
+    auto device = tensor->GetDevice();
+    auto *tp_group = ProcessGroupFactory::Instance(device.type())
+                         ->Get(GetTensorParallelProcessGroupName(device.Rank().GlobalRank()));
+
+    std::vector<int64_t> gathered_dims = tensor->Dims();
+    gathered_dims[0] *= tp_size;
+    auto gathered = std::make_shared<Tensor>(gathered_dims, tensor->Dtype(), device);
+    tp_group->AllGather(gathered, tensor, false);
+
+    if (dim == 0) {
+        return gathered;
+    }
+
+    // AllGather stacks shards along dim 0. Restore rank-major shards before concatenating on the requested dimension.
+    auto rank_major_shards = gathered->Split(tensor->Dims()[0], 0);
+    return nn::function::Concat(rank_major_shards, dim)->Contiguous();
 }
 
 } // namespace infini_train::nn::parallel

--- a/scripts/run_models_and_profile.bash
+++ b/scripts/run_models_and_profile.bash
@@ -309,7 +309,8 @@ run_and_log() {
     echo "[GIT_BRANCH] $GIT_BRANCH" >> "$log_path"
     echo "[GIT_COMMIT] $GIT_COMMIT_FULL" >> "$log_path"
     echo "[GIT_COMMIT_SHORT] $GIT_COMMIT_SHORT" >> "$log_path"
-    echo "[COMMAND] $cmd" >> "$log_path"
+    local expanded_cmd="${cmd//\$LORA_WEIGHTS_DIR/$LORA_WEIGHTS_DIR}"
+    echo "[COMMAND] $expanded_cmd" >> "$log_path"
 
     # Run the command and append both stdout and stderr to the log file
     if ! eval "$cmd" >> "$log_path" 2>&1; then
@@ -510,12 +511,14 @@ for ((id=0; id<num_basic_compile_commands; ++id)); do
             for ((ti=0; ti<num_tests; ++ti)); do
                 test_id=$(jq -r ".test_groups[$gi].tests[$ti].id" "$CONFIG_FILE")
                 if tag_enabled_for_model "$group_tag" "$GPT2_TEST_GROUPS"; then
+                    LORA_WEIGHTS_DIR="$GPT2_LORA_WEIGHTS_DIR"
                     gpt2_arg_str="$(args_string_for_test "$gi" "$ti" "gpt2" "$test_id")"
                     gpt2_cmd="${prefix}./gpt2 --input_bin ${GPT2_INPUT_BIN} --llmc_filepath ${GPT2_LLMC_FILEPATH} --device cuda ${gpt2_arg_str}"
                     run_and_log "$gpt2_cmd" "gpt2_${test_id}${log_suffix}" "$profile_flag" "$group_tag"
                 fi
 
                 if tag_enabled_for_model "$group_tag" "$LLAMA3_TEST_GROUPS"; then
+                    LORA_WEIGHTS_DIR="$LLAMA3_LORA_WEIGHTS_DIR"
                     llama3_arg_str="$(args_string_for_test "$gi" "$ti" "llama3" "$test_id")"
                     llama3_cmd="${prefix}./llama3 --input_bin ${LLAMA3_INPUT_BIN} --llmc_filepath ${LLAMA3_LLMC_FILEPATH} --device cuda ${llama3_arg_str}"
                     run_and_log "$llama3_cmd" "llama3_${test_id}${log_suffix}" "$profile_flag" "$group_tag"

--- a/scripts/test_config.json
+++ b/scripts/test_config.json
@@ -5,6 +5,8 @@
         "GPT2_LLMC_FILEPATH": "/data1/shared/InfiniTrain-dev/data/llmc/gpt2/gpt2_124M.bin",
         "LLAMA3_INPUT_BIN": "/data1/shared/InfiniTrain-dev/data/llmc/llama3/tinyshakespeare/tiny_shakespeare_train.bin",
         "LLAMA3_LLMC_FILEPATH": "/data1/shared/InfiniTrain-dev/data/llmc/llama3/llama3.2_1B_fp32.bin",
+        "LLAMA3_LORA_WEIGHTS_DIR": "/data1/shared/InfiniTrain-dev/data/llmc/llama3/llama3.2_1B_lora_weights_rank8_alpha16.bin",
+        "GPT2_LORA_WEIGHTS_DIR": "/data1/shared/InfiniTrain-dev/data/llmc/gpt2/gpt2_124M_lora_weights_rank8_alpha16.bin",
         "PROFILE_LOG_DIR": "./profile_logs",
         "LOG_DIR": "./logs",
         "CKPT_ROOT_DIR": "/data1/ckpt",
@@ -563,7 +565,8 @@
                         "dtype": "float32",
                         "lora_rank": 8,
                         "lora_alpha": 16.0,
-                        "lora_target_modules": "c_attn,attn.c_proj"
+                        "lora_target_modules": "c_attn,attn.c_proj",
+                        "lora_load_path": "$LORA_WEIGHTS_DIR"
                     }
                 },
                 {
@@ -572,7 +575,8 @@
                         "dtype": "bfloat16",
                         "lora_rank": 8,
                         "lora_alpha": 16.0,
-                        "lora_target_modules": "c_attn,attn.c_proj"
+                        "lora_target_modules": "c_attn,attn.c_proj",
+                        "lora_load_path": "$LORA_WEIGHTS_DIR"
                     }
                 },
                 {
@@ -584,7 +588,8 @@
                         "total_batch_size": 5120,
                         "lora_rank": 8,
                         "lora_alpha": 16.0,
-                        "lora_target_modules": "c_attn,attn.c_proj"
+                        "lora_target_modules": "c_attn,attn.c_proj",
+                        "lora_load_path": "$LORA_WEIGHTS_DIR"
                     }
                 },
                 {
@@ -596,7 +601,8 @@
                         "total_batch_size": 5120,
                         "lora_rank": 8,
                         "lora_alpha": 16.0,
-                        "lora_target_modules": "c_attn,attn.c_proj"
+                        "lora_target_modules": "c_attn,attn.c_proj",
+                        "lora_load_path": "$LORA_WEIGHTS_DIR"
                     }
                 },
                 {
@@ -609,7 +615,8 @@
                         "total_batch_size": 5120,
                         "lora_rank": 8,
                         "lora_alpha": 16.0,
-                        "lora_target_modules": "c_attn,attn.c_proj"
+                        "lora_target_modules": "c_attn,attn.c_proj",
+                        "lora_load_path": "$LORA_WEIGHTS_DIR"
                     }
                 },
                 {
@@ -622,7 +629,8 @@
                         "total_batch_size": 5120,
                         "lora_rank": 8,
                         "lora_alpha": 16.0,
-                        "lora_target_modules": "c_attn,attn.c_proj"
+                        "lora_target_modules": "c_attn,attn.c_proj",
+                        "lora_load_path": "$LORA_WEIGHTS_DIR"
                     }
                 },
                 {
@@ -634,9 +642,10 @@
                         "batch_size": 40,
                         "total_batch_size": 5120,
                         "tensor_parallel": 4,
-                        "lora_rank": 4,
-                        "lora_alpha": 8.0,
-                        "lora_target_modules": "c_attn,c_fc,c_proj"
+                        "lora_rank": 8,
+                        "lora_alpha": 16.0,
+                        "lora_target_modules": "c_attn,attn.c_proj",
+                        "lora_load_path": "$LORA_WEIGHTS_DIR"
                     }
                 },
                 {
@@ -648,9 +657,10 @@
                         "batch_size": 40,
                         "total_batch_size": 5120,
                         "tensor_parallel": 4,
-                        "lora_rank": 16,
-                        "lora_alpha": 32.0,
-                        "lora_target_modules": "c_attn,c_fc,c_proj"
+                        "lora_rank": 8,
+                        "lora_alpha": 16.0,
+                        "lora_target_modules": "c_attn,attn.c_proj",
+                        "lora_load_path": "$LORA_WEIGHTS_DIR"
                     }
                 },
                 {

--- a/tests/lora/test_lora.cc
+++ b/tests/lora/test_lora.cc
@@ -1,5 +1,6 @@
 #include <cmath>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -28,6 +29,12 @@ static float TensorSum(const std::shared_ptr<Tensor> &t) {
     auto cpu = std::make_shared<Tensor>(t->Dims(), t->Dtype(), Device(Device::DeviceType::kCPU, 0));
     cpu->CopyFrom(t);
     return cpu->EigenMatrix().sum();
+}
+
+static std::shared_ptr<Tensor> MakeFilledTensor(const std::vector<int64_t> &dims, Device device, float value) {
+    auto tensor = std::make_shared<Tensor>(dims, DataType::kFLOAT32, device);
+    tensor->Fill(value);
+    return tensor;
 }
 
 static float RowValue(int64_t row, int64_t col) { return static_cast<float>(row * 100 + col); }
@@ -343,6 +350,30 @@ TEST_P(LoRATest, LoRAStateDict) {
     EXPECT_EQ(state_dict.at("lora_A")->Dims()[1], 64);
     EXPECT_EQ(state_dict.at("lora_B")->Dims()[0], 128);
     EXPECT_EQ(state_dict.at("lora_B")->Dims()[1], config.rank);
+}
+
+TEST_P(LoRATest, LoadLoRAStateDictConsumesDDPModulePrefix) {
+    auto base_linear = std::make_shared<nn::Linear>(64, 128, /*bias=*/true, GetDevice());
+
+    LoRAConfig config;
+    config.rank = 4;
+    config.alpha = 8.0f;
+    config.target_modules = {"Linear"};
+
+    auto model = GetLoRAModel(base_linear, config);
+    auto lora_state_dict = LoRAStateDict(model);
+
+    std::unordered_map<std::string, std::shared_ptr<Tensor>> prefixed_state_dict;
+    prefixed_state_dict["module.lora_A"] = MakeFilledTensor(lora_state_dict.at("lora_A")->Dims(), GetDevice(), 3.0f);
+    prefixed_state_dict["module.lora_B"] = MakeFilledTensor(lora_state_dict.at("lora_B")->Dims(), GetDevice(), 5.0f);
+
+    LoadLoRAStateDict(model, prefixed_state_dict);
+
+    auto loaded_state_dict = LoRAStateDict(model);
+    EXPECT_FLOAT_EQ(TensorSum(loaded_state_dict.at("lora_A")),
+                    3.0f * static_cast<float>(loaded_state_dict.at("lora_A")->NumElements()));
+    EXPECT_FLOAT_EQ(TensorSum(loaded_state_dict.at("lora_B")),
+                    5.0f * static_cast<float>(loaded_state_dict.at("lora_B")->NumElements()));
 }
 
 TEST_P(LoRATest, GetLoRAModel) {

--- a/tests/lora/test_lora.cc
+++ b/tests/lora/test_lora.cc
@@ -30,6 +30,48 @@ static float TensorSum(const std::shared_ptr<Tensor> &t) {
     return cpu->EigenMatrix().sum();
 }
 
+static float RowValue(int64_t row, int64_t col) { return static_cast<float>(row * 100 + col); }
+
+static std::shared_ptr<Tensor> MakeRowLabeledTensor(int64_t rows, int64_t cols, Device device) {
+    auto cpu_tensor = std::make_shared<Tensor>(std::vector<int64_t>{rows, cols}, DataType::kFLOAT32,
+                                               Device(Device::DeviceType::kCPU, 0));
+    auto matrix = cpu_tensor->EigenMatrix();
+    for (int64_t row = 0; row < rows; ++row) {
+        for (int64_t col = 0; col < cols; ++col) { matrix(row, col) = RowValue(row, col); }
+    }
+
+    if (device.IsCPU()) {
+        return cpu_tensor;
+    }
+
+    auto device_tensor = std::make_shared<Tensor>(std::vector<int64_t>{rows, cols}, DataType::kFLOAT32, device);
+    device_tensor->CopyFrom(cpu_tensor);
+    return device_tensor;
+}
+
+static std::shared_ptr<Tensor> ToCpuTensor(const std::shared_ptr<Tensor> &tensor) {
+    if (tensor->GetDevice().IsCPU()) {
+        return tensor;
+    }
+
+    auto cpu_tensor = std::make_shared<Tensor>(tensor->Dims(), tensor->Dtype(), Device(Device::DeviceType::kCPU, 0));
+    cpu_tensor->CopyFrom(tensor);
+    return cpu_tensor;
+}
+
+static void ExpectRows(const std::shared_ptr<Tensor> &tensor, const std::vector<int64_t> &source_rows) {
+    ASSERT_EQ(tensor->Dims().size(), 2);
+    ASSERT_EQ(tensor->Dims()[0], static_cast<int64_t>(source_rows.size()));
+
+    auto cpu_tensor = ToCpuTensor(tensor);
+    auto matrix = cpu_tensor->EigenMatrix();
+    for (int64_t row = 0; row < static_cast<int64_t>(source_rows.size()); ++row) {
+        for (int64_t col = 0; col < tensor->Dims()[1]; ++col) {
+            EXPECT_FLOAT_EQ(matrix(row, col), RowValue(source_rows[row], col));
+        }
+    }
+}
+
 TEST_P(LoRATest, LoRAConfigScaling) {
     LoRAConfig config;
     config.rank = 8;
@@ -37,6 +79,33 @@ TEST_P(LoRATest, LoRAConfigScaling) {
 
     float expected_scaling = 16.0f / 8.0f;
     EXPECT_EQ(config.Scaling(), expected_scaling);
+}
+
+TEST_P(LoRATest, PackedQKVShardGPTStyle) {
+    auto full_qkv = MakeRowLabeledTensor(/*rows=*/12, /*cols=*/3, GetDevice());
+    auto shard = infini_train::nn::lora::detail::SlicePackedQKVRowsForTensorParallel(full_qkv, /*q_rows=*/4,
+                                                                                     /*tp_rank=*/1, /*tp_size=*/2);
+
+    EXPECT_EQ(shard->Dims(), (std::vector<int64_t>{6, 3}));
+    ExpectRows(shard, {2, 3, 6, 7, 10, 11});
+}
+
+TEST_P(LoRATest, PackedQKVShardGQAStyle) {
+    auto full_qkv = MakeRowLabeledTensor(/*rows=*/16, /*cols=*/2, GetDevice());
+    auto shard = infini_train::nn::lora::detail::SlicePackedQKVRowsForTensorParallel(full_qkv, /*q_rows=*/8,
+                                                                                     /*tp_rank=*/2, /*tp_size=*/4);
+
+    EXPECT_EQ(shard->Dims(), (std::vector<int64_t>{4, 2}));
+    ExpectRows(shard, {4, 5, 10, 14});
+}
+
+TEST_P(LoRATest, PackedQKVRestoreFromTPGather) {
+    auto rank_major_qkv = MakeRowLabeledTensor(/*rows=*/12, /*cols=*/3, GetDevice());
+    auto restored = infini_train::nn::lora::detail::RestorePackedQKVRowsFromTensorParallel(rank_major_qkv, /*q_rows=*/4,
+                                                                                           /*tp_size=*/2);
+
+    EXPECT_EQ(restored->Dims(), (std::vector<int64_t>{12, 3}));
+    ExpectRows(restored, {0, 1, 6, 7, 2, 3, 8, 9, 4, 5, 10, 11});
 }
 
 TEST_P(LoRATest, LoRAConfigShouldApply) {

--- a/tests/lora/test_lora.cc
+++ b/tests/lora/test_lora.cc
@@ -56,22 +56,12 @@ static std::shared_ptr<Tensor> MakeRowLabeledTensor(int64_t rows, int64_t cols, 
     return device_tensor;
 }
 
-static std::shared_ptr<Tensor> ToCpuTensor(const std::shared_ptr<Tensor> &tensor) {
-    if (tensor->GetDevice().IsCPU()) {
-        return tensor;
-    }
-
-    auto cpu_tensor = std::make_shared<Tensor>(tensor->Dims(), tensor->Dtype(), Device(Device::DeviceType::kCPU, 0));
-    cpu_tensor->CopyFrom(tensor);
-    return cpu_tensor;
-}
-
 static void ExpectRows(const std::shared_ptr<Tensor> &tensor, const std::vector<int64_t> &source_rows) {
     ASSERT_EQ(tensor->Dims().size(), 2);
     ASSERT_EQ(tensor->Dims()[0], static_cast<int64_t>(source_rows.size()));
 
-    auto cpu_tensor = ToCpuTensor(tensor);
-    auto matrix = cpu_tensor->EigenMatrix();
+    auto cpu_tensor = tensor->To(Device(Device::DeviceType::kCPU, 0));
+    auto matrix = cpu_tensor.EigenMatrix();
     for (int64_t row = 0; row < static_cast<int64_t>(source_rows.size()); ++row) {
         for (int64_t col = 0; col < tensor->Dims()[1]; ++col) {
             EXPECT_FLOAT_EQ(matrix(row, col), RowValue(source_rows[row], col));


### PR DESCRIPTION
## Summary

Fix LoRA loss divergence under tensor/data parallel training by making LoRA tensor-parallel initialization deterministic and aligning the forward collective order between base linear and LoRA linear paths.

This PR changes TP LoRA parallel linear modules to compute the base shard and LoRA shard locally first, add them before communication, and then run a single TP collective on the combined output. It also adds rank-aware `Broadcast`/`Scatter` ProcessGroup APIs and updates LoRA weight loading to support loading full saved LoRA tensors into TP-sharded model parameters.

It also adds rank-aware `Broadcast`/`Scatter` ProcessGroup APIs, updates LoRA adapter save/load to use portable full tensors under TP, handles packed QKV LoRA tensors, and keeps adapter IO compatible with DDP-wrapped models.

## Motivation

In tensor-parallel LoRA training, the base linear output and the LoRA update together form one logical linear output. Previously, the base path and LoRA path could run separate TP collectives and add their outputs afterward:

```cpp
base = TPCollective(base_i);
lora = TPCollective(lora_i);
out = base + lora;
```

This changes the floating-point communication/reduction order compared with computing the logical local contribution first:

```cpp
out_i = base_i + lora_i;
out = TPCollective(out_i);
```

The separate-collective path can introduce numerical divergence across TP/DDP configurations.

Replicated or sharded LoRA parameters need rank-consistent initialization so every TP rank starts from the same logical LoRA weights.

## Key Changes

### LoRA parallel linear forward

* Update `LoRAColumnParallelLinear` to:

  * compute the base shard locally;
  * compute the LoRA shard locally;
  * add `base_shard + scaled_lora_shard` before TP gather;
  * run a single gather when `gather_output_` is enabled.

* Update `LoRARowParallelLinear` to:

  * compute the base shard locally;
  * compute the LoRA shard locally;
  * add `base_shard + scaled_lora_shard` before TP reduce/reduce-scatter;
  * apply bias after the collective, matching the base `RowParallelLinear` behavior.

This makes the LoRA path follow the same logical communication boundary as the base parallel linear layer and avoids running separate collectives for base and LoRA outputs.

### Deterministic TP LoRA initialization

* Make replicated ColumnParallel `lora_A` consistent across TP ranks.
* Initialize the logical RowParallel `lora_A` from TP rank 0 and distribute the correct local shards to each TP rank.
* Ensure TP ranks observe the same logical LoRA initialization instead of independently sampling incompatible parameter values.

### ProcessGroup communication APIs

* Add rank-aware communication APIs:

  * `ProcessGroup::Broadcast(tensors, root_rank_in_group, async_op)`
  * `ProcessGroup::Scatter(output_tensors, input_tensors, root_rank_in_group, async_op)`
* Rename the old APIs to `BroadCast_` / `Scatter_` to avoid semantic ambiguity.
* Update existing autograd communication wrappers to call the legacy renamed APIs where appropriate.

### LoRA weight save/load

* Extend `LoadLoRAWeights` to support loading full saved LoRA weights into TP-sharded model parameters.
* When a destination parameter is TP-sharded, slice the loaded full tensor according to the current `tp_rank` before copying it into the local parameter.
* Update `SaveLoRAWeights` to export portable full LoRA weights under TP:

  * TP-sharded LoRA tensors are gathered back into full/unsharded tensors before writing.
  * All TP ranks in the primary DP/PP group participate in the save-side gather.
  * Only the rank with `dp == 0 && tp == 0 && pp == 0` writes the weight file.

### Packed QKV LoRA tensor handling

  * Handle attention `c_attn.lora_B` specially when it uses the packed QKV layout `[Q | K | V]`.
  * On save, restore full packed QKV tensors from per-rank `[Qi | Ki | Vi]` shards.
  * On load, split full packed QKV tensors back into local `[Qi | Ki | Vi]` shards for the current TP rank.
  * Add helper utilities for packed QKV slicing/restoring and unit tests covering GPT-style and GQA-style QKV layouts.
 
### DDP adapter state dict compatibility

  * Expose the wrapped module from `DistributedDataParallel` and save LoRA adapters from the inner model.
  * This matches the common `model.module.state_dict()` behavior for DDP-wrapped models.
  * Consume a legacy leading `module.` prefix when loading LoRA adapter state dicts.
  * Add test coverage for DDP `module.` prefix compatibility.
  
## Test

The loss values in the LoRA tests fluctuate slightly, which is expected because the tests now use saved fixed initialization values.

<img width="791" height="1562" alt="image" src="https://github.com/user-attachments/assets/785f88a2-a56c-44ac-8625-da5d9636ebaa" />

The performance variance is concentrated in the `lora/bfloat16/distopt` tests and is treated as normal fluctuation.

<img width="1282" height="1454" alt="image" src="https://github.com/user-attachments/assets/f011de50-7384-4a8b-a7a6-f9709e8cd45b" />
