### PR TITLE
feat: add saved tensor hooks

### DIFF
--- a/infini_train/include/autograd/function.h
+++ b/infini_train/include/autograd/function.h
@@ -21,6 +21,14 @@ public:
     using FunctionPostHook = std::function<void(Function *, const std::vector<std::shared_ptr<Tensor>> &,
                                                 const std::vector<std::shared_ptr<Tensor>> &)>;
 
+    using SavedTensorPackHook = std::function<std::shared_ptr<void>(const std::shared_ptr<Tensor> &)>;
+    using SavedTensorUnpackHook = std::function<std::shared_ptr<Tensor>(const std::shared_ptr<void> &)>;
+
+    struct SavedTensorHooks {
+        SavedTensorPackHook pack;
+        SavedTensorUnpackHook unpack;
+    };
+
     static constexpr char kUndefinedType[] = "Undefined";
 
     Function() : type_(kUndefinedType) {}
@@ -45,8 +53,31 @@ public:
 
     const std::string &type() const { return type_; }
 
+    void SaveForBackward(const std::vector<std::shared_ptr<Tensor>> &tensors);
+    size_t SavedTensorsSize() const { return saved_tensors_.size(); }
+    std::shared_ptr<Tensor> GetSavedTensor(size_t index) const;
+    std::vector<std::shared_ptr<Tensor>> GetSavedTensors() const;
+
+    class SavedTensorHooksGuard {
+    public:
+        explicit SavedTensorHooksGuard(SavedTensorHooks hooks);
+        ~SavedTensorHooksGuard();
+
+        SavedTensorHooksGuard(const SavedTensorHooksGuard &) = delete;
+        SavedTensorHooksGuard &operator=(const SavedTensorHooksGuard &) = delete;
+
+    private:
+        size_t depth_ = 0;
+    };
+
 protected:
-    std::vector<std::shared_ptr<Tensor>> saved_tensors_;
+    struct SavedTensorEntry {
+        std::shared_ptr<Tensor> tensor;
+        std::shared_ptr<void> hook_state;
+        SavedTensorUnpackHook unpack;
+        bool has_hook = false;
+    };
+    std::vector<SavedTensorEntry> saved_tensors_;
     std::vector<bool> needs_input_grad_;
 
 private:

--- a/infini_train/include/autograd/normalization.h
+++ b/infini_train/include/autograd/normalization.h
@@ -17,8 +17,6 @@ public:
     explicit LayerNorm(float eps) : Function(kType), eps_(eps) {}
 
     std::vector<std::shared_ptr<Tensor>> Forward(const std::vector<std::shared_ptr<Tensor>> &input_tensors) override;
-    void SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_tensors,
-                      const std::vector<std::shared_ptr<Tensor>> &output_tensors) override;
     std::vector<std::shared_ptr<Tensor>> Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) override;
 
 private:

