### PR TITLE
refactor: improve config validation and remove default final ckpt

### DIFF
--- a/example/gpt2/main.cc
+++ b/example/gpt2/main.cc
@@ -83,7 +83,7 @@ DEFINE_uint32(virtual_pipeline_parallel, 1, "Number of chunks in PP stage.");
 DEFINE_string(dtype, "float32", "precision used in training (float32/bfloat16)");
 DEFINE_uint32(save_interval, 0, "save checkpoint every N steps; 0 disables saving");
 DEFINE_string(load, "", "checkpoint directory to resume from");
-DEFINE_string(save, "./checkpoints", "root directory used to store checkpoints");
+DEFINE_string(save, "", "root directory used to store checkpoints");
 DEFINE_uint32(max_checkpoint_keep, 3, "max number of checkpoint steps to keep");
 DEFINE_bool(save_optimizer_state, true, "whether optimizer state is persisted in checkpoints");
 // precision check
@@ -127,6 +127,22 @@ DEFINE_validator(zero_stage, [](const char *, int32_t value) { return value >= 0
 
 void Train(const nn::parallel::Rank &rank) {
     using namespace nn::parallel;
+
+    {
+        if (rank.IsLastRank()) {
+            if (!FLAGS_save.empty() && FLAGS_save_interval == 0) {
+                LOG(FATAL) << "Invalid configuration: --save is set ('" << FLAGS_save
+                           << "'), but --save_interval is 0. "
+                           << "They must be set together.";
+            }
+
+            if (FLAGS_save.empty() && FLAGS_save_interval > 0) {
+                LOG(FATAL) << "Invalid configuration: --save_interval is set to " << FLAGS_save_interval
+                           << ", but --save is empty. "
+                           << "They must be set together.";
+            }
+        }
+    }
 
     // select the device
     Device device;
@@ -489,13 +505,15 @@ void Train(const nn::parallel::Rank &rank) {
             }
         }
 
-        if (FLAGS_save_interval > 0 && (step + 1) % FLAGS_save_interval == 0) {
-            std::filesystem::path step_dir
-                = std::filesystem::path(FLAGS_save) / std::format("checkpoint_step_{:06d}", step + 1);
-            if (rank.IsParallel()) {
-                step_dir /= std::format("rank_{:06d}", rank.GlobalRank());
+        if (!FLAGS_save.empty() && FLAGS_save_interval > 0) {
+            if ((step + 1) % FLAGS_save_interval == 0 || (step + 1) == FLAGS_num_iteration) {
+                std::filesystem::path step_dir
+                    = std::filesystem::path(FLAGS_save) / std::format("checkpoint_step_{:06d}", step + 1);
+                if (rank.IsParallel()) {
+                    step_dir /= std::format("rank_{:06d}", rank.GlobalRank());
+                }
+                save_checkpoint(step_dir, step + 1);
             }
-            save_checkpoint(step_dir, step + 1);
         }
     }
 
@@ -504,12 +522,6 @@ void Train(const nn::parallel::Rank &rank) {
         LOG(INFO) << "Saving LoRA weights to: " << FLAGS_lora_save_path;
         nn::lora::SaveLoRAWeights(model, FLAGS_lora_save_path);
     }
-
-    std::filesystem::path final_dir = std::filesystem::path(FLAGS_save) / "checkpoint_final";
-    if (rank.IsParallel()) {
-        final_dir /= std::format("rank_{:06d}", rank.GlobalRank());
-    }
-    save_checkpoint(final_dir, FLAGS_num_iteration);
 
 #ifdef PROFILE_MODE
     Profiler::Instance().Report("gpt2.report", Profiler::SortBy::DeviceTimePercentage);

--- a/example/llama3/main.cc
+++ b/example/llama3/main.cc
@@ -81,7 +81,7 @@ DEFINE_uint32(virtual_pipeline_parallel, 1, "Number of chunks in PP stage.");
 DEFINE_string(dtype, "float32", "precision used in training (float32/bfloat16)");
 DEFINE_uint32(save_interval, 0, "save checkpoint every N steps; 0 disables saving");
 DEFINE_string(load, "", "checkpoint directory to resume from");
-DEFINE_string(save, "./checkpoints", "root directory used to store checkpoints");
+DEFINE_string(save, "", "root directory used to store checkpoints");
 DEFINE_uint32(max_checkpoint_keep, 3, "max number of checkpoint steps to keep");
 DEFINE_bool(save_optimizer_state, true, "whether optimizer state is persisted in checkpoints");
 
@@ -114,6 +114,22 @@ DEFINE_validator(zero_stage, [](const char *, int32_t value) { return value >= 0
 
 void Train(const nn::parallel::Rank &rank) {
     using namespace nn::parallel;
+
+    {
+        if (rank.IsLastRank()) {
+            if (!FLAGS_save.empty() && FLAGS_save_interval == 0) {
+                LOG(FATAL) << "Invalid configuration: --save is set ('" << FLAGS_save
+                           << "'), but --save_interval is 0. "
+                           << "They must be set together.";
+            }
+
+            if (FLAGS_save.empty() && FLAGS_save_interval > 0) {
+                LOG(FATAL) << "Invalid configuration: --save_interval is set to " << FLAGS_save_interval
+                           << ", but --save is empty. "
+                           << "They must be set together.";
+            }
+        }
+    }
 
     // select the device
     Device device;
@@ -466,13 +482,15 @@ void Train(const nn::parallel::Rank &rank) {
             }
         }
 
-        if (FLAGS_save_interval > 0 && (step + 1) % FLAGS_save_interval == 0) {
-            std::filesystem::path step_dir
-                = std::filesystem::path(FLAGS_save) / std::format("checkpoint_step_{:06d}", step + 1);
-            if (rank.IsParallel()) {
-                step_dir /= std::format("rank_{:06d}", rank.GlobalRank());
+        if (!FLAGS_save.empty() && FLAGS_save_interval > 0) {
+            if ((step + 1) % FLAGS_save_interval == 0 || (step + 1) == FLAGS_num_iteration) {
+                std::filesystem::path step_dir
+                    = std::filesystem::path(FLAGS_save) / std::format("checkpoint_step_{:06d}", step + 1);
+                if (rank.IsParallel()) {
+                    step_dir /= std::format("rank_{:06d}", rank.GlobalRank());
+                }
+                save_checkpoint(step_dir, step + 1);
             }
-            save_checkpoint(step_dir, step + 1);
         }
     }
 
@@ -481,12 +499,6 @@ void Train(const nn::parallel::Rank &rank) {
         LOG(INFO) << "Saving LoRA weights to: " << FLAGS_lora_save_path;
         nn::lora::SaveLoRAWeights(model, FLAGS_lora_save_path);
     }
-
-    std::filesystem::path final_dir = std::filesystem::path(FLAGS_save) / "checkpoint_final";
-    if (rank.IsParallel()) {
-        final_dir /= std::format("rank_{:06d}", rank.GlobalRank());
-    }
-    save_checkpoint(final_dir, FLAGS_num_iteration);
 
 #ifdef PROFILE_MODE
     Profiler::Instance().Report("llama3.report", Profiler::SortBy::DeviceTimePercentage);


### PR DESCRIPTION
## 简介

移除训练结束自动保存ckpt逻辑，取消FLAGS_save默认值

   - 删除训练结束时默认保存checkpoint的代码逻辑
   - 取消 FLAGS_save 参数的默认值，未显式传入时不执行保存
   - 用户需通过 FLAGS_save 显式指定才会保存checkpoint
   - 检查 FLAGS_save 和 FLAGS_save_interval 组合一致性


## 精度检查

<img width="1262" height="1821" alt="img_v3_0212p_19c815ab-9506-4680-8a1c-dc09b26abd0g" src="https://github.com/user-attachments/assets/62423135-1f85-46f5-9578-cf28fd9c98d2" />
