### PR TITLE
refactor: add backend-neutral GEMM params

### DIFF
--- a/infini_train/src/kernels/common/gemm.h
+++ b/infini_train/src/kernels/common/gemm.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "infini_train/include/datatype.h"
+#include "infini_train/include/device.h"
+
+namespace infini_train::kernels {
+
+enum class GemmTranspose : int {
+    kNoTranspose = 0,
+    kTranspose = 1,
+};
+
+/**
+ * Parameter bundle for a single GEMM call:
+ *   C = alpha * op(A) * op(B) + beta * C
+ *
+ * batch_count == 1 describes a non-batched GEMM. batch_count > 1 describes a
+ * strided-batched GEMM. When batch_count == 1, stride_a/b/c are unused and must
+ * be left at 0.
+ */
+struct GemmParams {
+    GemmTranspose trans_a = GemmTranspose::kNoTranspose;
+    GemmTranspose trans_b = GemmTranspose::kNoTranspose;
+
+    int m = 0; // rows of op(A) and C
+    int n = 0; // cols of op(B) and C
+    int k = 0; // cols of op(A) == rows of op(B)
+
+    const void *A = nullptr;
+    int lda = 0;
+    const void *B = nullptr;
+    int ldb = 0;
+    void *C = nullptr;
+    int ldc = 0;
+
+    float alpha = 1.0f;
+    float beta = 0.0f;
+
+    int batch_count = 1;
+    long long stride_a = 0;
+    long long stride_b = 0;
+    long long stride_c = 0;
+
+    DataType input_dtype;
+    DataType output_dtype;
+};
+
+} // namespace infini_train::kernels

--- a/infini_train/src/kernels/cuda/common/gemm.cu
+++ b/infini_train/src/kernels/cuda/common/gemm.cu
@@ -7,12 +7,24 @@
 #include "infini_train/include/common/cuda/common_cuda.h"
 #include "infini_train/include/core/runtime/device_guard.h"
 #include "infini_train/include/datatype.h"
