### PR TITLE
feat: save forward autocast context in FunctionCtx

### DIFF
--- a/infini_train/include/autocast.h
+++ b/infini_train/include/autocast.h
@@ -143,9 +143,16 @@ struct AutocastContext {
 // Global thread-local storage for autocast context
 inline thread_local AutocastContext tls_autocast_context;
 
+inline AutocastContext GetCurrentAutocastContext() { return tls_autocast_context; }
+
 // RAII guard to enable/disable autocast in a scope
 class AutocastGuard {
 public:
+    explicit AutocastGuard(const AutocastContext &context) {
+        saved_context_ = tls_autocast_context;
+        tls_autocast_context = context;
+    }
+
     AutocastGuard(Device::DeviceType device_type, DataType autocast_dtype) {
         saved_context_ = tls_autocast_context;
         tls_autocast_context.enabled = true;

--- a/infini_train/include/autograd/function.h
+++ b/infini_train/include/autograd/function.h
@@ -49,7 +49,7 @@ public:
 
     const std::vector<bool> &needs_input_grad() const;
 
-    const AutocastContext &GetForwardAutocastContext() const;
+    const AutocastContext &forward_autocast_context() const;
 
 private:
     struct SavedTensorEntry {
@@ -61,7 +61,7 @@ private:
     friend class Function;
 
     void set_needs_input_grad(std::vector<bool> needs_input_grad);
-    void SaveForwardAutocastContext(const AutocastContext &context);
+    void set_forward_autocast_context(const AutocastContext &context);
 
     void SaveVariables(const std::vector<std::shared_ptr<Tensor>> &outputs);
     void ReleaseVariables();

--- a/infini_train/include/autograd/function.h
+++ b/infini_train/include/autograd/function.h
@@ -2,9 +2,12 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
+
+#include "infini_train/include/autocast.h"
 
 namespace infini_train {
 class Tensor;
@@ -46,6 +49,8 @@ public:
 
     const std::vector<bool> &needs_input_grad() const;
 
+    const AutocastContext &GetForwardAutocastContext() const;
+
 private:
     struct SavedTensorEntry {
         std::shared_ptr<Tensor> tensor;
@@ -56,6 +61,7 @@ private:
     friend class Function;
 
     void set_needs_input_grad(std::vector<bool> needs_input_grad);
+    void SaveForwardAutocastContext(const AutocastContext &context);
 
     void SaveVariables(const std::vector<std::shared_ptr<Tensor>> &outputs);
     void ReleaseVariables();
@@ -66,6 +72,7 @@ private:
     std::vector<SavedTensorEntry> saved_tensor_entries_;
     std::vector<bool> needs_input_grad_;
     std::vector<Tensor *> non_differentiable_;
+    std::optional<AutocastContext> forward_autocast_context_;
 };
 
 class Function : public std::enable_shared_from_this<Function> {

--- a/infini_train/src/autograd/function.cc
+++ b/infini_train/src/autograd/function.cc
@@ -57,7 +57,7 @@ const std::vector<bool> &FunctionCtx::needs_input_grad() const { return needs_in
 
 void FunctionCtx::SaveForBackward(const std::vector<std::shared_ptr<Tensor>> &tensors) { to_save_ = tensors; }
 
-const AutocastContext &FunctionCtx::GetForwardAutocastContext() const {
+const AutocastContext &FunctionCtx::forward_autocast_context() const {
     CHECK(forward_autocast_context_.has_value()) << "Forward autocast context has not been saved";
     return *forward_autocast_context_;
 }
@@ -76,7 +76,7 @@ void FunctionCtx::set_needs_input_grad(std::vector<bool> needs_input_grad) {
     needs_input_grad_ = std::move(needs_input_grad);
 }
 
-void FunctionCtx::SaveForwardAutocastContext(const AutocastContext &context) { forward_autocast_context_ = context; }
+void FunctionCtx::set_forward_autocast_context(const AutocastContext &context) { forward_autocast_context_ = context; }
 
 void FunctionCtx::SaveVariables(const std::vector<std::shared_ptr<Tensor>> &outputs) {
     saved_tensor_entries_.clear();
@@ -178,7 +178,7 @@ std::vector<std::shared_ptr<Tensor>> Function::Apply(const std::vector<std::shar
     // original autograd graph (leaf -> AccumulateGrad / non-leaf -> grad_fn).
     // Also, save the autocast context in FunctionCtx so that custom backward can
     // explicitly restore the forward autocast context from FunctionCtx if needed.
-    ctx_.SaveForwardAutocastContext(GetCurrentAutocastContext());
+    ctx_.set_forward_autocast_context(GetCurrentAutocastContext());
     auto compute_inputs = input_tensors;
     for (auto &t : compute_inputs) { tls_autocast_context.Autocast(type_, t); }
 

--- a/infini_train/src/autograd/function.cc
+++ b/infini_train/src/autograd/function.cc
@@ -57,6 +57,11 @@ const std::vector<bool> &FunctionCtx::needs_input_grad() const { return needs_in
 
 void FunctionCtx::SaveForBackward(const std::vector<std::shared_ptr<Tensor>> &tensors) { to_save_ = tensors; }
 
+const AutocastContext &FunctionCtx::GetForwardAutocastContext() const {
+    CHECK(forward_autocast_context_.has_value()) << "Forward autocast context has not been saved";
+    return *forward_autocast_context_;
+}
+
 void FunctionCtx::MarkNonDifferentiable(const std::vector<std::shared_ptr<Tensor>> &outputs) {
     non_differentiable_.clear();
     non_differentiable_.reserve(outputs.size());
@@ -70,6 +75,8 @@ void FunctionCtx::MarkNonDifferentiable(const std::vector<std::shared_ptr<Tensor
 void FunctionCtx::set_needs_input_grad(std::vector<bool> needs_input_grad) {
     needs_input_grad_ = std::move(needs_input_grad);
 }
+
+void FunctionCtx::SaveForwardAutocastContext(const AutocastContext &context) { forward_autocast_context_ = context; }
 
 void FunctionCtx::SaveVariables(const std::vector<std::shared_ptr<Tensor>> &outputs) {
     saved_tensor_entries_.clear();
@@ -106,6 +113,7 @@ void FunctionCtx::ReleaseVariables() {
     saved_tensor_entries_.clear();
     needs_input_grad_.clear();
     non_differentiable_.clear();
+    forward_autocast_context_.reset();
 }
 
 bool FunctionCtx::IsNonDifferentiable(const std::shared_ptr<Tensor> &output) const {
@@ -168,6 +176,9 @@ std::vector<std::shared_ptr<Tensor>> Function::Apply(const std::vector<std::shar
     // tensors already in the compute dtype. The shared_ptr copies are local; we keep
     // the caller's `input_tensors` untouched so next_functions_ wires up to the
     // original autograd graph (leaf -> AccumulateGrad / non-leaf -> grad_fn).
+    // Also, save the autocast context in FunctionCtx so that custom backward can
+    // explicitly restore the forward autocast context from FunctionCtx if needed.
+    ctx_.SaveForwardAutocastContext(GetCurrentAutocastContext());
     auto compute_inputs = input_tensors;
     for (auto &t : compute_inputs) { tls_autocast_context.Autocast(type_, t); }
 

--- a/tests/autograd/test_autograd.cc
+++ b/tests/autograd/test_autograd.cc
@@ -124,7 +124,7 @@ public:
     void SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_tensors,
                       const std::vector<std::shared_ptr<Tensor>> &) override {
         ctx_.SaveForBackward({input_tensors[0]});
-        observed_forward_context_ = ctx_.GetForwardAutocastContext();
+        observed_forward_context_ = ctx_.forward_autocast_context();
     }
 
     std::vector<std::shared_ptr<Tensor>> Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) override {
@@ -132,10 +132,10 @@ public:
     }
 
     const AutocastContext &ObservedForwardContext() const { return observed_forward_context_; }
-    const AutocastContext &ForwardAutocastContext() const { return ctx_.GetForwardAutocastContext(); }
+    const AutocastContext &ForwardAutocastContext() const { return ctx_.forward_autocast_context(); }
 
     AutocastContext SnapshotWithForwardAutocastContextRestored() const {
-        AutocastGuard guard(ctx_.GetForwardAutocastContext());
+        AutocastGuard guard(ctx_.forward_autocast_context());
         return GetCurrentAutocastContext();
     }
 

--- a/tests/autograd/test_autograd.cc
+++ b/tests/autograd/test_autograd.cc
@@ -3,13 +3,14 @@
 
 #include "gtest/gtest.h"
 
+#include "infini_train/include/autocast.h"
 #include "infini_train/include/autograd/activations.h"
 #include "infini_train/include/autograd/elementwise.h"
 #include "infini_train/include/autograd/function.h"
 #include "infini_train/include/autograd/linear.h"
 #include "infini_train/include/autograd/matmul.h"
-#include "infini_train/include/autograd/normalization.h"
 #include "infini_train/include/autograd/no_op.h"
+#include "infini_train/include/autograd/normalization.h"
 #include "infini_train/include/autograd/outer.h"
 #include "infini_train/include/autograd/reduction.h"
 #include "infini_train/include/autograd/softmax.h"
@@ -107,6 +108,41 @@ public:
     }
 };
 
+class ObserveAutocastContextFunction : public autograd::Function {
+public:
+    static constexpr char kType[] = "ObserveAutocastContextFunction";
+
+    ObserveAutocastContextFunction() : autograd::Function(kType) {}
+
+    std::vector<std::shared_ptr<Tensor>> Forward(const std::vector<std::shared_ptr<Tensor>> &input_tensors) override {
+        const auto &input = input_tensors[0];
+        auto output = std::make_shared<Tensor>(input->Dims(), input->Dtype(), input->GetDevice());
+        output->CopyFrom(input);
+        return {output};
+    }
+
+    void SetupContext(const std::vector<std::shared_ptr<Tensor>> &input_tensors,
+                      const std::vector<std::shared_ptr<Tensor>> &) override {
+        ctx_.SaveForBackward({input_tensors[0]});
+        observed_forward_context_ = ctx_.GetForwardAutocastContext();
+    }
+
+    std::vector<std::shared_ptr<Tensor>> Backward(const std::vector<std::shared_ptr<Tensor>> &grad_outputs) override {
+        return {grad_outputs[0]};
+    }
+
+    const AutocastContext &ObservedForwardContext() const { return observed_forward_context_; }
+    const AutocastContext &ForwardAutocastContext() const { return ctx_.GetForwardAutocastContext(); }
+
+    AutocastContext SnapshotWithForwardAutocastContextRestored() const {
+        AutocastGuard guard(ctx_.GetForwardAutocastContext());
+        return GetCurrentAutocastContext();
+    }
+
+private:
+    AutocastContext observed_forward_context_;
+};
+
 TEST_P(AutogradForwardTest, SavedOutputIsPackedWithoutAutogradMeta) {
     auto input = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice(), true);
     input->Fill(1.0f);
@@ -123,7 +159,8 @@ TEST_P(AutogradForwardTest, SavedOutputIsPackedWithoutAutogradMeta) {
 }
 
 TEST_P(AutogradForwardTest, FunctionCtxNeedsInputGradAndSaveForBackward) {
-    auto requires_grad_input = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice(), true);
+    auto requires_grad_input
+        = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice(), true);
     auto no_grad_input = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice(), false);
     requires_grad_input->Fill(1.0f);
     no_grad_input->Fill(2.0f);
@@ -191,6 +228,72 @@ TEST_P(AutogradForwardTest, FunctionCtxSavedTensorHooksPackAndUnpack) {
     auto saved = fn->GetSavedTensor();
     EXPECT_EQ(unpack_calls, 1);
     EXPECT_EQ(saved.get(), packed_tensor.get());
+}
+
+TEST_P(AutogradForwardTest, FunctionCtxRecordsForwardAutocastContext) {
+    auto input = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice(), true);
+    input->Fill(1.0f);
+
+    auto fn = std::make_shared<ObserveAutocastContextFunction>();
+    const auto forward_dtype = kDeviceDefaultDtype[static_cast<size_t>(GetDevice().type())];
+    {
+        AutocastGuard autocast_guard(GetDevice().type(), forward_dtype);
+        auto outputs = fn->Apply({input});
+        ASSERT_EQ(outputs.size(), 1);
+    }
+
+    const auto &state = fn->ObservedForwardContext();
+    EXPECT_TRUE(state.enabled);
+    EXPECT_EQ(state.device_type, GetDevice().type());
+    EXPECT_EQ(state.autocast_dtype, forward_dtype);
+}
+
+TEST_P(AutogradForwardTest, FunctionCtxRestoresForwardAutocastContextForRecompute) {
+    auto input = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice(), true);
+    input->Fill(1.0f);
+
+    auto fn = std::make_shared<ObserveAutocastContextFunction>();
+    const auto forward_dtype = kDeviceDefaultDtype[static_cast<size_t>(GetDevice().type())];
+    {
+        AutocastGuard autocast_guard(GetDevice().type(), forward_dtype);
+        auto outputs = fn->Apply({input});
+        ASSERT_EQ(outputs.size(), 1);
+    }
+
+    EXPECT_FALSE(GetCurrentAutocastContext().enabled);
+    const auto restored = fn->SnapshotWithForwardAutocastContextRestored();
+    EXPECT_TRUE(restored.enabled);
+    EXPECT_EQ(restored.device_type, GetDevice().type());
+    EXPECT_EQ(restored.autocast_dtype, forward_dtype);
+    EXPECT_FALSE(GetCurrentAutocastContext().enabled);
+}
+
+TEST_P(AutogradForwardTest, AutocastGuardRestoresCallerContextAfterForwardAutocastContext) {
+    auto input = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice(), true);
+    input->Fill(1.0f);
+
+    auto fn = std::make_shared<ObserveAutocastContextFunction>();
+    const auto forward_dtype = kDeviceDefaultDtype[static_cast<size_t>(GetDevice().type())];
+    {
+        AutocastGuard autocast_guard(GetDevice().type(), forward_dtype);
+        auto outputs = fn->Apply({input});
+        ASSERT_EQ(outputs.size(), 1);
+    }
+
+    const auto backward_dtype = DataType::kFLOAT32;
+    AutocastGuard backward_autocast_guard(GetDevice().type(), backward_dtype);
+    {
+        AutocastGuard restore_guard(fn->ForwardAutocastContext());
+        const auto restored = GetCurrentAutocastContext();
+        EXPECT_TRUE(restored.enabled);
+        EXPECT_EQ(restored.device_type, GetDevice().type());
+        EXPECT_EQ(restored.autocast_dtype, forward_dtype);
+    }
+
+    const auto current = GetCurrentAutocastContext();
+    EXPECT_TRUE(current.enabled);
+    EXPECT_EQ(current.device_type, GetDevice().type());
+    EXPECT_EQ(current.autocast_dtype, backward_dtype);
 }
 
 TEST_P(AutogradForwardTest, AddForward) {


### PR DESCRIPTION
为 `autograd::FunctionCtx` 增加了用于保存并恢复前向执行时的 autocast state (放在框架中是 AutocastContext 结构体）的功能，目标是对齐 PyTorch `torch.amp.custom_fwd/custom_bwd` 的语义：前向阶段记录当前生效的 AutocastContext；当自定义 backward 或重计算路径需要重新执行部分前向子图时，可以显式恢复该前向 AutocastContext。

## 改动内容
1. Autocast 侧修改：
    * 新增 `GetCurrentAutocastContext()`，用于快照当前线程本地的 autocast 上下文。
    * 新增 `AutocastGuard(const AutocastContext&)` 的构造方法，调用方可以通过 RAII 语义临时恢复一个已保存的 autocast 上下文。
2. Function 侧修改：
    * 在执行 `Function::Forward()` 之前，将前向 autocast 上下文保存到 `FunctionCtx`。
    * 新增 `FunctionCtx::GetForwardAutocastContext()`，供自定义 backward 和重计算路径获取前向阶段保存的 autocast 上下文。
    * 在重置 `FunctionCtx` 保存变量时，同时重置已保存的前向 autocast 上下文。
    * 注意：并不会自动将所有 backward 都包裹在前向 autocast 上下文中。保存的上下文通过 `FunctionCtx` 暴露，只有显式重算前向计算的代码路径才会通过上述接口来主动恢复该上下文。
3. 新增 autograd 测试，覆盖以下场景：
    * 前向 autocast 上下文会被正确记录到 `FunctionCtx`；
    * 手动恢复后，能够观察到与前向一致的 enabled/device/dtype；
    * 退出 restore guard 后，调用方原有的 autocast 上下文会被正确恢复。

## PyTorch 对齐证据

torch 没有显式包出一个 AutoCastContext 结构体，但是的确存在 forward 会存下此 context 然后 backward 再度调用恢复的情况。对于常见的两种情况：

1. custom backward：相关逻辑实现位于 [`torch/amp/autocast_mode.py`](https://github.com/pytorch/pytorch/blob/main/torch/amp/autocast_mode.py)。

    `args[0]` 就是 FunctionCtx。自定义前向会存下来相应信息，反向再用相应信息开启 autocast。

<img width="512" alt="image" src="https://github.com/user-attachments/assets/9909f3c6-a28b-46f3-88f0-9519d9e9accd" />

2. 重计算：相关逻辑实现位于 [`torch/utils/checkpoint.py`](https://github.com/pytorch/pytorch/blob/main/torch/utils/checkpoint.py)。

    有一个存 autocast 信息的 helper，它在 `Checkpoint.Function.forward()` 会被调用然后记录信息，在 `Checkpoint.Function.backward()` 重新恢复。 

<img width="300" alt="image" src="https://github.com/user-attachments/assets/02abdefa-1038-4a32-829f-3772a92f9c9f" />


<img width="512" alt="image" src="https://github.com/user-attachments/assets/0a90a078-1f35-4ca8-9bd5-3233340b1b9b" />