--- a/infini_train/src/autograd/activations.cc
+++ b/infini_train/src/autograd/activations.cc
@@ -17,12 +17,12 @@ std::vector<std::shared_ptr<Tensor>> Sigmoid::Forward(const std::vector<std::sha
 void Sigmoid::SetupContext(const std::vector<std::shared_ptr<Tensor>> &,
                            const std::vector<std::shared_ptr<Tensor>> &output_tensors) {
     const auto &output = output_tensors[0];
-    saved_tensors_ = {output};
+    SaveForBackward({output});
 }
 
 std::vector<std::shared_ptr<Tensor>> Sigmoid::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
-    CHECK_EQ(saved_tensors_.size(), 1);
-    const auto &output = saved_tensors_[0];
+    CHECK_EQ(SavedTensorsSize(), 1);
+    const auto &output = GetSavedTensor(0);
     CHECK_EQ(grad_outputs.size(), 1);
     const auto &grad_output = grad_outputs[0];
 

--- a/infini_train/src/autograd/elementwise.cc
+++ b/infini_train/src/autograd/elementwise.cc
@@ -33,12 +33,12 @@ std::vector<std::shared_ptr<Tensor>> Reciprocal::Forward(const std::vector<std::
 void Reciprocal::SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_tensors,
                               const std::vector<std::shared_ptr<Tensor>> &) {
     const auto &input = input_tensors[0];
-    saved_tensors_ = {input};
+    SaveForBackward({input});
 }
 
 std::vector<std::shared_ptr<Tensor>> Reciprocal::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
-    CHECK_EQ(saved_tensors_.size(), 1);
-    const auto &input = saved_tensors_[0];
+    CHECK_EQ(SavedTensorsSize(), 1);
+    const auto &input = GetSavedTensor(0);
     CHECK_EQ(grad_outputs.size(), 1);
     const auto &grad_output = grad_outputs[0];
 
@@ -57,12 +57,12 @@ std::vector<std::shared_ptr<Tensor>> Sin::Forward(const std::vector<std::shared_
 void Sin::SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_tensors,
                        const std::vector<std::shared_ptr<Tensor>> &) {
     const auto &input = input_tensors[0];
-    saved_tensors_ = {input};
+    SaveForBackward({input});
 }
 
 std::vector<std::shared_ptr<Tensor>> Sin::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
-    CHECK_EQ(saved_tensors_.size(), 1);
-    const auto &input = saved_tensors_[0];
+    CHECK_EQ(SavedTensorsSize(), 1);
+    const auto &input = GetSavedTensor(0);
     CHECK_EQ(grad_outputs.size(), 1);
     const auto &grad_output = grad_outputs[0];
 
@@ -81,12 +81,12 @@ std::vector<std::shared_ptr<Tensor>> Cos::Forward(const std::vector<std::shared_
 void Cos::SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_tensors,
                        const std::vector<std::shared_ptr<Tensor>> &) {
     const auto &input = input_tensors[0];
-    saved_tensors_ = {input};
+    SaveForBackward({input});
 }
 
 std::vector<std::shared_ptr<Tensor>> Cos::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
-    CHECK_EQ(saved_tensors_.size(), 1);
-    const auto &input = saved_tensors_[0];
+    CHECK_EQ(SavedTensorsSize(), 1);
+    const auto &input = GetSavedTensor(0);
     CHECK_EQ(grad_outputs.size(), 1);
     const auto &grad_output = grad_outputs[0];
 
@@ -105,12 +105,12 @@ std::vector<std::shared_ptr<Tensor>> Tanh::Forward(const std::vector<std::shared
 void Tanh::SetupContext(const std::vector<std::shared_ptr<Tensor>> &,
                         const std::vector<std::shared_ptr<Tensor>> &output_tensors) {
     const auto &output = output_tensors[0];
-    saved_tensors_ = {output};
+    SaveForBackward({output});
 }
 
 std::vector<std::shared_ptr<Tensor>> Tanh::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
-    CHECK_EQ(saved_tensors_.size(), 1);
-    const auto &output = saved_tensors_[0];
+    CHECK_EQ(SavedTensorsSize(), 1);
+    const auto &output = GetSavedTensor(0);
     CHECK_EQ(grad_outputs.size(), 1);
     const auto &grad_output = grad_outputs[0];
 
@@ -130,12 +130,12 @@ std::vector<std::shared_ptr<Tensor>> Pow::Forward(const std::vector<std::shared_
 void Pow::SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_tensors,
                        const std::vector<std::shared_ptr<Tensor>> &) {
     const auto &input = input_tensors[0];
-    saved_tensors_ = {input};
+    SaveForBackward({input});
 }
 
 std::vector<std::shared_ptr<Tensor>> Pow::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
-    CHECK_EQ(saved_tensors_.size(), 1);
-    const auto &input = saved_tensors_[0];
+    CHECK_EQ(SavedTensorsSize(), 1);
+    const auto &input = GetSavedTensor(0);
     CHECK_EQ(grad_outputs.size(), 1);
     const auto &grad_output = grad_outputs[0];
 
@@ -155,12 +155,12 @@ std::vector<std::shared_ptr<Tensor>> Rsqrt::Forward(const std::vector<std::share
 void Rsqrt::SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_tensors,
                          const std::vector<std::shared_ptr<Tensor>> &) {
     const auto &input = input_tensors[0];
-    saved_tensors_ = {input};
+    SaveForBackward({input});
 }
 
 std::vector<std::shared_ptr<Tensor>> Rsqrt::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
-    CHECK_EQ(saved_tensors_.size(), 1);
-    const auto &input = saved_tensors_[0];
+    CHECK_EQ(SavedTensorsSize(), 1);
+    const auto &input = GetSavedTensor(0);
     CHECK_EQ(grad_outputs.size(), 1);
     const auto &grad_output = grad_outputs[0];
 
@@ -195,12 +195,12 @@ std::vector<std::shared_ptr<Tensor>> Log::Forward(const std::vector<std::shared_
 void Log::SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_tensors,
                        const std::vector<std::shared_ptr<Tensor>> &) {
     const auto &input = input_tensors[0];
-    saved_tensors_ = {input};
+    SaveForBackward({input});
 }
 
 std::vector<std::shared_ptr<Tensor>> Log::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
-    CHECK_EQ(saved_tensors_.size(), 1);
-    const auto &input = saved_tensors_[0];
+    CHECK_EQ(SavedTensorsSize(), 1);
+    const auto &input = GetSavedTensor(0);
     CHECK_EQ(grad_outputs.size(), 1);
     const auto &grad_output = grad_outputs[0];
 
@@ -455,13 +455,13 @@ void Mul::SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_tensors
                        const std::vector<std::shared_ptr<Tensor>> &) {
     const auto &a = input_tensors[0];
     const auto &b = input_tensors[1];
-    saved_tensors_ = {a, b};
+    SaveForBackward({a, b});
 }
 
 std::vector<std::shared_ptr<Tensor>> Mul::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
-    CHECK_EQ(saved_tensors_.size(), 2);
-    const auto &a = saved_tensors_[0];
-    const auto &b = saved_tensors_[1];
+    CHECK_EQ(SavedTensorsSize(), 2);
+    const auto &a = GetSavedTensor(0);
+    const auto &b = GetSavedTensor(1);
     CHECK_EQ(grad_outputs.size(), 1);
     const auto &grad_output = grad_outputs[0];
 
@@ -500,13 +500,13 @@ void Div::SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_tensors
                        const std::vector<std::shared_ptr<Tensor>> &) {
     const auto &a = input_tensors[0];
     const auto &b = input_tensors[1];
-    saved_tensors_ = {a, b};
+    SaveForBackward({a, b});
 }
 
 std::vector<std::shared_ptr<Tensor>> Div::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