+#include "infini_train/include/dispatcher.h"
 
 #include "infini_train/src/core/runtime/cuda/cuda_runtime_common.h"
 
 namespace infini_train::kernels::cuda {
 
 namespace {
+
+cublasOperation_t ToCublasOperation(GemmTranspose op) {
+    switch (op) {
+    case GemmTranspose::kNoTranspose:
+        return CUBLAS_OP_N;
+    case GemmTranspose::kTranspose:
+        return CUBLAS_OP_T;
+    }
+    LOG(FATAL) << "Gemm: unsupported transpose flag " << static_cast<int>(op);
+    return CUBLAS_OP_N; // unreachable
+}
 
 cudaDataType_t ToCudaDataType(DataType dt) {
     switch (dt) {
@@ -23,14 +35,14 @@ cudaDataType_t ToCudaDataType(DataType dt) {
     case DataType::kFLOAT16:
         return CUDA_R_16F;
     default:
-        LOG(FATAL) << "GemmCuda: unsupported DataType " << static_cast<int>(dt);
+        LOG(FATAL) << "Gemm: unsupported DataType " << static_cast<int>(dt);
         return CUDA_R_32F; // unreachable
     }
 }
 
 } // namespace
 
-void GemmCuda(const Device &device, const GemmParams &p) {
+void Gemm(Device device, GemmParams p) {
     const cublasHandle_t blas_handle = dynamic_cast<infini_train::core::cuda::CudaBlasHandle *>(
                                            infini_train::core::GetDeviceGuardImpl(device.type())->GetBlasHandle(device))
                                            ->cublas_handle();
@@ -43,6 +55,8 @@ void GemmCuda(const Device &device, const GemmParams &p) {
         DCHECK_EQ(p.stride_c, 0LL);
     }
 
+    const cublasOperation_t trans_a = ToCublasOperation(p.trans_a);
+    const cublasOperation_t trans_b = ToCublasOperation(p.trans_b);
     const cudaDataType_t type_a = ToCudaDataType(p.input_dtype);
     const cudaDataType_t type_b = ToCudaDataType(p.input_dtype);
     const cudaDataType_t type_c = ToCudaDataType(p.output_dtype);
@@ -51,10 +65,10 @@ void GemmCuda(const Device &device, const GemmParams &p) {
     const cublasComputeType_t compute_type = CUBLAS_COMPUTE_32F;
 
     if (p.batch_count == 1) {
-        CUBLAS_CHECK(cublasGemmEx(blas_handle, p.trans_a, p.trans_b, p.m, p.n, p.k, &p.alpha, p.A, type_a, p.lda, p.B,
+        CUBLAS_CHECK(cublasGemmEx(blas_handle, trans_a, trans_b, p.m, p.n, p.k, &p.alpha, p.A, type_a, p.lda, p.B,
                                   type_b, p.ldb, &p.beta, p.C, type_c, p.ldc, compute_type, CUBLAS_GEMM_DEFAULT));
     } else {
-        CUBLAS_CHECK(cublasGemmStridedBatchedEx(blas_handle, p.trans_a, p.trans_b, p.m, p.n, p.k, &p.alpha, p.A, type_a,
+        CUBLAS_CHECK(cublasGemmStridedBatchedEx(blas_handle, trans_a, trans_b, p.m, p.n, p.k, &p.alpha, p.A, type_a,
                                                 p.lda, p.stride_a, p.B, type_b, p.ldb, p.stride_b, &p.beta, p.C, type_c,
                                                 p.ldc, p.stride_c, p.batch_count, compute_type, CUBLAS_GEMM_DEFAULT));
     }
@@ -64,7 +78,10 @@ void SgemvCuda(const Device &device, const SgemvParams &p) {
     const cublasHandle_t blas_handle = dynamic_cast<infini_train::core::cuda::CudaBlasHandle *>(
                                            infini_train::core::GetDeviceGuardImpl(device.type())->GetBlasHandle(device))
                                            ->cublas_handle();
-    CUBLAS_CHECK(cublasSgemv(blas_handle, p.trans, p.m, p.n, &p.alpha, p.A, p.lda, p.x, p.incx, &p.beta, p.y, p.incy));
+    CUBLAS_CHECK(cublasSgemv(blas_handle, ToCublasOperation(p.trans), p.m, p.n, &p.alpha, p.A, p.lda, p.x, p.incx,
+                             &p.beta, p.y, p.incy));
 }
 
 } // namespace infini_train::kernels::cuda
+
+REGISTER_KERNEL(infini_train::Device::DeviceType::kCUDA, Gemm, infini_train::kernels::cuda::Gemm)

--- a/infini_train/src/kernels/cuda/common/gemm.cuh
+++ b/infini_train/src/kernels/cuda/common/gemm.cuh
@@ -1,58 +1,15 @@
 #pragma once
 
-#include <cublas_v2.h>
-
-#include "infini_train/include/datatype.h"
-#include "infini_train/include/device.h"
+#include "infini_train/src/kernels/common/gemm.h"
 
 namespace infini_train::kernels::cuda {
 
 /**
- * Parameter bundle for a single GEMM call:
- *   C = alpha * op(A) * op(B) + beta * C
+ * Execute the GEMM described by `p` via the CUDA backend.
  *
- * batch_count == 1  →  non-batched path  (cublasGemmEx)
- * batch_count  > 1  →  strided-batched   (cublasGemmStridedBatchedEx)
- *
- * When batch_count == 1, stride_a/b/c are unused and must be left at 0.
+ * Arguments are passed by value to match Dispatcher function erasure reliably.
  */
-struct GemmParams {
-    cublasOperation_t trans_a = CUBLAS_OP_N;
-    cublasOperation_t trans_b = CUBLAS_OP_N;
-
-    int m = 0; // rows of op(A) and C
-    int n = 0; // cols of op(B) and C
-    int k = 0; // cols of op(A) == rows of op(B)
-
-    const void *A = nullptr;
-    int lda = 0;
-    const void *B = nullptr;
-    int ldb = 0;
-    void *C = nullptr;
-    int ldc = 0;
-
-    float alpha = 1.0f;
-    float beta = 0.0f;
-
-    // batch_count=1: non-batched (Linear path); stride_a/b/c must be 0
-    // batch_count>1: strided-batched (Matmul path)
-    int batch_count = 1;
-    long long stride_a = 0;
-    long long stride_b = 0;
-    long long stride_c = 0;
-
-    DataType input_dtype;  // dtype of A and B
-    DataType output_dtype; // dtype of C (may differ, e.g. bf16 in → fp32 out)
-};
-
-/**
- * Execute the GEMM described by `p` via cuBLAS.
- * Dispatches to cublasGemmEx (batch_count==1) or
- * cublasGemmStridedBatchedEx (batch_count>1).
- * Uses CUBLAS_COMPUTE_32F for all input dtypes to ensure precision.
- * Aborts on cuBLAS error (via CUBLAS_CHECK / LOG(FATAL)).
- */
-void GemmCuda(const Device &device, const GemmParams &p);
+void Gemm(Device device, GemmParams p);
 
 /**
  * Parameter bundle for a single SGEMV call (fp32 only):
@@ -62,7 +19,7 @@ void GemmCuda(const Device &device, const GemmParams &p);
  * where m_phys and n_phys are the physical (pre-transpose) row/col counts of A.
  */
 struct SgemvParams {
-    cublasOperation_t trans = CUBLAS_OP_N;
+    GemmTranspose trans = GemmTranspose::kNoTranspose;
     int m = 0;
     int n = 0;
     const float *A = nullptr;

--- a/infini_train/src/kernels/cuda/linear.cu
+++ b/infini_train/src/kernels/cuda/linear.cu
@@ -83,10 +83,10 @@ std::shared_ptr<Tensor> LinearForward(const std::shared_ptr<Tensor> &input, cons
     }
 
     // When bs==1 and fp32, use cublasSgemv (more efficient than GEMM for matrix-vector).
-    // cublasSgemv does not support bf16, so bf16 falls through to GemmCuda.
+    // cublasSgemv does not support bf16, so bf16 falls through to Gemm.
     if (bs == 1 && dtype == DataType::kFLOAT32) {
         SgemvCuda(device, SgemvParams{
-                              .trans = transpose ? CUBLAS_OP_T : CUBLAS_OP_N,
+                              .trans = transpose ? GemmTranspose::kTranspose : GemmTranspose::kNoTranspose,
                               .m = static_cast<int>(transpose ? in_features : out_features),
                               .n = static_cast<int>(transpose ? out_features : in_features),
                               .A = static_cast<const float *>(weight->DataPtr()),
@@ -110,24 +110,26 @@ std::shared_ptr<Tensor> LinearForward(const std::shared_ptr<Tensor> &input, cons
         // C = output.T[out_features, bs]
         // A = weight.T[out_features, in_features]
         // B = input.T[in_features, bs]
-        GemmCuda(device, GemmParams{
-                             .trans_a = transpose ? CUBLAS_OP_T : CUBLAS_OP_N,
-                             .trans_b = CUBLAS_OP_N,
-                             .m = static_cast<int>(out_features),
-                             .n = static_cast<int>(bs),
-                             .k = static_cast<int>(in_features),
-                             .A = weight->DataPtr(),
-                             .lda = static_cast<int>(transpose ? in_features : out_features),
-                             .B = input->DataPtr(),
-                             .ldb = static_cast<int>(in_features),
-                             .C = output->DataPtr(),
-                             .ldc = static_cast<int>(out_features),
-                             .alpha = 1.0f,
-                             .beta = 1.0f, // bias already written into output; beta=1 accumulates
-                             .batch_count = 1,
-                             .input_dtype = dtype,
-                             .output_dtype = dtype,
-                         });
+        Dispatcher::Instance().Call<void>(
+            {device.type(), "Gemm"}, device,
+            GemmParams{
+                .trans_a = transpose ? GemmTranspose::kTranspose : GemmTranspose::kNoTranspose,
+                .trans_b = GemmTranspose::kNoTranspose,
+                .m = static_cast<int>(out_features),
+                .n = static_cast<int>(bs),
+                .k = static_cast<int>(in_features),
+                .A = weight->DataPtr(),
+                .lda = static_cast<int>(transpose ? in_features : out_features),
+                .B = input->DataPtr(),
+                .ldb = static_cast<int>(in_features),
+                .C = output->DataPtr(),
+                .ldc = static_cast<int>(out_features),
+                .alpha = 1.0f,
+                .beta = 1.0f, // bias already written into output; beta=1 accumulates
+                .batch_count = 1,
+                .input_dtype = dtype,
+                .output_dtype = dtype,
+            });
     }
 
     return output;
@@ -172,19 +174,20 @@ std::shared_ptr<Tensor> LinearBackwardInput(const std::shared_ptr<Tensor> &weigh
     auto grad_input = std::make_shared<Tensor>(input_dims, output_dtype, grad_output->GetDevice());
 
     // When bs==1 and fp32, use cublasSgemv (more efficient than GEMM for matrix-vector).
-    // cublasSgemv does not support bf16, so bf16 falls through to GemmCuda.
+    // cublasSgemv does not support bf16, so bf16 falls through to Gemm.
     if (bs == 1 && compute_dtype == DataType::kFLOAT32) {
-        SgemvCuda(grad_output->GetDevice(), SgemvParams{
-                                                .trans = transpose ? CUBLAS_OP_N : CUBLAS_OP_T,
-                                                .m = static_cast<int>(transpose ? in_features : out_features),
-                                                .n = static_cast<int>(transpose ? out_features : in_features),
-                                                .A = static_cast<const float *>(weight->DataPtr()),
-                                                .lda = static_cast<int>(transpose ? in_features : out_features),
-                                                .x = static_cast<const float *>(grad_output_promoted->DataPtr()),
-                                                .y = static_cast<float *>(grad_input->DataPtr()),
-                                                .alpha = 1.0f,
-                                                .beta = 0.0f,
-                                            });
+        SgemvCuda(grad_output->GetDevice(),
+                  SgemvParams{
+                      .trans = transpose ? GemmTranspose::kNoTranspose : GemmTranspose::kTranspose,
+                      .m = static_cast<int>(transpose ? in_features : out_features),
+                      .n = static_cast<int>(transpose ? out_features : in_features),
+                      .A = static_cast<const float *>(weight->DataPtr()),
+                      .lda = static_cast<int>(transpose ? in_features : out_features),
+                      .x = static_cast<const float *>(grad_output_promoted->DataPtr()),
+                      .y = static_cast<float *>(grad_input->DataPtr()),
+                      .alpha = 1.0f,
+                      .beta = 0.0f,
+                  });
     } else {
         // - if transpose:
         // weight is [out_features, in_features] here
@@ -199,24 +202,26 @@ std::shared_ptr<Tensor> LinearBackwardInput(const std::shared_ptr<Tensor> &weigh
         // C = d_input.T[in_features, bs]
         // A = weight.T[out_features, in_features]
         // B = d_output.T[out_features, bs]
-        GemmCuda(grad_output->GetDevice(), GemmParams{
-                                               .trans_a = transpose ? CUBLAS_OP_N : CUBLAS_OP_T,
-                                               .trans_b = CUBLAS_OP_N,
-                                               .m = static_cast<int>(in_features),
-                                               .n = static_cast<int>(bs),
-                                               .k = static_cast<int>(out_features),
-                                               .A = weight->DataPtr(),
-                                               .lda = static_cast<int>(transpose ? in_features : out_features),
-                                               .B = grad_output_promoted->DataPtr(),
-                                               .ldb = static_cast<int>(out_features),
-                                               .C = grad_input->DataPtr(),
-                                               .ldc = static_cast<int>(in_features),
-                                               .alpha = 1.0f,
-                                               .beta = 0.0f,
-                                               .batch_count = 1,
-                                               .input_dtype = compute_dtype,
-                                               .output_dtype = output_dtype,
-                                           });
+        Dispatcher::Instance().Call<void>(
+            {grad_output->GetDevice().type(), "Gemm"}, grad_output->GetDevice(),
+            GemmParams{
+                .trans_a = transpose ? GemmTranspose::kNoTranspose : GemmTranspose::kTranspose,
+                .trans_b = GemmTranspose::kNoTranspose,
+                .m = static_cast<int>(in_features),
+                .n = static_cast<int>(bs),
+                .k = static_cast<int>(out_features),
+                .A = weight->DataPtr(),
+                .lda = static_cast<int>(transpose ? in_features : out_features),
+                .B = grad_output_promoted->DataPtr(),
+                .ldb = static_cast<int>(out_features),
+                .C = grad_input->DataPtr(),
+                .ldc = static_cast<int>(in_features),
+                .alpha = 1.0f,
+                .beta = 0.0f,
+                .batch_count = 1,
+                .input_dtype = compute_dtype,
+                .output_dtype = output_dtype,
+            });
     }
 
     return grad_input;
@@ -258,24 +263,25 @@ std::shared_ptr<Tensor> LinearBackwardWeight(const std::shared_ptr<Tensor> &inpu
     const int lda = static_cast<int>(transpose ? in_features : out_features);
     const int ldb = static_cast<int>(transpose ? out_features : in_features);
 
-    GemmCuda(grad_output->GetDevice(), GemmParams{
-                                           .trans_a = CUBLAS_OP_N,
-                                           .trans_b = CUBLAS_OP_T,
-                                           .m = static_cast<int>(transpose ? in_features : out_features),
-                                           .n = static_cast<int>(transpose ? out_features : in_features),
-                                           .k = static_cast<int>(bs),
-                                           .A = a,
-                                           .lda = lda,
-                                           .B = b,
-                                           .ldb = ldb,
-                                           .C = grad_weight->DataPtr(),
-                                           .ldc = static_cast<int>(transpose ? in_features : out_features),
-                                           .alpha = 1.0f,
-                                           .beta = 0.0f,
-                                           .batch_count = 1,
-                                           .input_dtype = compute_dtype,
-                                           .output_dtype = output_dtype,
-                                       });
+    Dispatcher::Instance().Call<void>({grad_output->GetDevice().type(), "Gemm"}, grad_output->GetDevice(),
+                                      GemmParams{
+                                          .trans_a = GemmTranspose::kNoTranspose,
+                                          .trans_b = GemmTranspose::kTranspose,
+                                          .m = static_cast<int>(transpose ? in_features : out_features),
+                                          .n = static_cast<int>(transpose ? out_features : in_features),
+                                          .k = static_cast<int>(bs),
+                                          .A = a,
+                                          .lda = lda,
+                                          .B = b,
+                                          .ldb = ldb,
+                                          .C = grad_weight->DataPtr(),
+                                          .ldc = static_cast<int>(transpose ? in_features : out_features),
+                                          .alpha = 1.0f,
+                                          .beta = 0.0f,
+                                          .batch_count = 1,
+                                          .input_dtype = compute_dtype,
+                                          .output_dtype = output_dtype,
+                                      });
 
     return grad_weight;
 }

--- a/infini_train/src/kernels/cuda/matmul.cu
+++ b/infini_train/src/kernels/cuda/matmul.cu
@@ -48,27 +48,28 @@ std::shared_ptr<Tensor> MatmulForward(const std::shared_ptr<Tensor> &input, cons
     // A = other.T[*, n, k]
     // B = input.T[*, k, m]
     // NOTE(zbl): the last cublasGemmAlgo_t param has no effect on GPU arch >= sm_80(Ampere)
-    GemmCuda(device, GemmParams{
-                         .trans_a = CUBLAS_OP_N,
-                         .trans_b = CUBLAS_OP_N,
-                         .m = static_cast<int>(n),
-                         .n = static_cast<int>(m),
-                         .k = static_cast<int>(k),
-                         .A = other->DataPtr(),
-                         .lda = static_cast<int>(n),
-                         .B = input->DataPtr(),
-                         .ldb = static_cast<int>(k),
-                         .C = output->DataPtr(),
-                         .ldc = static_cast<int>(n),
-                         .alpha = 1.0f,
-                         .beta = 0.0f,
-                         .batch_count = static_cast<int>(bs),
-                         .stride_a = bs > 1 ? n * k : 0,
-                         .stride_b = bs > 1 ? k * m : 0,
-                         .stride_c = bs > 1 ? m * n : 0,
-                         .input_dtype = dtype,
-                         .output_dtype = dtype,
-                     });
+    Dispatcher::Instance().Call<void>({device.type(), "Gemm"}, device,
+                                      GemmParams{
+                                          .trans_a = GemmTranspose::kNoTranspose,
+                                          .trans_b = GemmTranspose::kNoTranspose,
+                                          .m = static_cast<int>(n),
+                                          .n = static_cast<int>(m),
+                                          .k = static_cast<int>(k),
+                                          .A = other->DataPtr(),
+                                          .lda = static_cast<int>(n),
+                                          .B = input->DataPtr(),
+                                          .ldb = static_cast<int>(k),
+                                          .C = output->DataPtr(),
+                                          .ldc = static_cast<int>(n),
+                                          .alpha = 1.0f,
+                                          .beta = 0.0f,
+                                          .batch_count = static_cast<int>(bs),
+                                          .stride_a = bs > 1 ? n * k : 0,
+                                          .stride_b = bs > 1 ? k * m : 0,
+                                          .stride_c = bs > 1 ? m * n : 0,
+                                          .input_dtype = dtype,
+                                          .output_dtype = dtype,
+                                      });
 
     return output;
 }
@@ -118,27 +119,28 @@ std::shared_ptr<Tensor> MatmulBackwardInput(const std::shared_ptr<Tensor> &other
     // C = grad_input.T[*, k, m]
     // A = other.T[*, n, k]
     // B = grad_output.T[*, n, m]
-    GemmCuda(device, GemmParams{
-                         .trans_a = CUBLAS_OP_T,
-                         .trans_b = CUBLAS_OP_N,
-                         .m = static_cast<int>(k),
-                         .n = static_cast<int>(m),
-                         .k = static_cast<int>(n),
-                         .A = other->DataPtr(),
-                         .lda = static_cast<int>(n),
-                         .B = grad_output_promoted->DataPtr(),
-                         .ldb = static_cast<int>(n),
-                         .C = grad_input->DataPtr(),
-                         .ldc = static_cast<int>(k),
-                         .alpha = 1.0f,
-                         .beta = 0.0f,
-                         .batch_count = static_cast<int>(bs),
-                         .stride_a = bs > 1 ? k * n : 0,
-                         .stride_b = bs > 1 ? n * m : 0,
-                         .stride_c = bs > 1 ? m * k : 0,
-                         .input_dtype = compute_dtype,
-                         .output_dtype = output_dtype,
-                     });
+    Dispatcher::Instance().Call<void>({device.type(), "Gemm"}, device,
+                                      GemmParams{
+                                          .trans_a = GemmTranspose::kTranspose,
+                                          .trans_b = GemmTranspose::kNoTranspose,
+                                          .m = static_cast<int>(k),
+                                          .n = static_cast<int>(m),
+                                          .k = static_cast<int>(n),
+                                          .A = other->DataPtr(),
+                                          .lda = static_cast<int>(n),
+                                          .B = grad_output_promoted->DataPtr(),
+                                          .ldb = static_cast<int>(n),
+                                          .C = grad_input->DataPtr(),
+                                          .ldc = static_cast<int>(k),
+                                          .alpha = 1.0f,
+                                          .beta = 0.0f,
+                                          .batch_count = static_cast<int>(bs),
+                                          .stride_a = bs > 1 ? k * n : 0,
+                                          .stride_b = bs > 1 ? n * m : 0,
+                                          .stride_c = bs > 1 ? m * k : 0,
+                                          .input_dtype = compute_dtype,
+                                          .output_dtype = output_dtype,
+                                      });
 
     return grad_input;
 }
@@ -187,27 +189,28 @@ std::shared_ptr<Tensor> MatmulBackwardOther(const std::shared_ptr<Tensor> &input
     // C = grad_other.T[*, n, k]
     // A = grad_output.T[*, n, m]
     // B = input.T[*, k, m]
-    GemmCuda(device, GemmParams{
-                         .trans_a = CUBLAS_OP_N,
-                         .trans_b = CUBLAS_OP_T,
-                         .m = static_cast<int>(n),
-                         .n = static_cast<int>(k),
-                         .k = static_cast<int>(m),
-                         .A = grad_output_promoted->DataPtr(),
-                         .lda = static_cast<int>(n),
-                         .B = input1->DataPtr(),
-                         .ldb = static_cast<int>(k),
-                         .C = grad_other->DataPtr(),
-                         .ldc = static_cast<int>(n),
-                         .alpha = 1.0f,
-                         .beta = 0.0f,
-                         .batch_count = static_cast<int>(bs),
-                         .stride_a = bs > 1 ? n * m : 0,
-                         .stride_b = bs > 1 ? k * m : 0,
-                         .stride_c = bs > 1 ? n * k : 0,
-                         .input_dtype = compute_dtype,
-                         .output_dtype = output_dtype,
-                     });
+    Dispatcher::Instance().Call<void>({device.type(), "Gemm"}, device,
+                                      GemmParams{
+                                          .trans_a = GemmTranspose::kNoTranspose,
+                                          .trans_b = GemmTranspose::kTranspose,
+                                          .m = static_cast<int>(n),
+                                          .n = static_cast<int>(k),
+                                          .k = static_cast<int>(m),
+                                          .A = grad_output_promoted->DataPtr(),
+                                          .lda = static_cast<int>(n),
+                                          .B = input1->DataPtr(),
+                                          .ldb = static_cast<int>(k),
+                                          .C = grad_other->DataPtr(),
+                                          .ldc = static_cast<int>(n),
+                                          .alpha = 1.0f,
+                                          .beta = 0.0f,
+                                          .batch_count = static_cast<int>(bs),
+                                          .stride_a = bs > 1 ? n * m : 0,
+                                          .stride_b = bs > 1 ? k * m : 0,
+                                          .stride_c = bs > 1 ? n * k : 0,
+                                          .input_dtype = compute_dtype,
+                                          .output_dtype = output_dtype,
+                                      });
 
     return grad_other;
 }

--- a/infini_train/src/kernels/cuda/outer.cu
+++ b/infini_train/src/kernels/cuda/outer.cu
@@ -39,24 +39,25 @@ std::shared_ptr<Tensor> OuterForward(const std::shared_ptr<Tensor> &input, const
     // output[M, N] = input[M, 1] * other.T[1, N]
     // output.T[N, M] = other[N, 1] * input.T[1, M]
     // This is a GEMM with k=1: C[N,M] = A[N,1] * B[1,M]
-    GemmCuda(device, GemmParams{
-                         .trans_a = CUBLAS_OP_N,
-                         .trans_b = CUBLAS_OP_N,
-                         .m = static_cast<int>(N),
-                         .n = static_cast<int>(M),
-                         .k = 1,
-                         .A = other->DataPtr(),
-                         .lda = static_cast<int>(N),
-                         .B = input->DataPtr(),
-                         .ldb = 1,
-                         .C = output->DataPtr(),
-                         .ldc = static_cast<int>(N),
-                         .alpha = 1.0f,
-                         .beta = 0.0f,
-                         .batch_count = 1,
-                         .input_dtype = dtype,
-                         .output_dtype = dtype,
-                     });
+    Dispatcher::Instance().Call<void>({device.type(), "Gemm"}, device,
+                                      GemmParams{
+                                          .trans_a = GemmTranspose::kNoTranspose,
+                                          .trans_b = GemmTranspose::kNoTranspose,
+                                          .m = static_cast<int>(N),
+                                          .n = static_cast<int>(M),
+                                          .k = 1,
+                                          .A = other->DataPtr(),
+                                          .lda = static_cast<int>(N),
+                                          .B = input->DataPtr(),
+                                          .ldb = 1,
+                                          .C = output->DataPtr(),
+                                          .ldc = static_cast<int>(N),
+                                          .alpha = 1.0f,
+                                          .beta = 0.0f,
+                                          .batch_count = 1,
+                                          .input_dtype = dtype,
+                                          .output_dtype = dtype,
+                                      });
 
     return output;
 }
@@ -98,7 +99,7 @@ std::tuple<std::shared_ptr<Tensor>, std::shared_ptr<Tensor>> OuterBackward(const
     case DataType::kFLOAT32: {
         // grad_input[M] = grad_output[M, N] × other[N]
         SgemvCuda(device, SgemvParams{
-                              .trans = CUBLAS_OP_T,
+                              .trans = GemmTranspose::kTranspose,
                               .m = static_cast<int>(N),
                               .n = static_cast<int>(M),
                               .A = static_cast<const float *>(grad_output_promoted->DataPtr()),
@@ -109,7 +110,7 @@ std::tuple<std::shared_ptr<Tensor>, std::shared_ptr<Tensor>> OuterBackward(const
 
         // grad_other[N] = grad_output.T[N, M] × input[M]
         SgemvCuda(device, SgemvParams{
-                              .trans = CUBLAS_OP_N,
+                              .trans = GemmTranspose::kNoTranspose,
                               .m = static_cast<int>(N),
                               .n = static_cast<int>(M),
                               .A = static_cast<const float *>(grad_output_promoted->DataPtr()),
@@ -120,51 +121,53 @@ std::tuple<std::shared_ptr<Tensor>, std::shared_ptr<Tensor>> OuterBackward(const
         break;
     }
     case DataType::kBFLOAT16: {
-        // bf16: cublasSgemv does not support bf16; use GemmCuda (GEMM with k=M or k=N).
+        // bf16: cublasSgemv does not support bf16; use Gemm (GEMM with k=M or k=N).
 
         // grad_input[M] = grad_output[M, N] × other[N]
         // grad_input.T[1, M] = other.T[1, N] × grad_output.T[N, M]
         // C[1,M] = A[1,N] * B[N,M]
-        GemmCuda(device, GemmParams{
-                             .trans_a = CUBLAS_OP_N,
-                             .trans_b = CUBLAS_OP_N,
-                             .m = 1,
-                             .n = static_cast<int>(M),
-                             .k = static_cast<int>(N),
-                             .A = other_promoted->DataPtr(),
-                             .lda = 1,
-                             .B = grad_output_promoted->DataPtr(),
-                             .ldb = static_cast<int>(N),
-                             .C = grad_input->DataPtr(),
-                             .ldc = 1,
-                             .alpha = 1.0f,
-                             .beta = 0.0f,
-                             .batch_count = 1,
-                             .input_dtype = promoted_type,
-                             .output_dtype = output_dtype,
-                         });
+        Dispatcher::Instance().Call<void>({device.type(), "Gemm"}, device,
+                                          GemmParams{
+                                              .trans_a = GemmTranspose::kNoTranspose,
+                                              .trans_b = GemmTranspose::kNoTranspose,
+                                              .m = 1,
+                                              .n = static_cast<int>(M),
+                                              .k = static_cast<int>(N),
+                                              .A = other_promoted->DataPtr(),
+                                              .lda = 1,
+                                              .B = grad_output_promoted->DataPtr(),
+                                              .ldb = static_cast<int>(N),
+                                              .C = grad_input->DataPtr(),
+                                              .ldc = 1,
+                                              .alpha = 1.0f,
+                                              .beta = 0.0f,
+                                              .batch_count = 1,
+                                              .input_dtype = promoted_type,
+                                              .output_dtype = output_dtype,
+                                          });
 
         // grad_other[N] = grad_output.T[N, M] × input[M]
         // grad_other.T[1, N] = input.T[1, M] × grad_output[M, N]
         // C[1,N] = A[1,M] * B[M,N]  (B stored as grad_output.T[N,M], so ldb=N, trans_b=T)
-        GemmCuda(device, GemmParams{
-                             .trans_a = CUBLAS_OP_N,
-                             .trans_b = CUBLAS_OP_T,
-                             .m = 1,
-                             .n = static_cast<int>(N),
-                             .k = static_cast<int>(M),
-                             .A = input_promoted->DataPtr(),
-                             .lda = 1,
-                             .B = grad_output_promoted->DataPtr(),
-                             .ldb = static_cast<int>(N),
-                             .C = grad_other->DataPtr(),
-                             .ldc = 1,
-                             .alpha = 1.0f,
-                             .beta = 0.0f,
-                             .batch_count = 1,
-                             .input_dtype = promoted_type,
-                             .output_dtype = output_dtype,
-                         });
+        Dispatcher::Instance().Call<void>({device.type(), "Gemm"}, device,
+                                          GemmParams{
+                                              .trans_a = GemmTranspose::kNoTranspose,
+                                              .trans_b = GemmTranspose::kTranspose,
+                                              .m = 1,
+                                              .n = static_cast<int>(N),
+                                              .k = static_cast<int>(M),
+                                              .A = input_promoted->DataPtr(),
+                                              .lda = 1,
+                                              .B = grad_output_promoted->DataPtr(),
+                                              .ldb = static_cast<int>(N),
+                                              .C = grad_other->DataPtr(),
+                                              .ldc = 1,
+                                              .alpha = 1.0f,
+                                              .beta = 0.0f,
+                                              .batch_count = 1,
+                                              .input_dtype = promoted_type,
+                                              .output_dtype = output_dtype,
+                                          });
         break;
     }
     default:


### PR DESCRIPTION
## Summary

Refactor the internal CUDA GEMM call path to use a backend-neutral `GemmParams` abstraction.

## Changes

- Add `infini_train/src/kernels/common/gemm.h` for shared GEMM metadata.
- Move `GemmParams` and transpose flags out of CUDA-specific headers.
- Replace direct `cublasOperation_t` usage at GEMM call sites with `GemmTranspose`.
- Register CUDA GEMM through the dispatcher as `Gemm`.
- Route CUDA `linear`, `matmul`, and `outer` GEMM calls through `Dispatcher::Call`.

## Motivation

This separates the framework-level GEMM parameter abstraction from CUDA/cuBLAS details. It makes the existing GEMM interface easier to reuse for future kernel providers without exposing CUDA-specific types such as `cublasOperation_t` in common call sites.

## Test

Ctest结果：
<img width="645" height="216" alt="image" src="https://github.com/user-attachments/assets/b78dbeb3-3a08-4e42-83fc-abab4234e64c" />

<img width="673" height="230" alt="image" src="https://github.com/user-attachments/assets/41038e3f-3fae-41bb-bc85-9c99a1702625" />

精度对比：
<img width="1127" height="336" alt="image" src="https://github.com/user-attachments/assets/8f8a5541-a8e6-46e2-b3db-22e70df7094b" />

性能对比：（波动）
<img width="1200" height="1299" alt="image" src="https://github.com/user-attachments/assets/d629e843-99fe-4bc4-860a-43357f92d567" />

