### PR TITLE
refactor: enable -Wunused -Wunused-function globally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Generate compile_commands.json
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+add_compile_options(-Wunused -Wunused-function)
+
 # ------------------------------------------------------------------------------
 # GoogleTest (submodule)
 # ------------------------------------------------------------------------------

--- a/example/common/tiny_shakespeare_dataset.cc
+++ b/example/common/tiny_shakespeare_dataset.cc
@@ -68,6 +68,7 @@ TinyShakespeareFile ReadTinyShakespeareFile(const std::string &path, size_t sequ
     const auto header = ReadSeveralBytesFromIfstream(1024, &ifs);
     const int magic = BytesToType<int32_t>(header, 0);
     const int version = BytesToType<int32_t>(header, 4);
+    (void)version; // Read but unused; reserved in binary format specification
     const int num_tokens = BytesToType<int32_t>(header, 8);
     text_file.type = kTypeMap.at(magic);
 

--- a/example/gpt2/checkpoint_loader.cc
+++ b/example/gpt2/checkpoint_loader.cc
@@ -114,11 +114,8 @@ std::shared_ptr<nn::TransformerModel> LoadFromLLMC(const std::string &filepath) 
     // calculate xx_size_per_partition
     const int64_t vpp = model_vocab_size / tp_size;
     const int64_t v_start = static_cast<int64_t>(tp_rank) * vpp;
-    const int64_t v_end = v_start + vpp;
 
     const int64_t qkv_out = 3 * n_embd;
-    const int64_t qkv_pp = qkv_out / tp_size;
-    const int64_t qkv_start = static_cast<int64_t>(tp_rank) * qkv_pp;
 
     const int64_t fc_out = 4 * n_embd;
     const int64_t fc_pp = fc_out / tp_size;

--- a/example/llama3/checkpoint_loader.cc
+++ b/example/llama3/checkpoint_loader.cc
@@ -155,7 +155,6 @@ std::shared_ptr<nn::TransformerModel> LoadFromLLMC(const std::string &filepath) 
     const int64_t q_local_rows = static_cast<int64_t>(n_embd) / tp_size; // = (n_head/world)*head_dim
     const int64_t kv_head_local = static_cast<int64_t>(n_kv_head) / tp_size;
     const int64_t kv_local_rows = kv_head_local * head_dim; // for K or V (each)
-    const int64_t attn_local_rows = q_local_rows + 2 * kv_local_rows;
 
     // RowParallel (proj)
     const int64_t in_pp = static_cast<int64_t>(n_embd) / tp_size;

--- a/infini_train/src/nn/parallel/ddp/param_and_grad_buffer.cc
+++ b/infini_train/src/nn/parallel/ddp/param_and_grad_buffer.cc
@@ -161,7 +161,7 @@ void ParamAndGradBucketGroup::RegisterGradReady(const std::shared_ptr<Tensor> &p
             return;
         }
 
-        const bool inserted = params_with_grad_.insert(parameter.get()).second;
+        params_with_grad_.insert(parameter.get());
         // TODO(zbl): check this if sync is only done in last mircobatch
         // if (!inserted) {
         //     LOG(FATAL) << "ParamAndGradBucketGroup: RegisterGradReady() was called twice for the same parameter in a

--- a/infini_train/src/nn/parallel/global.cc
+++ b/infini_train/src/nn/parallel/global.cc
@@ -13,11 +13,6 @@ int GetEnvAsInt(const std::string &name, int default_value) {
     return value ? std::atoi(value) : default_value;
 }
 
-std::string GetEnvAsStr(const std::string &name, const std::string &default_value) {
-    const char *value = std::getenv(name.c_str());
-    return value ? std::string(value) : default_value;
-}
-
 } // namespace
 
 namespace infini_train::nn::parallel::global {


### PR DESCRIPTION
## 说明：
新增了全局的编译选项 -Wunused -Wunused-function，编译时可以告警未使用局部变量和函数。

## 精度对比：
<img width="1314" height="551" alt="image" src="https://github.com/user-attachments/assets/9bade4a3-17d9-4b21-bb0c-405429e9c22f" />