-    CHECK_EQ(saved_tensors_.size(), 2);
-    const auto &a = saved_tensors_[0];
-    const auto &b = saved_tensors_[1];
+    CHECK_EQ(SavedTensorsSize(), 2);
+    const auto &a = GetSavedTensor(0);
+    const auto &b = GetSavedTensor(1);
     CHECK_EQ(grad_outputs.size(), 1);
     const auto &grad_output = grad_outputs[0];
 

--- a/infini_train/src/autograd/function.cc
+++ b/infini_train/src/autograd/function.cc
@@ -15,6 +15,9 @@
 #include "infini_train/include/utils/precision_checker.h"
 
 namespace infini_train::autograd {
+namespace {
+thread_local std::vector<Function::SavedTensorHooks> tls_saved_tensor_hooks;
+} // namespace
 
 std::vector<std::shared_ptr<Tensor>> Function::Apply(const std::vector<std::shared_ptr<Tensor>> &input_tensors) {
     CHECK_GE(input_tensors.size(), 1);
@@ -181,6 +184,59 @@ void Function::BackwardPartial(std::shared_ptr<Tensor> grad_output, int grad_out
             }
         }
         next_functions_.clear();
+    }
+}
+
+void Function::SaveForBackward(const std::vector<std::shared_ptr<Tensor>> &tensors) {
+    saved_tensors_.clear();
+    saved_tensors_.reserve(tensors.size());
+    for (const auto &tensor : tensors) {
+        SavedTensorEntry entry;
+        if (!tensor || tls_saved_tensor_hooks.empty()) {
+            entry.tensor = tensor;
+        } else {
+            const auto &hooks = tls_saved_tensor_hooks.back();
+            if (!hooks.pack && !hooks.unpack) {
+                entry.tensor = tensor;
+            } else {
+                CHECK(hooks.pack && hooks.unpack) << "saved tensor hooks must provide both pack and unpack hooks";
+                entry.hook_state = hooks.pack(tensor);
+                entry.unpack = hooks.unpack;
+                entry.has_hook = true;
+            }
+        }
+        saved_tensors_.push_back(std::move(entry));
+    }
+}
+
+std::shared_ptr<Tensor> Function::GetSavedTensor(size_t index) const {
+    CHECK_LT(index, SavedTensorsSize());
+    const auto &entry = saved_tensors_[index];
+    if (entry.has_hook) {
+        CHECK(entry.unpack) << "saved tensor entry is missing its unpack hook";
+        return entry.unpack(entry.hook_state);
+    }
+    return entry.tensor;
+}
+
+std::vector<std::shared_ptr<Tensor>> Function::GetSavedTensors() const {
+    std::vector<std::shared_ptr<Tensor>> tensors;
+    tensors.reserve(SavedTensorsSize());
+    for (size_t index = 0; index < SavedTensorsSize(); ++index) { tensors.push_back(GetSavedTensor(index)); }
+    return tensors;
+}
+
+Function::SavedTensorHooksGuard::SavedTensorHooksGuard(SavedTensorHooks hooks) {
+    tls_saved_tensor_hooks.push_back(std::move(hooks));
+    depth_ = tls_saved_tensor_hooks.size();
+}
+
+Function::SavedTensorHooksGuard::~SavedTensorHooksGuard() {
+    if (tls_saved_tensor_hooks.size() == depth_) {
+        tls_saved_tensor_hooks.pop_back();
+    } else if (!tls_saved_tensor_hooks.empty()) {
+        LOG(WARNING) << "SavedTensorHooksGuard destroyed out of order.";
+        tls_saved_tensor_hooks.pop_back();
     }
 }
 

