### PR TITLE
fix: remove unused 'ModelType'

### DIFF
--- a/infini_train/include/nn/modules/transformer/transformer_config.h
+++ b/infini_train/include/nn/modules/transformer/transformer_config.h
@@ -5,11 +5,6 @@
 
 namespace infini_train::nn {
 
-enum class ModelType {
-    kGPT2,   // GPT-2
-    kLLaMA3, // LLaMA3
-};
-
 enum class AttentionType {
     kStandard, // Standard attention
     kRoPE      // Rotary Position Embedding


### PR DESCRIPTION
删除之前遗留的ModelType未使用