### PR TITLE
test: refactor dtype dispatch compile-fail test target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,28 +217,12 @@ link_infini_train_exe(test_dtype_dispatch)
 set(DTYPE_DISPATCH_COMPILE_FAIL_SOURCE
   ${PROJECT_SOURCE_DIR}/test/dtype/test_dtype_dispatch_compile_fail.cc)
 
-try_compile(DTYPE_DISPATCH_COMPILE_UNEXPECTEDLY_SUCCEEDED
-  ${CMAKE_BINARY_DIR}/CMakeFiles/try_compile_dtype_dispatch_missing_map
-  SOURCES ${DTYPE_DISPATCH_COMPILE_FAIL_SOURCE}
-  CMAKE_FLAGS
-    "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"
-    "-DCMAKE_CXX_STANDARD_REQUIRED=ON"
-    "-DCMAKE_CXX_EXTENSIONS=OFF"
-    "-DCMAKE_CXX_FLAGS=-I${PROJECT_SOURCE_DIR}"
-  OUTPUT_VARIABLE DTYPE_DISPATCH_TRY_COMPILE_OUTPUT
+add_executable(test_dtype_dispatch_compile_fail EXCLUDE_FROM_ALL
+  ${DTYPE_DISPATCH_COMPILE_FAIL_SOURCE}
 )
 
-if(DTYPE_DISPATCH_COMPILE_UNEXPECTEDLY_SUCCEEDED)
-  message(FATAL_ERROR
-    "dtype dispatch compile-fail test unexpectedly succeeded.\n"
-    "Source: ${DTYPE_DISPATCH_COMPILE_FAIL_SOURCE}\n"
-    "Output:\n${DTYPE_DISPATCH_TRY_COMPILE_OUTPUT}")
-endif()
-
-add_custom_target(test_dtype_dispatch_compile_fail
-  COMMAND ${CMAKE_COMMAND} -E echo
-    "dtype dispatch compile-fail check passed (missing dtype registration correctly fails to compile)."
-  VERBATIM
+target_include_directories(test_dtype_dispatch_compile_fail PRIVATE
+  ${PROJECT_SOURCE_DIR}
 )
 
-add_dependencies(test_dtype_dispatch test_dtype_dispatch_compile_fail)
+link_infini_train_exe(test_dtype_dispatch_compile_fail)


### PR DESCRIPTION
修复现有 compile-fail test 存在的报错噪声的问题。

正常构建：

```
cmake -DUSE_CUDA=ON -DUSE_NCCL=ON ..
make -j
```

不会编译该负向测试。

当需要查看 compile-fail 报错时，手动执行：

```
cmake -DUSE_CUDA=ON -DUSE_NCCL=ON ..
make -j test_dtype_dispatch_compile_fail
```

现在的报错信息如下：
<img width="2147" height="1410" alt="image" src="https://github.com/user-attachments/assets/f670a362-16ff-4451-8d34-a844db1d361b" />