--- a/infini_train/src/autograd/linear.cc
+++ b/infini_train/src/autograd/linear.cc
@@ -25,7 +25,7 @@ void Linear::SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_tens
     bool need_weight = needs_input_grad_.size() > 1 && needs_input_grad_[1];
 
     // grad_input needs weight, grad_weight needs input
-    saved_tensors_ = {need_weight ? input : nullptr, need_input ? weight : nullptr};
+    SaveForBackward({need_weight ? input : nullptr, need_input ? weight : nullptr});
 
     transpose_ = true;
     bias_ = input_tensors.size() == 3;
@@ -35,9 +35,9 @@ void Linear::SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_tens
 }
 
 std::vector<std::shared_ptr<Tensor>> Linear::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
-    CHECK_EQ(saved_tensors_.size(), 2);
-    const auto &input = saved_tensors_[0];
-    const auto &weight = saved_tensors_[1];
+    CHECK_EQ(SavedTensorsSize(), 2);
+    const auto &input = GetSavedTensor(0);
+    const auto &weight = GetSavedTensor(1);
     CHECK_EQ(grad_outputs.size(), 1);
     const auto &grad_output = grad_outputs[0];
 

--- a/infini_train/src/autograd/loss.cc
+++ b/infini_train/src/autograd/loss.cc
@@ -19,13 +19,13 @@ void CrossEntropy::SetupContext(const std::vector<std::shared_ptr<Tensor>> &inpu
                                 const std::vector<std::shared_ptr<Tensor>> &) {
     const auto &input = input_tensors[0];
     const auto &target = input_tensors[1];
-    saved_tensors_ = {input, target};
+    SaveForBackward({input, target});
 }
 
 std::vector<std::shared_ptr<Tensor>> CrossEntropy::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
