### PR TITLE
feat: run CUDA tests in parallel via CTest GPU resource allocation

### DIFF
--- a/cmake/test_macros.cmake
+++ b/cmake/test_macros.cmake
@@ -28,8 +28,9 @@ include(GoogleTest)
 # Features:
 #   1. Create executable target
 #   2. Configure compile options, link libraries, and include paths
-#   3. Use gtest_discover_tests to auto-discover test cases
-#   4. Set test labels
+#   3. Use gtest_discover_tests to auto-discover CPU test cases
+#   4. Register CUDA tests at binary granularity with CTest GPU resources
+#   5. Set test labels
 #
 # Arguments:
 #   SOURCES:    Source file list (required)
@@ -73,7 +74,7 @@ macro(infini_train_add_test)
   # 5. Link project library (reuses framework linking strategy)
   link_infini_train_exe(${ARG_TEST_NAME})
 
-  # 6. Auto-discover gtest cases and register as ctest tests
+  # 6. Register tests
   set(labels "cpu")
   if(ARG_LABELS)
     set(labels "${ARG_LABELS}")
@@ -84,16 +85,30 @@ macro(infini_train_add_test)
     set(test_timeout ${ARG_TEST_TIMEOUT})
   endif()
 
-  if(ARG_TEST_FILTER)
+  list(FIND labels cuda _has_cuda_label)
+  if(NOT _has_cuda_label EQUAL -1)
+    set(_cuda_test_args)
+    if(ARG_TEST_FILTER)
+      list(APPEND _cuda_test_args --gtest_filter=${ARG_TEST_FILTER})
+    endif()
+
+    add_test(
+      NAME ${ARG_TEST_NAME}
+      COMMAND $<TARGET_FILE:${ARG_TEST_NAME}> ${_cuda_test_args}
+    )
+    set_tests_properties(${ARG_TEST_NAME}
+      PROPERTIES
+        LABELS "${labels}"
+        TIMEOUT ${test_timeout}
+    )
+  elseif(ARG_TEST_FILTER)
     gtest_discover_tests(${ARG_TEST_NAME}
-      EXTRA_ARGS --gtest_output=xml:%T.xml
       TEST_FILTER "${ARG_TEST_FILTER}"
       DISCOVERY_TIMEOUT 10
       PROPERTIES LABELS "${labels}" TIMEOUT ${test_timeout}
     )
   else()
     gtest_discover_tests(${ARG_TEST_NAME}
-      EXTRA_ARGS --gtest_output=xml:%T.xml
       PROPERTIES LABELS "${labels}" TIMEOUT ${test_timeout}
     )
   endif()

--- a/scripts/compare_utils.py
+++ b/scripts/compare_utils.py
@@ -8,7 +8,7 @@ def collect_log_files(base_dir: Path):
     duplicates = {}
 
     for path in base_dir.rglob("*.log"):
-        if path.name.startswith("build") or path.name.endswith("_profile.log"):
+        if path.name.startswith(("build", "ctest_")) or path.name.endswith("_profile.log"):
             continue
 
         key = path.name

--- a/scripts/run_models_and_profile.bash
+++ b/scripts/run_models_and_profile.bash
@@ -71,7 +71,6 @@ LOG_DIR="$(read_var LOG_DIR)";                  : "${LOG_DIR:=logs}"
 PROFILE_LOG_DIR="$(read_var PROFILE_LOG_DIR)";  : "${PROFILE_LOG_DIR:=./profile_logs}"
 COMPARE_LOG_DIR="$(read_var COMPARE_LOG_DIR)";  : "${COMPARE_LOG_DIR:=}"
 RUN_CTEST="$(read_var RUN_CTEST)";              : "${RUN_CTEST:=true}"
-CTEST_CMD="$(read_var CTEST_CMD)";              : "${CTEST_CMD:=ctest --output-on-failure -LE cuda -j$(nproc) && ctest --output-on-failure -L cuda -j1}"
 CKPT_ROOT_DIR="$(read_var CKPT_ROOT_DIR)";      : "${CKPT_ROOT_DIR:=/data1/ckpt}"
 
 mkdir -p "$BUILD_DIR" "$LOG_DIR" "$PROFILE_LOG_DIR"