-    CHECK_EQ(saved_tensors_.size(), 2);
-    const auto &input = saved_tensors_[0];
-    const auto &target = saved_tensors_[1];
+    CHECK_EQ(SavedTensorsSize(), 2);
+    const auto &input = GetSavedTensor(0);
+    const auto &target = GetSavedTensor(1);
     CHECK_EQ(grad_outputs.size(), 1);
     const auto &grad_output = grad_outputs[0];
 

--- a/infini_train/src/autograd/matmul.cc
+++ b/infini_train/src/autograd/matmul.cc
@@ -26,16 +26,16 @@ void Matmul::SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_tens
     bool need_grad_input1 = needs_input_grad_.size() > 0 && needs_input_grad_[0];
     bool need_grad_input2 = needs_input_grad_.size() > 1 && needs_input_grad_[1];
 
-    saved_tensors_ = {need_grad_input2 ? input1 : nullptr, need_grad_input1 ? input2 : nullptr};
+    SaveForBackward({need_grad_input2 ? input1 : nullptr, need_grad_input1 ? input2 : nullptr});
     input1_dims_ = input1->Dims();
     input2_dims_ = input2->Dims();
     out_features_ = output->Dims()[0];
 }
 
 std::vector<std::shared_ptr<Tensor>> Matmul::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
-    CHECK_EQ(saved_tensors_.size(), 2);
-    const auto &input1 = saved_tensors_[0];
-    const auto &input2 = saved_tensors_[1];
+    CHECK_EQ(SavedTensorsSize(), 2);
+    const auto &input1 = GetSavedTensor(0);
+    const auto &input2 = GetSavedTensor(1);
     CHECK_EQ(grad_outputs.size(), 1);
     const auto &grad_output = grad_outputs[0];
 

--- a/infini_train/src/autograd/misc.cc
+++ b/infini_train/src/autograd/misc.cc
@@ -42,13 +42,13 @@ void IndexGather::SetupContext(const std::vector<std::shared_ptr<Tensor>> &input
     const auto &input = input_tensors[0];
     const auto &index = input_tensors[1];
     input_dims_ = input->Dims();
-    saved_tensors_ = {index};
+    SaveForBackward({index});
 }
 
 std::vector<std::shared_ptr<Tensor>> IndexGather::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
     CHECK_EQ(grad_outputs.size(), 1);
     const auto &grad_output = grad_outputs[0];
-    const auto &index = saved_tensors_[0];
+    const auto &index = GetSavedTensor(0);
 
     auto device = grad_outputs[0]->GetDevice();
     auto kernel = Dispatcher::Instance().GetKernel({device.type(), "IndexGatherBackward"});
@@ -90,12 +90,12 @@ void Slice::SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_tenso
                          const std::vector<std::shared_ptr<Tensor>> &) {
     // FIXME(dcj): only input's dim need to be saved
     const auto &input = input_tensors[0];
-    saved_tensors_ = {input};
+    SaveForBackward({input});
 }
 
 std::vector<std::shared_ptr<Tensor>> Slice::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
-    CHECK_EQ(saved_tensors_.size(), 1);
-    const auto &input = saved_tensors_[0];
+    CHECK_EQ(SavedTensorsSize(), 1);
+    const auto &input = GetSavedTensor(0);
     const auto &grad_output = grad_outputs[0];
 
     auto device = input->GetDevice().type();

--- a/infini_train/src/autograd/normalization.cc
+++ b/infini_train/src/autograd/normalization.cc
@@ -18,25 +18,17 @@ std::vector<std::shared_ptr<Tensor>> LayerNorm::Forward(const std::vector<std::s
         = Dispatcher::Instance()
               .Call<std::tuple<std::shared_ptr<Tensor>, std::shared_ptr<Tensor>, std::shared_ptr<Tensor>>>(
                   {device, "LayerNormForward"}, input, weight, bias, eps_);
-    saved_tensors_ = {mean, rstd};
+    SaveForBackward({input, weight, bias, mean, rstd});
     return {output};
 }
 
-void LayerNorm::SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_tensors,
-                             const std::vector<std::shared_ptr<Tensor>> &) {
-    const auto &input = input_tensors[0];
-    const auto &weight = input_tensors[1];
-    const auto &bias = input_tensors[2];
-    saved_tensors_.insert(saved_tensors_.begin(), {input, weight, bias});
-}
-
 std::vector<std::shared_ptr<Tensor>> LayerNorm::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
-    CHECK_EQ(saved_tensors_.size(), 5);
-    const auto &input = saved_tensors_[0];
-    const auto &weight = saved_tensors_[1];
-    const auto &bias = saved_tensors_[2];
-    const auto &mean = saved_tensors_[3];
-    const auto &rstd = saved_tensors_[4];
+    CHECK_EQ(SavedTensorsSize(), 5);
+    const auto &input = GetSavedTensor(0);
+    const auto &weight = GetSavedTensor(1);
+    const auto &bias = GetSavedTensor(2);
+    const auto &mean = GetSavedTensor(3);
+    const auto &rstd = GetSavedTensor(4);
     CHECK_EQ(grad_outputs.size(), 1);
     const auto &grad_output = grad_outputs[0];
 

--- a/infini_train/src/autograd/outer.cc
+++ b/infini_train/src/autograd/outer.cc
@@ -22,13 +22,13 @@ void Outer::SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_tenso
                          const std::vector<std::shared_ptr<Tensor>> &output_tensors) {
     const auto &input1 = input_tensors[0];
     const auto &input2 = input_tensors[1];
-    saved_tensors_ = {input1, input2};
+    SaveForBackward({input1, input2});
 }
 
 std::vector<std::shared_ptr<Tensor>> Outer::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
-    CHECK_EQ(saved_tensors_.size(), 2);
-    const auto &input1 = saved_tensors_[0];
-    const auto &input2 = saved_tensors_[1];
+    CHECK_EQ(SavedTensorsSize(), 2);
+    const auto &input1 = GetSavedTensor(0);
+    const auto &input2 = GetSavedTensor(1);
     CHECK_EQ(grad_outputs.size(), 1);
     const auto &grad_output = grad_outputs[0];
 

--- a/infini_train/src/autograd/reduction.cc
+++ b/infini_train/src/autograd/reduction.cc
@@ -67,15 +67,15 @@ void Max::SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_tensors
                        const std::vector<std::shared_ptr<Tensor>> &output_tensors) {
     const auto &input = input_tensors[0];
     const auto &output = output_tensors[0];
-    saved_tensors_ = {input, output};
+    SaveForBackward({input, output});
 }
 
 std::vector<std::shared_ptr<Tensor>> Max::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
     CHECK_EQ(grad_outputs.size(), 1);
-    CHECK_EQ(saved_tensors_.size(), 2);
+    CHECK_EQ(SavedTensorsSize(), 2);
     const auto &grad_output = grad_outputs[0];