@@ -122,6 +121,74 @@ clean_checkpoints() {
         echo -e "\033[1;31m[CLEAN] Removing: ${CKPT_ROOT_DIR}\033[0m"
         rm -rf "${CKPT_ROOT_DIR:?}"
     fi
+}
+
+run_ctest() {
+    local gpu_list=()
+    local cuda_tests=()
+
+    if [[ -n "${CTEST_CUDA_GPUS:-}" ]]; then
+        IFS=',' read -r -a gpu_list <<< "$CTEST_CUDA_GPUS"
+    elif command -v nvidia-smi >/dev/null 2>&1; then
+        mapfile -t gpu_list < <(nvidia-smi --query-gpu=index --format=csv,noheader 2>/dev/null || true)
+    fi
+
+    if [[ ${#gpu_list[@]} -eq 0 ]]; then
+        gpu_list=(0)
+    fi
+
+    local filtered_gpu_list=()
+    local gpu
+    for gpu in "${gpu_list[@]}"; do
+        gpu="${gpu//[[:space:]]/}"
+        [[ -z "$gpu" ]] && continue
+        filtered_gpu_list+=("$gpu")
+    done
+
+    if [[ ${#filtered_gpu_list[@]} -eq 0 ]]; then
+        filtered_gpu_list=(0)
+    fi
+
+    ctest --output-on-failure -LE cuda -j"$(nproc)"
+
+    mapfile -t cuda_tests < <(ctest -N -L cuda | sed -n 's/^ *Test *#[0-9][0-9]*: //p')
+    if [[ ${#cuda_tests[@]} -eq 0 ]]; then
+        return 0
+    fi
+
+    local worker_count="${#filtered_gpu_list[@]}"
+    local pids=()
+    local worker_idx
+    for ((worker_idx = 0; worker_idx < worker_count; worker_idx++)); do
+        (
+            local worker_failed=0
+            local test_idx="$worker_idx"
+            local test_name
+            local assigned_gpu="${filtered_gpu_list[$worker_idx]}"
+
+            while ((test_idx < ${#cuda_tests[@]})); do
+                test_name="${cuda_tests[$test_idx]}"
+                echo "[CUDA GPU ${assigned_gpu}] ${test_name}"
+                if ! CUDA_VISIBLE_DEVICES="$assigned_gpu" ctest --output-on-failure -R "^${test_name}$" -j1; then
+                    worker_failed=1
+                fi
+                test_idx=$((test_idx + worker_count))
+            done
+
+            exit "$worker_failed"
+        ) &
+        pids+=("$!")
+    done
+
+    local failed=0
+    local pid
+    for pid in "${pids[@]}"; do
+        if ! wait "$pid"; then
+            failed=1
+        fi
+    done
+
+    return "$failed"
 }
 
 # Run a command and log output
@@ -276,7 +343,7 @@ for ((id=0; id<num_builds; ++id)); do
     clean_build_dir
     run_and_log "$LAST_CMAKE_CMD" "${build_id}" "no" "build"
     if [[ "$RUN_CTEST" == "true" && "$build_profile" != "true" ]]; then
-        run_and_log "$CTEST_CMD" "ctest_${build_id}" "no" "ctest"
+        run_and_log "run_ctest" "ctest_${build_id}" "no" "ctest"
     fi
 
     # profile flag for runs

--- a/scripts/test_config.json
+++ b/scripts/test_config.json
@@ -9,8 +9,7 @@
         "LOG_DIR": "./logs",
         "CKPT_ROOT_DIR": "/data1/ckpt",
         "COMPARE_LOG_DIR": "",
-        "RUN_CTEST": "true",
-        "CTEST_CMD": "ctest --output-on-failure -LE cuda -j$(nproc) && ctest --output-on-failure -L cuda -j1"
+        "RUN_CTEST": "true"
     },
     "builds": [
         {


### PR DESCRIPTION
## Summary

支持 CUDA 测试在多 GPU 环境下并行执行。

此前 CUDA 测试通过 `ctest -L cuda -j1` 串行运行，可以避免多个 CUDA 测试同时抢占 GPU，但无法利用多 GPU 机器上的空闲资源。本 PR 将带 `cuda` label 的测试改为按 test binary 粒度注册，并在 `run_ctest` 中按 GPU 对 CUDA tests 进行分组调度：每个 worker 绑定一张 GPU，通过 `CUDA_VISIBLE_DEVICES` 只暴露对应 GPU，然后串行执行该 worker 分配到的 CUDA 测试。

CPU 测试仍保持原有的 GoogleTest 自动发现和并行执行逻辑。

## Motivation

当前测试流程中，CPU 测试可以并行执行，但 CUDA 测试固定串行：

```bash
ctest --output-on-failure -LE cuda -j$(nproc)
ctest --output-on-failure -L cuda -j1
```

这种方式虽然安全，但会导致多 GPU 机器利用率很低。即使机器上有多张 GPU，CUDA 测试也只能一个接一个运行。

本 PR 的目标是：

* 保持单个 CUDA 测试进程只使用指定 GPU；
* 避免多个 CUDA 测试无控制地同时看到全部 GPU；
* 在多 GPU 机器上并行执行多个 CUDA test binary；
* 保留 CPU 测试的 test case 级别自动发现能力。

## Key Changes

### CUDA test registration

更新 `cmake/test_macros.cmake` 中的测试注册逻辑。

对于带有 `cuda` label 的测试：

* 不再通过 `gtest_discover_tests` 展开为单个 GoogleTest case；
* 改为使用 `add_test` 按 test binary 粒度注册；
* 如果传入 `TEST_FILTER`，继续通过 `--gtest_filter` 传递给测试 binary；
* 设置对应的 `LABELS` 和 `TIMEOUT`。

非 CUDA 测试继续使用 `gtest_discover_tests`，保持原有的自动发现行为。

### CTest runner

在 `scripts/run_models_and_profile.bash` 中新增 `run_ctest` 函数，统一执行 CTest 测试流程。

`run_ctest` 会：

* 优先从 `CTEST_CUDA_GPUS` 读取用户指定的 GPU 列表；
* 如果未指定，则通过 `nvidia-smi --query-gpu=index` 自动探测 GPU；
* 如果没有探测到 GPU，则默认使用 GPU `0`；
* 先并行执行非 CUDA 测试：

```bash
ctest --output-on-failure -LE cuda -j$(nproc)
```

* 再通过以下命令列出 CUDA 测试：

```bash
ctest -N -L cuda
```

* 根据可用 GPU 数量启动多个 worker；
* 每个 worker 绑定一张 GPU，并用 round-robin 方式执行自己分配到的 CUDA tests：

```bash
CUDA_VISIBLE_DEVICES="$assigned_gpu" ctest --output-on-failure -R "^${test_name}$" -j1
```

这样可以让不同 CUDA test binary 分布到不同 GPU 上并行执行，同时保证单个 CUDA test 进程只看到自己绑定的 GPU。

### Test config

更新 `scripts/test_config.json`：

* 删除原先硬编码的 `CTEST_CMD`；
* 保留 `RUN_CTEST` 作为是否执行 CTest 的布尔开关。

`scripts/run_models_and_profile.bash` 中不再从配置文件读取完整的 CTest shell 命令，而是在 `RUN_CTEST=true` 且当前不是 profile build 时调用 `run_ctest`。

## Expected Behavior

修改后：

* CPU 测试仍通过 `-LE cuda` 排除 CUDA 测试并并行执行；
* CUDA 测试不再固定整体 `-j1` 串行运行；
* CUDA tests 会按 test binary 粒度被分配到多个 GPU worker；
* 每个 CUDA test 进程通过 `CUDA_VISIBLE_DEVICES` 只看到指定 GPU；
* 多 GPU 机器上可以并发运行多个 CUDA test binary；
* 如果任一 worker 中的 CUDA 测试失败，`run_ctest` 会返回失败状态。


### Test
单独运行`ctest --output-on-failure` 结果如下：

<img width="1460" height="818" alt="image" src="https://github.com/user-attachments/assets/44754a72-1d1b-4134-a587-171f1396f248" />

在运行脚本中，每个 CUDA binary 单独跑一次 ctest。所以每跑一个 test，CTest 都会输出一整段自己的总结:
<img width="1251" height="825" alt="image" src="https://github.com/user-attachments/assets/fdde40c1-9356-4f4a-8a25-5dbb5795a931" />

GPU 测试加速：471.58 / 30.96 = 15.23x
节省时间：471.58 - 30.96 = 440.62 sec
约 7 分 21 秒，CUDA 测试耗时减少约 93.43%。

<img width="1109" height="324" alt="image" src="https://github.com/user-attachments/assets/9b9bf27f-4d2c-4f26-b5a9-43371aa880cf" />
<img width="899" height="1365" alt="image" src="https://github.com/user-attachments/assets/482826aa-64e2-4e77-8821-41e0e3a6ecb8" />