-    const auto &input = saved_tensors_[0];
-    const auto &reduced = saved_tensors_[1];
+    const auto &input = GetSavedTensor(0);
+    const auto &reduced = GetSavedTensor(1);
 
     auto device = input->GetDevice().type();
     return {Dispatcher::Instance().Call<std::shared_ptr<Tensor>>({device, "MaxBackward"}, grad_output, input, reduced,
@@ -94,15 +94,15 @@ void Min::SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_tensors
                        const std::vector<std::shared_ptr<Tensor>> &output_tensors) {
     const auto &input = input_tensors[0];
     const auto &output = output_tensors[0];
-    saved_tensors_ = {input, output};
+    SaveForBackward({input, output});
 }
 
 std::vector<std::shared_ptr<Tensor>> Min::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
     CHECK_EQ(grad_outputs.size(), 1);
-    CHECK_EQ(saved_tensors_.size(), 2);
+    CHECK_EQ(SavedTensorsSize(), 2);
     const auto &grad_output = grad_outputs[0];
-    const auto &input = saved_tensors_[0];
-    const auto &reduced = saved_tensors_[1];
+    const auto &input = GetSavedTensor(0);
+    const auto &reduced = GetSavedTensor(1);
 
     auto device = input->GetDevice().type();
     return {Dispatcher::Instance().Call<std::shared_ptr<Tensor>>({device, "MinBackward"}, grad_output, input, reduced,

--- a/infini_train/src/autograd/softmax.cc
+++ b/infini_train/src/autograd/softmax.cc
@@ -17,12 +17,12 @@ std::vector<std::shared_ptr<Tensor>> Softmax::Forward(const std::vector<std::sha
 void Softmax::SetupContext(const std::vector<std::shared_ptr<Tensor>> &,
                            const std::vector<std::shared_ptr<Tensor>> &output_tensors) {
     const auto &output = output_tensors[0];
-    saved_tensors_ = {output};
+    SaveForBackward({output});
 }
 
 std::vector<std::shared_ptr<Tensor>> Softmax::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
-    CHECK_EQ(saved_tensors_.size(), 1);
-    const auto &output = saved_tensors_[0];
+    CHECK_EQ(SavedTensorsSize(), 1);
+    const auto &output = GetSavedTensor(0);
     CHECK_EQ(grad_outputs.size(), 1);
     const auto &grad_output = grad_outputs[0];
 

--- a/infini_train/src/autograd/sparse.cc
+++ b/infini_train/src/autograd/sparse.cc
@@ -20,12 +20,12 @@ void Embedding::SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_t
     const auto &input = input_tensors[0];
     const auto &weight = input_tensors[1];
     weight_dims_ = weight->Dims();
-    saved_tensors_ = {input};
+    SaveForBackward({input});
 }
 
 std::vector<std::shared_ptr<Tensor>> Embedding::Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) {
     CHECK_EQ(grad_outputs.size(), 1);
-    const auto &input = saved_tensors_[0];
+    const auto &input = GetSavedTensor(0);
     const auto &grad_output = grad_outputs[0];
 
     auto device = input->GetDevice().type();

--- a/infini_train/src/nn/parallel/tensor_parallel.cc
+++ b/infini_train/src/nn/parallel/tensor_parallel.cc
@@ -536,7 +536,7 @@ VocabParallelCrossEntropy::Forward(const std::vector<std::shared_ptr<Tensor>> &i
     }
 
     // 8. Save for backward
-    saved_tensors_ = {softmax_local, target_mask, masked_target, valid_mask_local};
+    SaveForBackward({softmax_local, target_mask, masked_target, valid_mask_local});
 
     return {loss};
 }
@@ -546,10 +546,10 @@ VocabParallelCrossEntropy::Backward(const std::vector<std::shared_ptr<Tensor>> &
     CHECK_EQ(grad_outputs.size(), 1);
 
     auto grad_output = grad_outputs[0];
-    auto softmax_local = saved_tensors_[0];
-    auto target_mask = std::make_shared<Tensor>(saved_tensors_[1]->To(softmax_local->Dtype()));
-    auto masked_target = saved_tensors_[2];
-    auto valid_mask_local = saved_tensors_[3];
+    auto softmax_local = GetSavedTensor(0);
+    auto target_mask = std::make_shared<Tensor>(GetSavedTensor(1)->To(softmax_local->Dtype()));
+    auto masked_target = GetSavedTensor(2);
+    auto valid_mask_local = GetSavedTensor(3);
 
     auto device = grad_output->GetDevice().type();
     auto grad_input = Dispatcher::Instance().Call<std::shared_ptr<Tensor>>(

--- a/tests/hook/test_hook.cc
+++ b/tests/hook/test_hook.cc
@@ -75,4 +75,85 @@ TEST_P(HookTest, HookRemove) {
     EXPECT_EQ(hook3_count, 3);
 }
 
+TEST_P(HookTest, SavedTensorHooksPackAndUnpack) {
+    auto x = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice(), true);
+    x->Fill(1.0f);
+
+    int pack_count = 0;
+    int unpack_count = 0;
+    autograd::Function::SavedTensorHooks hooks{
+        [&pack_count](const std::shared_ptr<Tensor> &tensor) {
+            ++pack_count;
+            return std::shared_ptr<void>(tensor);
+        },
+        [&unpack_count](const std::shared_ptr<void> &state) {
+            ++unpack_count;
+            return std::static_pointer_cast<Tensor>(state);
+        },
+    };
+
+    auto sin_fn = std::make_shared<autograd::Sin>();
+    {
+        autograd::Function::SavedTensorHooksGuard guard(std::move(hooks));
+        sin_fn->Apply({x});
+    }
+
+    EXPECT_EQ(pack_count, 1);
+    EXPECT_EQ(unpack_count, 0);
+    EXPECT_EQ(sin_fn->GetSavedTensor(0), x);
+    EXPECT_EQ(unpack_count, 1);
+}
+
+TEST_P(HookTest, SavedTensorHooksCanBeDisabledInNestedScope) {
+    auto x = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice(), true);
+    x->Fill(1.0f);
+
+    int pack_count = 0;
+    autograd::Function::SavedTensorHooks hooks{
+        [&pack_count](const std::shared_ptr<Tensor> &tensor) {
+            ++pack_count;
+            return std::shared_ptr<void>(tensor);
+        },
+        [](const std::shared_ptr<void> &state) { return std::static_pointer_cast<Tensor>(state); },
+    };
+
+    autograd::Function::SavedTensorHooksGuard outer_guard(std::move(hooks));
+    auto first_fn = std::make_shared<autograd::Sin>();
+    first_fn->Apply({x});
+    {
+        autograd::Function::SavedTensorHooksGuard disable_hooks({nullptr, nullptr});
+        auto disabled_fn = std::make_shared<autograd::Sin>();
+        disabled_fn->Apply({x});
+        EXPECT_EQ(disabled_fn->GetSavedTensor(0), x);
+    }
+    auto second_fn = std::make_shared<autograd::Sin>();
+    second_fn->Apply({x});
+
+    EXPECT_EQ(pack_count, 2);
+}
+
+TEST_P(HookTest, SavedTensorHooksSupportNullHookState) {
+    auto x = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice(), true);
+    x->Fill(1.0f);
+
+    int unpack_count = 0;
+    autograd::Function::SavedTensorHooks hooks{
+        [](const std::shared_ptr<Tensor> &) { return std::shared_ptr<void>{}; },
+        [&x, &unpack_count](const std::shared_ptr<void> &state) {
+            ++unpack_count;
+            EXPECT_EQ(state, nullptr);
+            return x;
+        },
+    };
+
+    auto sin_fn = std::make_shared<autograd::Sin>();
+    {
+        autograd::Function::SavedTensorHooksGuard guard(std::move(hooks));
+        sin_fn->Apply({x});
+    }
+
+    EXPECT_EQ(sin_fn->GetSavedTensor(0), x);
+    EXPECT_EQ(unpack_count, 1);
+}
+
 INFINI_TRAIN_REGISTER_TEST(HookTest);


### PR DESCRIPTION
## 背景

当前 Autograd Function 直接通过 `saved_tensors_` 保存和读取反向传播所需的 Tensor，无法在保存和读取过程中插入自定义处理逻辑。

本 PR 引入 Saved Tensor Hooks 基础设施，为后续实现 Tensor 压缩、卸载及 Activation Checkpointing 提供统一扩展点。

本 PR 为重计算实现所必需的基建之一，故单独拆分提交。

## 主要修改

- 新增 Saved Tensor Hooks API：
  - `SavedTensorPackHook`
  - `SavedTensorUnpackHook`
  - `SavedTensorHooksGuard`
- 新增统一的 Saved Tensor 访问接口：
  - `SaveForBackward()`
  - `GetSavedTensor()`
  - `GetSavedTensors()`
  - `SavedTensorsSize()`
- 使用线程局部 Hook 栈，支持嵌套作用域及临时禁用 Hooks。
- 将现有 Autograd 算子的 `saved_tensors_` 直接读写迁移至统一接口。
- 调整 LayerNorm 的 Saved Tensor 保存路径，确保输入及中间结果均经过 Hooks。
- 增加 Saved Tensor Hooks 单元测试，覆盖：
  - Pack/Unpack 基本行为
  - 嵌套作用域中禁用 Hooks
  - Pack Hook 返回空状态