### PR TITLE
perf: reduce redundant CUDA initialization and synchronization

### DIFF
--- a/example/gpt2/main.cc
+++ b/example/gpt2/main.cc
@@ -476,10 +476,12 @@ void Train(const nn::parallel::Rank &rank) {
 
                 LOG(INFO) << "Rank " << rank.GlobalRank() << ": finish loss forward";
 
-                auto loss_cpu = loss->To(Device());
-                lossf += static_cast<const float *>(loss_cpu.DataPtr())[0];
                 LOG(INFO) << "Rank " << rank.GlobalRank() << ": start backward";
                 loss->Backward();
+                // Defer the loss D2H copy until after backward; reading it earlier would synchronize CUDA
+                // between forward and backward.
+                auto loss_cpu = loss->To(Device());
+                lossf += static_cast<const float *>(loss_cpu.DataPtr())[0];
                 LOG(INFO) << "Rank " << rank.GlobalRank() << ": finish backward";
             }
 

--- a/example/llama3/main.cc
+++ b/example/llama3/main.cc
@@ -455,10 +455,12 @@ void Train(const nn::parallel::Rank &rank) {
 
                 LOG(INFO) << "Rank " << rank.GlobalRank() << ": finish loss forward";
 
-                auto loss_cpu = loss->To(Device());
-                lossf += static_cast<const float *>(loss_cpu.DataPtr())[0];
                 LOG(INFO) << "Rank " << rank.GlobalRank() << ": start backward";
                 loss->Backward();
+                // Defer the loss D2H copy until after backward; reading it earlier would synchronize CUDA
+                // between forward and backward.
+                auto loss_cpu = loss->To(Device());
+                lossf += static_cast<const float *>(loss_cpu.DataPtr())[0];
                 LOG(INFO) << "Rank " << rank.GlobalRank() << ": finish backward";
             }
 

--- a/example/mixtral/main.cc
+++ b/example/mixtral/main.cc
@@ -133,11 +133,13 @@ int main(int argc, char *argv[]) {
             auto y = std::make_shared<Tensor>(y_cpu->To(train_device));
             auto logits = (*model)({x})[0];
             auto loss = (*loss_fn)({logits, y})[0];
-            auto loss_cpu = loss->To(Device());
-            lossf += static_cast<const float *>(loss_cpu.DataPtr())[0] / grad_accum_steps;
             loss = loss / static_cast<float>(grad_accum_steps);
             autocast_guard.Disable();
             loss->Backward();
+            // Defer the loss D2H copy until after backward; reading it earlier would synchronize CUDA
+            // between forward and backward.
+            auto loss_cpu = loss->To(Device());
+            lossf += static_cast<const float *>(loss_cpu.DataPtr())[0];
         }
         optimizer->Step();
 

--- a/example/mnist/main.cc
+++ b/example/mnist/main.cc
@@ -70,6 +70,10 @@ int main(int argc, char *argv[]) {
             optimizer.ZeroGrad();
 
             auto loss = loss_fn.Forward({outputs[0], new_label});
+            loss[0]->Backward();
+
+            // Defer the loss D2H copy until after backward; reading it earlier would synchronize CUDA
+            // between forward and backward.
             auto loss_cpu = loss[0]->To(cpu_device);
             float current_loss = static_cast<float *>(loss_cpu.DataPtr())[0];
             total_loss += current_loss;
@@ -79,7 +83,6 @@ int main(int argc, char *argv[]) {
                            << " loss: " << current_loss;
             }
 
-            loss[0]->Backward();
             optimizer.Step();
             train_idx += 1;
         }

--- a/infini_train/src/kernels/cuda/concat.cu
+++ b/infini_train/src/kernels/cuda/concat.cu
@@ -186,7 +186,7 @@ std::vector<std::shared_ptr<Tensor>> ConcatBackward(const std::shared_ptr<Tensor
     grads.reserve(input_dims_list.size());
     for (const auto &dvec : input_dims_list) {
         auto t = std::make_shared<Tensor>(dvec, dtype, device);
-        t->Fill(0.0);
+        // ConcatBackwardKernel maps every grad_output element to exactly one grad tensor element; no Fill is needed.
         grads.push_back(t);
     }
 

--- a/infini_train/src/kernels/cuda/cross_entropy.cu
+++ b/infini_train/src/kernels/cuda/cross_entropy.cu
@@ -204,7 +204,7 @@ std::shared_ptr<Tensor> CrossEntropyBackward(const std::shared_ptr<Tensor> &inpu
                                  DataTypeList<INFINI_ALL_FLOATING_TYPES>>(
         {target->Dtype(), input_casted->Dtype()},
         [=]<typename Ttarget, typename Tinput>() {
-            grad_input->Fill(0.0);
+            // One sample block writes all of its num_classes gradient elements; no Fill is needed.
             const Tinput *output_grad_ptr = static_cast<const Tinput *>(grad_output->DataPtr());
             const Ttarget *target_ptr = static_cast<const Ttarget *>(target->DataPtr());
             const Tinput *input_ptr = static_cast<const Tinput *>(input_casted->DataPtr());

--- a/infini_train/src/kernels/cuda/layernorm.cu
+++ b/infini_train/src/kernels/cuda/layernorm.cu
@@ -89,8 +89,7 @@ LayerNormForward(const std::shared_ptr<Tensor> &input, const std::shared_ptr<Ten
     core::cuda::DispatchCudaFunc<INFINI_ALL_FLOATING_TYPES>(
         dtype,
         [=]<typename T>() {
-            mean->Fill(0.0);
-            rstd->Fill(0.0);
+            // Each token block writes its mean and rstd exactly once; no Fill is needed.
             LayerNormForwardKernel<BLOCK_SIZE><<<num_blocks, threads_per_block, 0, cuda_stream>>>(
                 static_cast<const T *>(input->DataPtr()), static_cast<const T *>(weight->DataPtr()),
                 static_cast<const T *>(bias->DataPtr()), static_cast<float *>(mean->DataPtr()),
@@ -183,7 +182,7 @@ LayerNormBackward(const std::shared_ptr<Tensor> &input, const std::shared_ptr<Te
     core::cuda::DispatchCudaFunc<INFINI_ALL_FLOATING_TYPES>(
         dtype,
         [=]<typename T>() {
-            grad_input->Fill(0.0);
+            // Each token block writes its complete grad_input slice; no Fill is needed.
             grad_weight->Fill(0.0);
             grad_bias->Fill(0.0);
             LayerNormBackwardKernel<BLOCK_SIZE><<<num_blocks, threads_per_block, 0, cuda_stream>>>(

--- a/infini_train/src/kernels/cuda/linear.cu
+++ b/infini_train/src/kernels/cuda/linear.cu
@@ -65,6 +65,7 @@ std::shared_ptr<Tensor> LinearForward(const std::shared_ptr<Tensor> &input, cons
                                  infini_train::core::GetDeviceGuardImpl(device.type())->GetStream(device))
                                  ->cuda_stream();
 
+    const float beta = bias ? 1.0f : 0.0f;
     if (bias) {
         CHECK_EQ(bias->Dims().size(), 1);
         CHECK_EQ(bias->Dims()[0], out_features);
@@ -78,9 +79,8 @@ std::shared_ptr<Tensor> LinearForward(const std::shared_ptr<Tensor> &input, cons
                     static_cast<T *>(output->DataPtr()), static_cast<const T *>(bias->DataPtr()), bs, out_features);
             },
             "CUDA LinearForward");
-    } else {
-        output->Fill(0.0);
     }
+    // In the no-bias path, beta=0 makes cuBLAS fully overwrite output; no Fill is needed.
 
     // When bs==1 and fp32, use cublasSgemv (more efficient than GEMM for matrix-vector).
     // cublasSgemv does not support bf16, so bf16 falls through to Gemm.
@@ -94,7 +94,7 @@ std::shared_ptr<Tensor> LinearForward(const std::shared_ptr<Tensor> &input, cons
                               .x = static_cast<const float *>(input->DataPtr()),
                               .y = static_cast<float *>(output->DataPtr()),
                               .alpha = 1.0f,
-                              .beta = 1.0f, // output already initialized with bias or zero above
+                              .beta = beta,
                           });
     } else {
         // cuBLAS is colmun-major
@@ -125,7 +125,7 @@ std::shared_ptr<Tensor> LinearForward(const std::shared_ptr<Tensor> &input, cons
                 .C = output->DataPtr(),
                 .ldc = static_cast<int>(out_features),
                 .alpha = 1.0f,
-                .beta = 1.0f, // bias already written into output; beta=1 accumulates
+                .beta = beta,
                 .batch_count = 1,
                 .input_dtype = dtype,
                 .output_dtype = dtype,

--- a/infini_train/src/kernels/cuda/reduction.cu
+++ b/infini_train/src/kernels/cuda/reduction.cu
@@ -181,7 +181,7 @@ std::shared_ptr<Tensor> ReduceOpBackward(const std::shared_ptr<Tensor> &grad_out
     core::cuda::DispatchCudaFunc<INFINI_ALL_FLOATING_TYPES>(
         dtype,
         [=]<typename T>() {
-            grad_input->Fill(0.0);
+            // The backward kernel assigns every grad_input element on all reduction branches; no Fill is needed.
             GenericReduceBackwardKernel<<<num_blocks, threads_per_block, 0, cuda_stream>>>(
                 static_cast<T *>(grad_input->DataPtr()), static_cast<const T *>(grad_output->DataPtr()),
                 input ? static_cast<const T *>(input->DataPtr()) : nullptr,

--- a/infini_train/src/kernels/cuda/slice.cu
+++ b/infini_train/src/kernels/cuda/slice.cu
@@ -48,8 +48,7 @@ std::shared_ptr<Tensor> SliceForward(const std::shared_ptr<Tensor> &input, const
 
     auto dtype = input->Dtype();
     auto new_tensor = std::make_shared<Tensor>(new_dims, dtype, input->GetDevice());
-    // NOTE(zbl): must initialize with 0
-    new_tensor->Fill(0.0);
+    // SliceForwardKernel writes every output index in [0, total_elements); no Fill is needed.
 
     std::vector<int64_t> src_strides(dims.size(), 0), dst_strides(new_dims.size(), 0);
     int64_t stride = 1;

--- a/infini_train/src/kernels/cuda/softmax.cu
+++ b/infini_train/src/kernels/cuda/softmax.cu
@@ -198,7 +198,7 @@ std::shared_ptr<Tensor> SoftmaxBackward(const std::shared_ptr<Tensor> &grad_outp
     CHECK(dim >= 0 && dim < output->Dims().size());
 
     auto grad_input = std::make_shared<Tensor>(output_dims, promoted_type, output->GetDevice());
-    grad_input->Fill(0.0);
+    // For non-empty tensors, the grid covers every outer/axis/inner index exactly once; no Fill is needed.
 
     switch (promoted_type) {
         DISPATCH_CASE(WRAP(LaunchBackward<256, float>(grad_input, grad_output_promoted, output_promoted, dim);),

--- a/infini_train/src/kernels/cuda/split.cu
+++ b/infini_train/src/kernels/cuda/split.cu
@@ -114,6 +114,7 @@ std::shared_ptr<Tensor> LaunchSplitBackward(const std::vector<int64_t> &input_di
     const auto &grad = grad_outputs[0];
     auto dtype = grad->Dtype();
     auto grad_input = std::make_shared<Tensor>(input_dims, dtype, grad->GetDevice());
+    // Keep initialization: defensive early returns in SplitBackwardKernel can leave elements unwritten.
     grad_input->Fill(0.0);
 
     int64_t N = std::accumulate(input_dims.begin(), input_dims.begin() + dim, 1, std::multiplies<int64_t>());

--- a/infini_train/src/kernels/cuda/stack.cu
+++ b/infini_train/src/kernels/cuda/stack.cu
@@ -113,7 +113,7 @@ std::vector<std::shared_ptr<Tensor>> StackBackward(const std::vector<int64_t> &i
     std::vector<std::shared_ptr<Tensor>> grads;
     for (int i = 0; i < num_inputs; ++i) {
         auto t = std::make_shared<Tensor>(base_dims, dtype, grad_output->GetDevice());
-        t->Fill(0.0);
+        // StackBackwardKernel writes every element of every grad tensor exactly once; no Fill is needed.
         grads.push_back(t);
     }
 

--- a/infini_train/src/nn/parallel/pp/pipeline_schedule.cc
+++ b/infini_train/src/nn/parallel/pp/pipeline_schedule.cc
@@ -255,9 +255,10 @@ float PipelineSchedule::StepMicroBatches(const std::vector<std::shared_ptr<Tenso
                         {activations[task.local_chunk_idx][mb][0], std::make_shared<Tensor>(target_on_device)})[0];
                     loss = loss / n;
                 }
-                total_loss += static_cast<const float *>(loss->To(Device()).DataPtr())[0];
-
                 loss->Backward();
+                // Defer the loss D2H copy until after backward; reading it earlier would synchronize CUDA
+                // between forward and backward.
+                total_loss += static_cast<const float *>(loss->To(Device()).DataPtr())[0];
             } else {
                 auto out_tensor = activations[task.local_chunk_idx][mb][0];
 

--- a/tests/autograd/test_autograd_linear_forward.cc
+++ b/tests/autograd/test_autograd_linear_forward.cc
@@ -3,6 +3,7 @@
 #include "gtest/gtest.h"
 
 #include "infini_train/include/autograd/linear.h"
+#include "infini_train/include/core/runtime/device_guard.h"
 #include "infini_train/include/nn/parallel/global.h"
 #include "infini_train/include/tensor.h"
 
@@ -12,17 +13,30 @@ using namespace infini_train;
 
 class AutogradLinearForwardTest : public infini_train::test::InfiniTrainTest {};
 
+namespace {
+std::shared_ptr<Tensor> CopyToCPU(const std::shared_ptr<Tensor> &tensor) {
+    auto cpu = std::make_shared<Tensor>(tensor->Dims(), tensor->Dtype(), Device());
+    cpu->CopyFrom(tensor);
+    core::GetDeviceGuardImpl(tensor->GetDevice().type())->SynchronizeDevice(tensor->GetDevice());
+    return cpu;
+}
+} // namespace
+
 TEST_P(AutogradLinearForwardTest, LinearForward) {
     auto input = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice(), true);
     input->Fill(1.0f);
     auto weight = std::make_shared<Tensor>(std::vector<int64_t>{4, 3}, DataType::kFLOAT32, GetDevice(), true);
     weight->Fill(1.0f);
     auto bias = std::make_shared<Tensor>(std::vector<int64_t>{4}, DataType::kFLOAT32, GetDevice(), true);
-    bias->Fill(0.0f);
+    bias->Fill(2.0f);
     auto linear_fn = std::make_shared<autograd::Linear>();
     auto result = linear_fn->Apply({input, weight, bias});
     EXPECT_EQ(result.size(), 1);
     EXPECT_EQ(result[0]->Dims(), (std::vector<int64_t>{2, 4}));
+
+    auto output = CopyToCPU(result[0]);
+    const float *actual = static_cast<const float *>(output->DataPtr());
+    for (int64_t i = 0; i < output->NumElements(); ++i) { EXPECT_FLOAT_EQ(actual[i], 5.0f); }
 }
 
 TEST_P(AutogradLinearForwardTest, LinearNoBias) {
@@ -34,6 +48,10 @@ TEST_P(AutogradLinearForwardTest, LinearNoBias) {
     auto result = linear_fn->Apply({input, weight});
     EXPECT_EQ(result.size(), 1);
     EXPECT_EQ(result[0]->Dims(), (std::vector<int64_t>{2, 4}));
+
+    auto output = CopyToCPU(result[0]);
+    const float *actual = static_cast<const float *>(output->DataPtr());
+    for (int64_t i = 0; i < output->NumElements(); ++i) { EXPECT_FLOAT_EQ(actual[i], 3.0f); }
 }
 
 TEST_P(AutogradLinearForwardTest, LinearBatch) {

--- a/tests/autograd/test_autograd_linear_forward.cc
+++ b/tests/autograd/test_autograd_linear_forward.cc
@@ -3,7 +3,6 @@
 #include "gtest/gtest.h"
 
 #include "infini_train/include/autograd/linear.h"
-#include "infini_train/include/core/runtime/device_guard.h"
 #include "infini_train/include/nn/parallel/global.h"
 #include "infini_train/include/tensor.h"
 
@@ -12,15 +11,6 @@
 using namespace infini_train;
 
 class AutogradLinearForwardTest : public infini_train::test::InfiniTrainTest {};
-
-namespace {
-std::shared_ptr<Tensor> CopyToCPU(const std::shared_ptr<Tensor> &tensor) {
-    auto cpu = std::make_shared<Tensor>(tensor->Dims(), tensor->Dtype(), Device());
-    cpu->CopyFrom(tensor);
-    core::GetDeviceGuardImpl(tensor->GetDevice().type())->SynchronizeDevice(tensor->GetDevice());
-    return cpu;
-}
-} // namespace
 
 TEST_P(AutogradLinearForwardTest, LinearForward) {
     auto input = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice(), true);
@@ -33,25 +23,19 @@ TEST_P(AutogradLinearForwardTest, LinearForward) {
     auto result = linear_fn->Apply({input, weight, bias});
     EXPECT_EQ(result.size(), 1);
     EXPECT_EQ(result[0]->Dims(), (std::vector<int64_t>{2, 4}));
-
-    auto output = CopyToCPU(result[0]);
-    const float *actual = static_cast<const float *>(output->DataPtr());
-    for (int64_t i = 0; i < output->NumElements(); ++i) { EXPECT_FLOAT_EQ(actual[i], 5.0f); }
+    test::ExpectTensorEqual(result[0], 5.0f);
 }
 
 TEST_P(AutogradLinearForwardTest, LinearNoBias) {
-    auto input = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice(), true);
+    auto input = std::make_shared<Tensor>(std::vector<int64_t>{1, 3}, DataType::kFLOAT32, GetDevice(), true);
     input->Fill(1.0f);
     auto weight = std::make_shared<Tensor>(std::vector<int64_t>{4, 3}, DataType::kFLOAT32, GetDevice(), true);
     weight->Fill(1.0f);
     auto linear_fn = std::make_shared<autograd::Linear>();
     auto result = linear_fn->Apply({input, weight});
     EXPECT_EQ(result.size(), 1);
-    EXPECT_EQ(result[0]->Dims(), (std::vector<int64_t>{2, 4}));
-
-    auto output = CopyToCPU(result[0]);
-    const float *actual = static_cast<const float *>(output->DataPtr());
-    for (int64_t i = 0; i < output->NumElements(); ++i) { EXPECT_FLOAT_EQ(actual[i], 3.0f); }
+    EXPECT_EQ(result[0]->Dims(), (std::vector<int64_t>{1, 4}));
+    test::ExpectTensorEqual(result[0], 3.0f);
 }
 
 TEST_P(AutogradLinearForwardTest, LinearBatch) {
@@ -59,12 +43,11 @@ TEST_P(AutogradLinearForwardTest, LinearBatch) {
     input->Fill(1.0f);
     auto weight = std::make_shared<Tensor>(std::vector<int64_t>{64, 128}, DataType::kFLOAT32, GetDevice(), true);
     weight->Fill(1.0f);
-    auto bias = std::make_shared<Tensor>(std::vector<int64_t>{64}, DataType::kFLOAT32, GetDevice(), true);
-    bias->Fill(0.0f);
     auto linear_fn = std::make_shared<autograd::Linear>();
-    auto result = linear_fn->Apply({input, weight, bias});
+    auto result = linear_fn->Apply({input, weight});
     EXPECT_EQ(result.size(), 1);
     EXPECT_EQ(result[0]->Dims(), (std::vector<int64_t>{32, 64}));
+    test::ExpectTensorEqual(result[0], 128.0f);
 }
 
 INFINI_TRAIN_REGISTER_TEST(AutogradLinearForwardTest);

--- a/tests/autograd/test_autograd_linear_forward.cc
+++ b/tests/autograd/test_autograd_linear_forward.cc
@@ -23,7 +23,7 @@ TEST_P(AutogradLinearForwardTest, LinearForward) {
     auto result = linear_fn->Apply({input, weight, bias});
     EXPECT_EQ(result.size(), 1);
     EXPECT_EQ(result[0]->Dims(), (std::vector<int64_t>{2, 4}));
-    test::ExpectTensorEqual(result[0], 5.0f);
+    test::ExpectTensorFloatEqual(result[0], 5.0f);
 }
 
 TEST_P(AutogradLinearForwardTest, LinearNoBias) {
@@ -35,7 +35,7 @@ TEST_P(AutogradLinearForwardTest, LinearNoBias) {
     auto result = linear_fn->Apply({input, weight});
     EXPECT_EQ(result.size(), 1);
     EXPECT_EQ(result[0]->Dims(), (std::vector<int64_t>{1, 4}));
-    test::ExpectTensorEqual(result[0], 3.0f);
+    test::ExpectTensorFloatEqual(result[0], 3.0f);
 }
 
 TEST_P(AutogradLinearForwardTest, LinearBatch) {
@@ -47,7 +47,7 @@ TEST_P(AutogradLinearForwardTest, LinearBatch) {
     auto result = linear_fn->Apply({input, weight});
     EXPECT_EQ(result.size(), 1);
     EXPECT_EQ(result[0]->Dims(), (std::vector<int64_t>{32, 64}));
-    test::ExpectTensorEqual(result[0], 128.0f);
+    test::ExpectTensorFloatEqual(result[0], 128.0f);
 }
 
 INFINI_TRAIN_REGISTER_TEST(AutogradLinearForwardTest);

--- a/tests/autograd/test_autograd_loss.cc
+++ b/tests/autograd/test_autograd_loss.cc
@@ -4,7 +4,6 @@
 #include "gtest/gtest.h"
 
 #include "infini_train/include/autograd/loss.h"
-#include "infini_train/include/core/runtime/device_guard.h"
 #include "infini_train/include/nn/parallel/global.h"
 #include "infini_train/include/tensor.h"
 
@@ -13,15 +12,6 @@
 using namespace infini_train;
 
 class AutogradLossTest : public infini_train::test::InfiniTrainTest {};
-
-namespace {
-std::shared_ptr<Tensor> CopyToCPU(const std::shared_ptr<Tensor> &tensor) {
-    auto cpu = std::make_shared<Tensor>(tensor->Dims(), tensor->Dtype(), Device());
-    cpu->CopyFrom(tensor);
-    core::GetDeviceGuardImpl(tensor->GetDevice().type())->SynchronizeDevice(tensor->GetDevice());
-    return cpu;
-}
-} // namespace
 
 TEST_P(AutogradLossTest, CrossEntropyForwardAndBackwardValues) {
     std::vector<float> logits_values{1.0f, 2.0f, 3.0f, 2.0f, 1.0f, 0.0f};
@@ -38,8 +28,7 @@ TEST_P(AutogradLossTest, CrossEntropyForwardAndBackwardValues) {
     const float row0_sum = std::exp(1.0f) + std::exp(2.0f) + std::exp(3.0f);
     const float row1_sum = std::exp(2.0f) + std::exp(1.0f) + std::exp(0.0f);
     const float expected_loss = 0.5f * ((std::log(row0_sum) - 1.0f) + (std::log(row1_sum) - 2.0f));
-    auto loss_cpu = CopyToCPU(result[0]);
-    EXPECT_NEAR(static_cast<const float *>(loss_cpu->DataPtr())[0], expected_loss, 1e-5f);
+    test::ExpectTensorNear(result[0], expected_loss, 1e-5f);
 
     auto grad_output = std::make_shared<Tensor>(std::vector<int64_t>{}, DataType::kFLOAT32, GetDevice());
     grad_output->Fill(1.0f);
@@ -48,16 +37,15 @@ TEST_P(AutogradLossTest, CrossEntropyForwardAndBackwardValues) {
     ASSERT_NE(grad_inputs[0], nullptr);
     EXPECT_EQ(grad_inputs[1], nullptr);
 
-    auto grad_cpu = CopyToCPU(grad_inputs[0]);
-    const float *actual_grad = static_cast<const float *>(grad_cpu->DataPtr());
+    std::vector<float> expected_grad(logits_values.size());
     for (int row = 0; row < 2; ++row) {
         const float sum = row == 0 ? row0_sum : row1_sum;
         for (int col = 0; col < 3; ++col) {
             const float probability = std::exp(logits_values[row * 3 + col]) / sum;
-            const float expected_grad = 0.5f * (probability - (col == 0 ? 1.0f : 0.0f));
-            EXPECT_NEAR(actual_grad[row * 3 + col], expected_grad, 1e-5f);
+            expected_grad[row * 3 + col] = 0.5f * (probability - (col == 0 ? 1.0f : 0.0f));
         }
     }
+    test::ExpectTensorNear(grad_inputs[0], expected_grad, 1e-5f);
 }
 
 INFINI_TRAIN_REGISTER_TEST(AutogradLossTest);

--- a/tests/autograd/test_autograd_loss.cc
+++ b/tests/autograd/test_autograd_loss.cc
@@ -1,0 +1,63 @@
+#include <cmath>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "infini_train/include/autograd/loss.h"
+#include "infini_train/include/core/runtime/device_guard.h"
+#include "infini_train/include/nn/parallel/global.h"
+#include "infini_train/include/tensor.h"
+
+#include "tests/common/test_utils.h"
+
+using namespace infini_train;
+
+class AutogradLossTest : public infini_train::test::InfiniTrainTest {};
+
+namespace {
+std::shared_ptr<Tensor> CopyToCPU(const std::shared_ptr<Tensor> &tensor) {
+    auto cpu = std::make_shared<Tensor>(tensor->Dims(), tensor->Dtype(), Device());
+    cpu->CopyFrom(tensor);
+    core::GetDeviceGuardImpl(tensor->GetDevice().type())->SynchronizeDevice(tensor->GetDevice());
+    return cpu;
+}
+} // namespace
+
+TEST_P(AutogradLossTest, CrossEntropyForwardAndBackwardValues) {
+    std::vector<float> logits_values{1.0f, 2.0f, 3.0f, 2.0f, 1.0f, 0.0f};
+    auto logits
+        = std::make_shared<Tensor>(logits_values.data(), std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice());
+    auto target = std::make_shared<Tensor>(std::vector<int64_t>{2}, DataType::kINT64, GetDevice());
+    target->Fill(0);
+
+    auto cross_entropy = std::make_shared<autograd::CrossEntropy>();
+    auto result = cross_entropy->Apply({logits, target});
+    ASSERT_EQ(result.size(), 1);
+    ASSERT_TRUE(result[0]->Dims().empty());
+
+    const float row0_sum = std::exp(1.0f) + std::exp(2.0f) + std::exp(3.0f);
+    const float row1_sum = std::exp(2.0f) + std::exp(1.0f) + std::exp(0.0f);
+    const float expected_loss = 0.5f * ((std::log(row0_sum) - 1.0f) + (std::log(row1_sum) - 2.0f));
+    auto loss_cpu = CopyToCPU(result[0]);
+    EXPECT_NEAR(static_cast<const float *>(loss_cpu->DataPtr())[0], expected_loss, 1e-5f);
+
+    auto grad_output = std::make_shared<Tensor>(std::vector<int64_t>{}, DataType::kFLOAT32, GetDevice());
+    grad_output->Fill(1.0f);
+    auto grad_inputs = cross_entropy->Backward({grad_output});
+    ASSERT_EQ(grad_inputs.size(), 2);
+    ASSERT_NE(grad_inputs[0], nullptr);
+    EXPECT_EQ(grad_inputs[1], nullptr);
+
+    auto grad_cpu = CopyToCPU(grad_inputs[0]);
+    const float *actual_grad = static_cast<const float *>(grad_cpu->DataPtr());
+    for (int row = 0; row < 2; ++row) {
+        const float sum = row == 0 ? row0_sum : row1_sum;
+        for (int col = 0; col < 3; ++col) {
+            const float probability = std::exp(logits_values[row * 3 + col]) / sum;
+            const float expected_grad = 0.5f * (probability - (col == 0 ? 1.0f : 0.0f));
+            EXPECT_NEAR(actual_grad[row * 3 + col], expected_grad, 1e-5f);
+        }
+    }
+}
+
+INFINI_TRAIN_REGISTER_TEST(AutogradLossTest);

--- a/tests/autograd/test_autograd_normalization_backward.cc
+++ b/tests/autograd/test_autograd_normalization_backward.cc
@@ -3,7 +3,6 @@
 #include "gtest/gtest.h"
 
 #include "infini_train/include/autograd/normalization.h"
-#include "infini_train/include/core/runtime/device_guard.h"
 #include "infini_train/include/nn/parallel/global.h"
 #include "infini_train/include/tensor.h"
 
@@ -12,17 +11,6 @@
 using namespace infini_train;
 
 class AutogradNormalizationBackwardTest : public infini_train::test::InfiniTrainTest {};
-
-namespace {
-void ExpectValues(const std::shared_ptr<Tensor> &tensor, float expected) {
-    auto cpu = std::make_shared<Tensor>(tensor->Dims(), tensor->Dtype(), Device());
-    cpu->CopyFrom(tensor);
-    core::GetDeviceGuardImpl(tensor->GetDevice().type())->SynchronizeDevice(tensor->GetDevice());
-
-    const float *actual = static_cast<const float *>(cpu->DataPtr());
-    for (int64_t i = 0; i < cpu->NumElements(); ++i) { EXPECT_NEAR(actual[i], expected, 1e-5f); }
-}
-} // namespace
 
 TEST_P(AutogradNormalizationBackwardTest, LayerNormBackward) {
     auto a = std::make_shared<Tensor>(std::vector<int64_t>{2, 3, 4}, DataType::kFLOAT32, GetDevice(), true);
@@ -37,9 +25,9 @@ TEST_P(AutogradNormalizationBackwardTest, LayerNormBackward) {
     grad->Fill(1.0f);
     auto grad_inputs = layernorm_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 3);
-    ExpectValues(grad_inputs[0], 0.0f);
-    ExpectValues(grad_inputs[1], 0.0f);
-    ExpectValues(grad_inputs[2], 6.0f);
+    test::ExpectTensorNear(grad_inputs[0], 0.0f, 1e-5f);
+    test::ExpectTensorNear(grad_inputs[1], 0.0f, 1e-5f);
+    test::ExpectTensorNear(grad_inputs[2], 6.0f, 1e-5f);
 }
 
 TEST_P(AutogradNormalizationBackwardTest, LayerNormBackwardZeroBias) {

--- a/tests/autograd/test_autograd_normalization_backward.cc
+++ b/tests/autograd/test_autograd_normalization_backward.cc
@@ -3,6 +3,7 @@
 #include "gtest/gtest.h"
 
 #include "infini_train/include/autograd/normalization.h"
+#include "infini_train/include/core/runtime/device_guard.h"
 #include "infini_train/include/nn/parallel/global.h"
 #include "infini_train/include/tensor.h"
 
@@ -11,6 +12,17 @@
 using namespace infini_train;
 
 class AutogradNormalizationBackwardTest : public infini_train::test::InfiniTrainTest {};
+
+namespace {
+void ExpectValues(const std::shared_ptr<Tensor> &tensor, float expected) {
+    auto cpu = std::make_shared<Tensor>(tensor->Dims(), tensor->Dtype(), Device());
+    cpu->CopyFrom(tensor);
+    core::GetDeviceGuardImpl(tensor->GetDevice().type())->SynchronizeDevice(tensor->GetDevice());
+
+    const float *actual = static_cast<const float *>(cpu->DataPtr());
+    for (int64_t i = 0; i < cpu->NumElements(); ++i) { EXPECT_NEAR(actual[i], expected, 1e-5f); }
+}
+} // namespace
 
 TEST_P(AutogradNormalizationBackwardTest, LayerNormBackward) {
     auto a = std::make_shared<Tensor>(std::vector<int64_t>{2, 3, 4}, DataType::kFLOAT32, GetDevice(), true);
@@ -25,6 +37,9 @@ TEST_P(AutogradNormalizationBackwardTest, LayerNormBackward) {
     grad->Fill(1.0f);
     auto grad_inputs = layernorm_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 3);
+    ExpectValues(grad_inputs[0], 0.0f);
+    ExpectValues(grad_inputs[1], 0.0f);
+    ExpectValues(grad_inputs[2], 6.0f);
 }
 
 TEST_P(AutogradNormalizationBackwardTest, LayerNormBackwardZeroBias) {

--- a/tests/autograd/test_autograd_normalization_backward.cc
+++ b/tests/autograd/test_autograd_normalization_backward.cc
@@ -13,21 +13,31 @@ using namespace infini_train;
 class AutogradNormalizationBackwardTest : public infini_train::test::InfiniTrainTest {};
 
 TEST_P(AutogradNormalizationBackwardTest, LayerNormBackward) {
-    auto a = std::make_shared<Tensor>(std::vector<int64_t>{2, 3, 4}, DataType::kFLOAT32, GetDevice(), true);
-    a->Fill(1.0f);
-    auto weight = std::make_shared<Tensor>(std::vector<int64_t>{4}, DataType::kFLOAT32, GetDevice(), true);
-    weight->Fill(1.0f);
-    auto bias = std::make_shared<Tensor>(std::vector<int64_t>{4}, DataType::kFLOAT32, GetDevice(), true);
-    bias->Fill(0.0f);
+    const std::vector<int64_t> input_dims{1, 2, 4};
+    std::vector<float> input_values{-1.5f, -0.5f, 0.5f, 1.5f, -3.0f, -1.0f, 1.0f, 3.0f};
+    std::vector<float> weight_values{1.0f, 0.5f, -1.0f, 2.0f};
+    std::vector<float> bias_values{0.5f, -0.5f, 1.0f, -1.0f};
+    auto input = std::make_shared<Tensor>(input_values.data(), input_dims, DataType::kFLOAT32, GetDevice());
+    auto weight
+        = std::make_shared<Tensor>(weight_values.data(), std::vector<int64_t>{4}, DataType::kFLOAT32, GetDevice());
+    auto bias = std::make_shared<Tensor>(bias_values.data(), std::vector<int64_t>{4}, DataType::kFLOAT32, GetDevice());
+
     auto layernorm_fn = std::make_shared<autograd::LayerNorm>(1e-5f);
-    auto result = layernorm_fn->Apply({a, weight, bias});
-    auto grad = std::make_shared<Tensor>(std::vector<int64_t>{2, 3, 4}, DataType::kFLOAT32, GetDevice(), true);
-    grad->Fill(1.0f);
+    auto result = layernorm_fn->Apply({input, weight, bias});
+    ASSERT_EQ(result.size(), 3);
+    test::ExpectTensorNear(result[1], {0.0f, 0.0f}, 1e-5f);
+    test::ExpectTensorNear(result[2], {0.89442366f, 0.44721317f}, 1e-5f);
+
+    std::vector<float> grad_values{1.0f, 2.0f, 3.0f, 4.0f, 0.5f, -1.0f, 2.0f, -0.5f};
+    auto grad = std::make_shared<Tensor>(grad_values.data(), input_dims, DataType::kFLOAT32, GetDevice());
     auto grad_inputs = layernorm_fn->Backward({grad});
-    EXPECT_EQ(grad_inputs.size(), 3);
-    test::ExpectTensorNear(grad_inputs[0], 0.0f, 1e-5f);
-    test::ExpectTensorNear(grad_inputs[1], 0.0f, 1e-5f);
-    test::ExpectTensorNear(grad_inputs[2], 6.0f, 1e-5f);
+    ASSERT_EQ(grad_inputs.size(), 3);
+    test::ExpectTensorNear(
+        grad_inputs[0],
+        {1.60994446f, 0.08943637f, -5.00876665f, 3.30938578f, 0.15652537f, -0.02236041f, -0.42485276f, 0.29068780f},
+        1e-5f);
+    test::ExpectTensorNear(grad_inputs[1], {-2.01245522f, -0.44721049f, 2.23606181f, 4.69572210f}, 1e-5f);
+    test::ExpectTensorNear(grad_inputs[2], {1.5f, 1.0f, 5.0f, 3.5f}, 1e-5f);
 }
 
 TEST_P(AutogradNormalizationBackwardTest, LayerNormBackwardZeroBias) {

--- a/tests/autograd/test_autograd_reduction_backward.cc
+++ b/tests/autograd/test_autograd_reduction_backward.cc
@@ -21,7 +21,7 @@ TEST_P(AutogradReductionBackwardTest, SumBackward) {
     grad->Fill(1.0f);
     auto grad_inputs = sum_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
-    test::ExpectTensorEqual(grad_inputs[0], {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f});
+    test::ExpectTensorFloatEqual(grad_inputs[0], {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f});
 }
 
 TEST_P(AutogradReductionBackwardTest, MeanBackward) {
@@ -33,8 +33,8 @@ TEST_P(AutogradReductionBackwardTest, MeanBackward) {
     grad->Fill(1.0f);
     auto grad_inputs = mean_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
-    test::ExpectTensorEqual(grad_inputs[0],
-                            {1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f});
+    test::ExpectTensorFloatEqual(grad_inputs[0],
+                                 {1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f});
 }
 
 TEST_P(AutogradReductionBackwardTest, MaxBackward) {
@@ -46,7 +46,7 @@ TEST_P(AutogradReductionBackwardTest, MaxBackward) {
     grad->Fill(1.0f);
     auto grad_inputs = max_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
-    test::ExpectTensorEqual(grad_inputs[0], {0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f});
+    test::ExpectTensorFloatEqual(grad_inputs[0], {0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f});
 }
 
 TEST_P(AutogradReductionBackwardTest, MinBackward) {
@@ -58,7 +58,7 @@ TEST_P(AutogradReductionBackwardTest, MinBackward) {
     grad->Fill(1.0f);
     auto grad_inputs = min_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
-    test::ExpectTensorEqual(grad_inputs[0], {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f});
+    test::ExpectTensorFloatEqual(grad_inputs[0], {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f});
 }
 
 TEST_P(AutogradReductionBackwardTest, SumBackwardKeepDim) {
@@ -70,7 +70,7 @@ TEST_P(AutogradReductionBackwardTest, SumBackwardKeepDim) {
     grad->Fill(1.0f);
     auto grad_inputs = sum_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
-    test::ExpectTensorEqual(grad_inputs[0], {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f});
+    test::ExpectTensorFloatEqual(grad_inputs[0], {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f});
 }
 
 TEST_P(AutogradReductionBackwardTest, MeanBackwardKeepDim) {
@@ -82,8 +82,8 @@ TEST_P(AutogradReductionBackwardTest, MeanBackwardKeepDim) {
     grad->Fill(1.0f);
     auto grad_inputs = mean_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
-    test::ExpectTensorEqual(grad_inputs[0],
-                            {1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f});
+    test::ExpectTensorFloatEqual(grad_inputs[0],
+                                 {1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f});
 }
 
 INFINI_TRAIN_REGISTER_TEST(AutogradReductionBackwardTest);

--- a/tests/autograd/test_autograd_reduction_backward.cc
+++ b/tests/autograd/test_autograd_reduction_backward.cc
@@ -3,7 +3,6 @@
 #include "gtest/gtest.h"
 
 #include "infini_train/include/autograd/reduction.h"
-#include "infini_train/include/core/runtime/device_guard.h"
 #include "infini_train/include/nn/parallel/global.h"
 #include "infini_train/include/tensor.h"
 
@@ -12,18 +11,6 @@
 using namespace infini_train;
 
 class AutogradReductionBackwardTest : public infini_train::test::InfiniTrainTest {};
-
-namespace {
-void ExpectValues(const std::shared_ptr<Tensor> &tensor, const std::vector<float> &expected) {
-    auto cpu = std::make_shared<Tensor>(tensor->Dims(), tensor->Dtype(), Device());
-    cpu->CopyFrom(tensor);
-    core::GetDeviceGuardImpl(tensor->GetDevice().type())->SynchronizeDevice(tensor->GetDevice());
-
-    ASSERT_EQ(cpu->NumElements(), expected.size());
-    const float *actual = static_cast<const float *>(cpu->DataPtr());
-    for (size_t i = 0; i < expected.size(); ++i) { EXPECT_FLOAT_EQ(actual[i], expected[i]); }
-}
-} // namespace
 
 TEST_P(AutogradReductionBackwardTest, SumBackward) {
     auto a = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice(), true);
@@ -34,7 +21,7 @@ TEST_P(AutogradReductionBackwardTest, SumBackward) {
     grad->Fill(1.0f);
     auto grad_inputs = sum_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
-    ExpectValues(grad_inputs[0], {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f});
+    test::ExpectTensorEqual(grad_inputs[0], {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f});
 }
 
 TEST_P(AutogradReductionBackwardTest, MeanBackward) {
@@ -46,7 +33,8 @@ TEST_P(AutogradReductionBackwardTest, MeanBackward) {
     grad->Fill(1.0f);
     auto grad_inputs = mean_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
-    ExpectValues(grad_inputs[0], {1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f});
+    test::ExpectTensorEqual(grad_inputs[0],
+                            {1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f});
 }
 
 TEST_P(AutogradReductionBackwardTest, MaxBackward) {
@@ -58,7 +46,7 @@ TEST_P(AutogradReductionBackwardTest, MaxBackward) {
     grad->Fill(1.0f);
     auto grad_inputs = max_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
-    ExpectValues(grad_inputs[0], {0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f});
+    test::ExpectTensorEqual(grad_inputs[0], {0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f});
 }
 
 TEST_P(AutogradReductionBackwardTest, MinBackward) {
@@ -70,7 +58,7 @@ TEST_P(AutogradReductionBackwardTest, MinBackward) {
     grad->Fill(1.0f);
     auto grad_inputs = min_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
-    ExpectValues(grad_inputs[0], {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f});
+    test::ExpectTensorEqual(grad_inputs[0], {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f});
 }
 
 TEST_P(AutogradReductionBackwardTest, SumBackwardKeepDim) {
@@ -82,7 +70,7 @@ TEST_P(AutogradReductionBackwardTest, SumBackwardKeepDim) {
     grad->Fill(1.0f);
     auto grad_inputs = sum_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
-    ExpectValues(grad_inputs[0], {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f});
+    test::ExpectTensorEqual(grad_inputs[0], {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f});
 }
 
 TEST_P(AutogradReductionBackwardTest, MeanBackwardKeepDim) {
@@ -94,7 +82,8 @@ TEST_P(AutogradReductionBackwardTest, MeanBackwardKeepDim) {
     grad->Fill(1.0f);
     auto grad_inputs = mean_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
-    ExpectValues(grad_inputs[0], {1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f});
+    test::ExpectTensorEqual(grad_inputs[0],
+                            {1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f});
 }
 
 INFINI_TRAIN_REGISTER_TEST(AutogradReductionBackwardTest);

--- a/tests/autograd/test_autograd_reduction_backward.cc
+++ b/tests/autograd/test_autograd_reduction_backward.cc
@@ -3,6 +3,7 @@
 #include "gtest/gtest.h"
 
 #include "infini_train/include/autograd/reduction.h"
+#include "infini_train/include/core/runtime/device_guard.h"
 #include "infini_train/include/nn/parallel/global.h"
 #include "infini_train/include/tensor.h"
 
@@ -11,6 +12,18 @@
 using namespace infini_train;
 
 class AutogradReductionBackwardTest : public infini_train::test::InfiniTrainTest {};
+
+namespace {
+void ExpectValues(const std::shared_ptr<Tensor> &tensor, const std::vector<float> &expected) {
+    auto cpu = std::make_shared<Tensor>(tensor->Dims(), tensor->Dtype(), Device());
+    cpu->CopyFrom(tensor);
+    core::GetDeviceGuardImpl(tensor->GetDevice().type())->SynchronizeDevice(tensor->GetDevice());
+
+    ASSERT_EQ(cpu->NumElements(), expected.size());
+    const float *actual = static_cast<const float *>(cpu->DataPtr());
+    for (size_t i = 0; i < expected.size(); ++i) { EXPECT_FLOAT_EQ(actual[i], expected[i]); }
+}
+} // namespace
 
 TEST_P(AutogradReductionBackwardTest, SumBackward) {
     auto a = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice(), true);
@@ -21,6 +34,7 @@ TEST_P(AutogradReductionBackwardTest, SumBackward) {
     grad->Fill(1.0f);
     auto grad_inputs = sum_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
+    ExpectValues(grad_inputs[0], {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f});
 }
 
 TEST_P(AutogradReductionBackwardTest, MeanBackward) {
@@ -32,28 +46,31 @@ TEST_P(AutogradReductionBackwardTest, MeanBackward) {
     grad->Fill(1.0f);
     auto grad_inputs = mean_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
+    ExpectValues(grad_inputs[0], {1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f});
 }
 
 TEST_P(AutogradReductionBackwardTest, MaxBackward) {
-    auto a = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice(), true);
-    a->Fill(1.0f);
+    std::vector<float> values{1.0f, 3.0f, 2.0f, 4.0f, 0.0f, -1.0f};
+    auto a = std::make_shared<Tensor>(values.data(), std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice());
     auto max_fn = std::make_shared<autograd::Max>(1, false);
     auto result = max_fn->Apply({a});
     auto grad = std::make_shared<Tensor>(std::vector<int64_t>{2}, DataType::kFLOAT32, GetDevice(), true);
     grad->Fill(1.0f);
     auto grad_inputs = max_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
+    ExpectValues(grad_inputs[0], {0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f});
 }
 
 TEST_P(AutogradReductionBackwardTest, MinBackward) {
-    auto a = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice(), true);
-    a->Fill(1.0f);
+    std::vector<float> values{1.0f, 3.0f, 2.0f, 4.0f, 0.0f, -1.0f};
+    auto a = std::make_shared<Tensor>(values.data(), std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice());
     auto min_fn = std::make_shared<autograd::Min>(1, false);
     auto result = min_fn->Apply({a});
     auto grad = std::make_shared<Tensor>(std::vector<int64_t>{2}, DataType::kFLOAT32, GetDevice(), true);
     grad->Fill(1.0f);
     auto grad_inputs = min_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
+    ExpectValues(grad_inputs[0], {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f});
 }
 
 TEST_P(AutogradReductionBackwardTest, SumBackwardKeepDim) {
@@ -65,6 +82,7 @@ TEST_P(AutogradReductionBackwardTest, SumBackwardKeepDim) {
     grad->Fill(1.0f);
     auto grad_inputs = sum_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
+    ExpectValues(grad_inputs[0], {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f});
 }
 
 TEST_P(AutogradReductionBackwardTest, MeanBackwardKeepDim) {
@@ -76,6 +94,7 @@ TEST_P(AutogradReductionBackwardTest, MeanBackwardKeepDim) {
     grad->Fill(1.0f);
     auto grad_inputs = mean_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
+    ExpectValues(grad_inputs[0], {1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f, 1.0f / 3.0f});
 }
 
 INFINI_TRAIN_REGISTER_TEST(AutogradReductionBackwardTest);

--- a/tests/autograd/test_autograd_softmax_backward.cc
+++ b/tests/autograd/test_autograd_softmax_backward.cc
@@ -3,7 +3,6 @@
 #include "gtest/gtest.h"
 
 #include "infini_train/include/autograd/softmax.h"
-#include "infini_train/include/core/runtime/device_guard.h"
 #include "infini_train/include/nn/parallel/global.h"
 #include "infini_train/include/tensor.h"
 
@@ -12,18 +11,6 @@
 using namespace infini_train;
 
 class AutogradSoftmaxBackwardTest : public infini_train::test::InfiniTrainTest {};
-
-namespace {
-void ExpectValues(const std::shared_ptr<Tensor> &tensor, const std::vector<float> &expected) {
-    auto cpu = std::make_shared<Tensor>(tensor->Dims(), tensor->Dtype(), Device());
-    cpu->CopyFrom(tensor);
-    core::GetDeviceGuardImpl(tensor->GetDevice().type())->SynchronizeDevice(tensor->GetDevice());
-
-    ASSERT_EQ(cpu->NumElements(), expected.size());
-    const float *actual = static_cast<const float *>(cpu->DataPtr());
-    for (size_t i = 0; i < expected.size(); ++i) { EXPECT_NEAR(actual[i], expected[i], 1e-6f); }
-}
-} // namespace
 
 TEST_P(AutogradSoftmaxBackwardTest, SoftmaxBackward) {
     auto a = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice(), true);
@@ -35,7 +22,8 @@ TEST_P(AutogradSoftmaxBackwardTest, SoftmaxBackward) {
         = std::make_shared<Tensor>(grad_values.data(), std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice());
     auto grad_inputs = softmax_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
-    ExpectValues(grad_inputs[0], {-4.0f / 9.0f, -1.0f / 9.0f, 5.0f / 9.0f, 5.0f / 9.0f, -1.0f / 9.0f, -4.0f / 9.0f});
+    test::ExpectTensorNear(grad_inputs[0],
+                           {-4.0f / 9.0f, -1.0f / 9.0f, 5.0f / 9.0f, 5.0f / 9.0f, -1.0f / 9.0f, -4.0f / 9.0f}, 1e-6f);
 }
 
 TEST_P(AutogradSoftmaxBackwardTest, SoftmaxBackwardDim0) {
@@ -48,8 +36,9 @@ TEST_P(AutogradSoftmaxBackwardTest, SoftmaxBackwardDim0) {
         = std::make_shared<Tensor>(grad_values.data(), std::vector<int64_t>{4, 3}, DataType::kFLOAT32, GetDevice());
     auto grad_inputs = softmax_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
-    ExpectValues(grad_inputs[0], {-1.125f, -1.125f, -1.125f, -0.375f, -0.375f, -0.375f, 0.375f, 0.375f, 0.375f, 1.125f,
-                                  1.125f, 1.125f});
+    test::ExpectTensorNear(
+        grad_inputs[0],
+        {-1.125f, -1.125f, -1.125f, -0.375f, -0.375f, -0.375f, 0.375f, 0.375f, 0.375f, 1.125f, 1.125f, 1.125f}, 1e-6f);
 }
 
 INFINI_TRAIN_REGISTER_TEST(AutogradSoftmaxBackwardTest);

--- a/tests/autograd/test_autograd_softmax_backward.cc
+++ b/tests/autograd/test_autograd_softmax_backward.cc
@@ -3,6 +3,7 @@
 #include "gtest/gtest.h"
 
 #include "infini_train/include/autograd/softmax.h"
+#include "infini_train/include/core/runtime/device_guard.h"
 #include "infini_train/include/nn/parallel/global.h"
 #include "infini_train/include/tensor.h"
 
@@ -12,15 +13,29 @@ using namespace infini_train;
 
 class AutogradSoftmaxBackwardTest : public infini_train::test::InfiniTrainTest {};
 
+namespace {
+void ExpectValues(const std::shared_ptr<Tensor> &tensor, const std::vector<float> &expected) {
+    auto cpu = std::make_shared<Tensor>(tensor->Dims(), tensor->Dtype(), Device());
+    cpu->CopyFrom(tensor);
+    core::GetDeviceGuardImpl(tensor->GetDevice().type())->SynchronizeDevice(tensor->GetDevice());
+
+    ASSERT_EQ(cpu->NumElements(), expected.size());
+    const float *actual = static_cast<const float *>(cpu->DataPtr());
+    for (size_t i = 0; i < expected.size(); ++i) { EXPECT_NEAR(actual[i], expected[i], 1e-6f); }
+}
+} // namespace
+
 TEST_P(AutogradSoftmaxBackwardTest, SoftmaxBackward) {
     auto a = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice(), true);
     a->Fill(1.0f);
     auto softmax_fn = std::make_shared<autograd::Softmax>(1);
     auto result = softmax_fn->Apply({a});
-    auto grad = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice(), true);
-    grad->Fill(1.0f);
+    std::vector<float> grad_values{1.0f, 2.0f, 4.0f, 4.0f, 2.0f, 1.0f};
+    auto grad
+        = std::make_shared<Tensor>(grad_values.data(), std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice());
     auto grad_inputs = softmax_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
+    ExpectValues(grad_inputs[0], {-4.0f / 9.0f, -1.0f / 9.0f, 5.0f / 9.0f, 5.0f / 9.0f, -1.0f / 9.0f, -4.0f / 9.0f});
 }
 
 TEST_P(AutogradSoftmaxBackwardTest, SoftmaxBackwardDim0) {
@@ -28,10 +43,13 @@ TEST_P(AutogradSoftmaxBackwardTest, SoftmaxBackwardDim0) {
     a->Fill(1.0f);
     auto softmax_fn = std::make_shared<autograd::Softmax>(0);
     auto result = softmax_fn->Apply({a});
-    auto grad = std::make_shared<Tensor>(std::vector<int64_t>{4, 3}, DataType::kFLOAT32, GetDevice(), true);
-    grad->Fill(1.0f);
+    std::vector<float> grad_values{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f};
+    auto grad
+        = std::make_shared<Tensor>(grad_values.data(), std::vector<int64_t>{4, 3}, DataType::kFLOAT32, GetDevice());
     auto grad_inputs = softmax_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
+    ExpectValues(grad_inputs[0], {-1.125f, -1.125f, -1.125f, -0.375f, -0.375f, -0.375f, 0.375f, 0.375f, 0.375f, 1.125f,
+                                  1.125f, 1.125f});
 }
 
 INFINI_TRAIN_REGISTER_TEST(AutogradSoftmaxBackwardTest);

--- a/tests/autograd/test_autograd_transform_backward.cc
+++ b/tests/autograd/test_autograd_transform_backward.cc
@@ -1,8 +1,10 @@
+#include <numeric>
 #include <vector>
 
 #include "gtest/gtest.h"
 
 #include "infini_train/include/autograd/transform.h"
+#include "infini_train/include/core/runtime/device_guard.h"
 #include "infini_train/include/nn/parallel/global.h"
 #include "infini_train/include/tensor.h"
 
@@ -11,6 +13,22 @@
 using namespace infini_train;
 
 class AutogradTransformBackwardTest : public infini_train::test::InfiniTrainTest {};
+
+namespace {
+std::shared_ptr<Tensor> CopyToCPU(const std::shared_ptr<Tensor> &tensor) {
+    auto cpu = std::make_shared<Tensor>(tensor->Dims(), tensor->Dtype(), Device());
+    cpu->CopyFrom(tensor);
+    core::GetDeviceGuardImpl(tensor->GetDevice().type())->SynchronizeDevice(tensor->GetDevice());
+    return cpu;
+}
+
+void ExpectValues(const std::shared_ptr<Tensor> &tensor, const std::vector<float> &expected) {
+    auto cpu = CopyToCPU(tensor);
+    ASSERT_EQ(cpu->NumElements(), expected.size());
+    const float *actual = static_cast<const float *>(cpu->DataPtr());
+    for (size_t i = 0; i < expected.size(); ++i) { EXPECT_FLOAT_EQ(actual[i], expected[i]); }
+}
+} // namespace
 
 TEST_P(AutogradTransformBackwardTest, TransposeBackward) {
     auto a = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice(), true);
@@ -21,6 +39,58 @@ TEST_P(AutogradTransformBackwardTest, TransposeBackward) {
     grad->Fill(1.0f);
     auto grad_inputs = transpose_fn->Backward({grad});
     EXPECT_EQ(grad_inputs.size(), 1);
+}
+
+TEST_P(AutogradTransformBackwardTest, SplitBackwardValues) {
+    auto input = std::make_shared<Tensor>(std::vector<int64_t>{2, 5}, DataType::kFLOAT32, GetDevice(), true);
+    auto split = std::make_shared<autograd::Split>(2, 1);
+    auto outputs = split->Apply({input});
+    ASSERT_EQ(outputs.size(), 3);
+
+    std::vector<std::shared_ptr<Tensor>> grad_outputs;
+    for (size_t i = 0; i < outputs.size(); ++i) {
+        auto grad = std::make_shared<Tensor>(outputs[i]->Dims(), DataType::kFLOAT32, GetDevice());
+        grad->Fill(static_cast<float>(i + 1));
+        grad_outputs.push_back(grad);
+    }
+
+    auto grad_inputs = split->Backward(grad_outputs);
+    ASSERT_EQ(grad_inputs.size(), 1);
+    ExpectValues(grad_inputs[0], {1.0f, 1.0f, 2.0f, 2.0f, 3.0f, 1.0f, 1.0f, 2.0f, 2.0f, 3.0f});
+}
+
+TEST_P(AutogradTransformBackwardTest, StackBackwardValues) {
+    auto a = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice(), true);
+    auto b = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice(), true);
+    auto stack = std::make_shared<autograd::Stack>(1);
+    auto outputs = stack->Apply({a, b});
+    ASSERT_EQ(outputs.size(), 1);
+
+    std::vector<float> grad_values(12);
+    std::iota(grad_values.begin(), grad_values.end(), 0.0f);
+    auto grad_output
+        = std::make_shared<Tensor>(grad_values.data(), outputs[0]->Dims(), DataType::kFLOAT32, GetDevice());
+    auto grad_inputs = stack->Backward({grad_output});
+    ASSERT_EQ(grad_inputs.size(), 2);
+    ExpectValues(grad_inputs[0], {0.0f, 1.0f, 2.0f, 6.0f, 7.0f, 8.0f});
+    ExpectValues(grad_inputs[1], {3.0f, 4.0f, 5.0f, 9.0f, 10.0f, 11.0f});
+}
+
+TEST_P(AutogradTransformBackwardTest, ConcatBackwardValues) {
+    auto a = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice(), true);
+    auto b = std::make_shared<Tensor>(std::vector<int64_t>{2, 1}, DataType::kFLOAT32, GetDevice(), true);
+    auto concat = std::make_shared<autograd::Concat>(1);
+    auto outputs = concat->Apply({a, b});
+    ASSERT_EQ(outputs.size(), 1);
+
+    std::vector<float> grad_values(6);
+    std::iota(grad_values.begin(), grad_values.end(), 0.0f);
+    auto grad_output
+        = std::make_shared<Tensor>(grad_values.data(), outputs[0]->Dims(), DataType::kFLOAT32, GetDevice());
+    auto grad_inputs = concat->Backward({grad_output});
+    ASSERT_EQ(grad_inputs.size(), 2);
+    ExpectValues(grad_inputs[0], {0.0f, 1.0f, 3.0f, 4.0f});
+    ExpectValues(grad_inputs[1], {2.0f, 5.0f});
 }
 
 INFINI_TRAIN_REGISTER_TEST(AutogradTransformBackwardTest);

--- a/tests/autograd/test_autograd_transform_backward.cc
+++ b/tests/autograd/test_autograd_transform_backward.cc
@@ -39,7 +39,7 @@ TEST_P(AutogradTransformBackwardTest, SplitBackwardValues) {
 
     auto grad_inputs = split->Backward(grad_outputs);
     ASSERT_EQ(grad_inputs.size(), 1);
-    test::ExpectTensorEqual(grad_inputs[0], {1.0f, 1.0f, 2.0f, 2.0f, 3.0f, 1.0f, 1.0f, 2.0f, 2.0f, 3.0f});
+    test::ExpectTensorFloatEqual(grad_inputs[0], {1.0f, 1.0f, 2.0f, 2.0f, 3.0f, 1.0f, 1.0f, 2.0f, 2.0f, 3.0f});
 }
 
 TEST_P(AutogradTransformBackwardTest, StackBackwardValues) {
@@ -55,8 +55,8 @@ TEST_P(AutogradTransformBackwardTest, StackBackwardValues) {
         = std::make_shared<Tensor>(grad_values.data(), outputs[0]->Dims(), DataType::kFLOAT32, GetDevice());
     auto grad_inputs = stack->Backward({grad_output});
     ASSERT_EQ(grad_inputs.size(), 2);
-    test::ExpectTensorEqual(grad_inputs[0], {0.0f, 1.0f, 2.0f, 6.0f, 7.0f, 8.0f});
-    test::ExpectTensorEqual(grad_inputs[1], {3.0f, 4.0f, 5.0f, 9.0f, 10.0f, 11.0f});
+    test::ExpectTensorFloatEqual(grad_inputs[0], {0.0f, 1.0f, 2.0f, 6.0f, 7.0f, 8.0f});
+    test::ExpectTensorFloatEqual(grad_inputs[1], {3.0f, 4.0f, 5.0f, 9.0f, 10.0f, 11.0f});
 }
 
 TEST_P(AutogradTransformBackwardTest, ConcatBackwardValues) {
@@ -72,8 +72,8 @@ TEST_P(AutogradTransformBackwardTest, ConcatBackwardValues) {
         = std::make_shared<Tensor>(grad_values.data(), outputs[0]->Dims(), DataType::kFLOAT32, GetDevice());
     auto grad_inputs = concat->Backward({grad_output});
     ASSERT_EQ(grad_inputs.size(), 2);
-    test::ExpectTensorEqual(grad_inputs[0], {0.0f, 1.0f, 3.0f, 4.0f});
-    test::ExpectTensorEqual(grad_inputs[1], {2.0f, 5.0f});
+    test::ExpectTensorFloatEqual(grad_inputs[0], {0.0f, 1.0f, 3.0f, 4.0f});
+    test::ExpectTensorFloatEqual(grad_inputs[1], {2.0f, 5.0f});
 }
 
 INFINI_TRAIN_REGISTER_TEST(AutogradTransformBackwardTest);

--- a/tests/autograd/test_autograd_transform_backward.cc
+++ b/tests/autograd/test_autograd_transform_backward.cc
@@ -4,7 +4,6 @@
 #include "gtest/gtest.h"
 
 #include "infini_train/include/autograd/transform.h"
-#include "infini_train/include/core/runtime/device_guard.h"
 #include "infini_train/include/nn/parallel/global.h"
 #include "infini_train/include/tensor.h"
 
@@ -13,22 +12,6 @@
 using namespace infini_train;
 
 class AutogradTransformBackwardTest : public infini_train::test::InfiniTrainTest {};
-
-namespace {
-std::shared_ptr<Tensor> CopyToCPU(const std::shared_ptr<Tensor> &tensor) {
-    auto cpu = std::make_shared<Tensor>(tensor->Dims(), tensor->Dtype(), Device());
-    cpu->CopyFrom(tensor);
-    core::GetDeviceGuardImpl(tensor->GetDevice().type())->SynchronizeDevice(tensor->GetDevice());
-    return cpu;
-}
-
-void ExpectValues(const std::shared_ptr<Tensor> &tensor, const std::vector<float> &expected) {
-    auto cpu = CopyToCPU(tensor);
-    ASSERT_EQ(cpu->NumElements(), expected.size());
-    const float *actual = static_cast<const float *>(cpu->DataPtr());
-    for (size_t i = 0; i < expected.size(); ++i) { EXPECT_FLOAT_EQ(actual[i], expected[i]); }
-}
-} // namespace
 
 TEST_P(AutogradTransformBackwardTest, TransposeBackward) {
     auto a = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice(), true);
@@ -56,7 +39,7 @@ TEST_P(AutogradTransformBackwardTest, SplitBackwardValues) {
 
     auto grad_inputs = split->Backward(grad_outputs);
     ASSERT_EQ(grad_inputs.size(), 1);
-    ExpectValues(grad_inputs[0], {1.0f, 1.0f, 2.0f, 2.0f, 3.0f, 1.0f, 1.0f, 2.0f, 2.0f, 3.0f});
+    test::ExpectTensorEqual(grad_inputs[0], {1.0f, 1.0f, 2.0f, 2.0f, 3.0f, 1.0f, 1.0f, 2.0f, 2.0f, 3.0f});
 }
 
 TEST_P(AutogradTransformBackwardTest, StackBackwardValues) {
@@ -72,8 +55,8 @@ TEST_P(AutogradTransformBackwardTest, StackBackwardValues) {
         = std::make_shared<Tensor>(grad_values.data(), outputs[0]->Dims(), DataType::kFLOAT32, GetDevice());
     auto grad_inputs = stack->Backward({grad_output});
     ASSERT_EQ(grad_inputs.size(), 2);
-    ExpectValues(grad_inputs[0], {0.0f, 1.0f, 2.0f, 6.0f, 7.0f, 8.0f});
-    ExpectValues(grad_inputs[1], {3.0f, 4.0f, 5.0f, 9.0f, 10.0f, 11.0f});
+    test::ExpectTensorEqual(grad_inputs[0], {0.0f, 1.0f, 2.0f, 6.0f, 7.0f, 8.0f});
+    test::ExpectTensorEqual(grad_inputs[1], {3.0f, 4.0f, 5.0f, 9.0f, 10.0f, 11.0f});
 }
 
 TEST_P(AutogradTransformBackwardTest, ConcatBackwardValues) {
@@ -89,8 +72,8 @@ TEST_P(AutogradTransformBackwardTest, ConcatBackwardValues) {
         = std::make_shared<Tensor>(grad_values.data(), outputs[0]->Dims(), DataType::kFLOAT32, GetDevice());
     auto grad_inputs = concat->Backward({grad_output});
     ASSERT_EQ(grad_inputs.size(), 2);
-    ExpectValues(grad_inputs[0], {0.0f, 1.0f, 3.0f, 4.0f});
-    ExpectValues(grad_inputs[1], {2.0f, 5.0f});
+    test::ExpectTensorEqual(grad_inputs[0], {0.0f, 1.0f, 3.0f, 4.0f});
+    test::ExpectTensorEqual(grad_inputs[1], {2.0f, 5.0f});
 }
 
 INFINI_TRAIN_REGISTER_TEST(AutogradTransformBackwardTest);

--- a/tests/autograd/test_autograd_transform_forward.cc
+++ b/tests/autograd/test_autograd_transform_forward.cc
@@ -30,7 +30,7 @@ TEST_P(AutogradTransformForwardTest, SliceForward) {
                                                       std::vector<int64_t>{1, 1});
     auto result = slice_fn->Apply({a});
     EXPECT_EQ(result.size(), 1);
-    test::ExpectTensorEqual(result[0], {5.0f, 6.0f, 9.0f, 10.0f});
+    test::ExpectTensorFloatEqual(result[0], {5.0f, 6.0f, 9.0f, 10.0f});
 }
 
 TEST_P(AutogradTransformForwardTest, SplitForward) {

--- a/tests/autograd/test_autograd_transform_forward.cc
+++ b/tests/autograd/test_autograd_transform_forward.cc
@@ -1,8 +1,10 @@
+#include <numeric>
 #include <vector>
 
 #include "gtest/gtest.h"
 
 #include "infini_train/include/autograd/transform.h"
+#include "infini_train/include/core/runtime/device_guard.h"
 #include "infini_train/include/nn/parallel/global.h"
 #include "infini_train/include/tensor.h"
 
@@ -11,6 +13,18 @@
 using namespace infini_train;
 
 class AutogradTransformForwardTest : public infini_train::test::InfiniTrainTest {};
+
+namespace {
+void ExpectValues(const std::shared_ptr<Tensor> &tensor, const std::vector<float> &expected) {
+    auto cpu = std::make_shared<Tensor>(tensor->Dims(), tensor->Dtype(), Device());
+    cpu->CopyFrom(tensor);
+    core::GetDeviceGuardImpl(tensor->GetDevice().type())->SynchronizeDevice(tensor->GetDevice());
+
+    ASSERT_EQ(cpu->NumElements(), expected.size());
+    const float *actual = static_cast<const float *>(cpu->DataPtr());
+    for (size_t i = 0; i < expected.size(); ++i) { EXPECT_FLOAT_EQ(actual[i], expected[i]); }
+}
+} // namespace
 
 TEST_P(AutogradTransformForwardTest, TransposeForward) {
     auto a = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice(), true);
@@ -22,12 +36,14 @@ TEST_P(AutogradTransformForwardTest, TransposeForward) {
 }
 
 TEST_P(AutogradTransformForwardTest, SliceForward) {
-    auto a = std::make_shared<Tensor>(std::vector<int64_t>{4, 4}, DataType::kFLOAT32, GetDevice(), true);
-    a->Fill(1.0f);
+    std::vector<float> values(16);
+    std::iota(values.begin(), values.end(), 0.0f);
+    auto a = std::make_shared<Tensor>(values.data(), std::vector<int64_t>{4, 4}, DataType::kFLOAT32, GetDevice());
     auto slice_fn = std::make_shared<autograd::Slice>(std::vector<int64_t>{1, 1}, std::vector<int64_t>{3, 3},
                                                       std::vector<int64_t>{1, 1});
     auto result = slice_fn->Apply({a});
     EXPECT_EQ(result.size(), 1);
+    ExpectValues(result[0], {5.0f, 6.0f, 9.0f, 10.0f});
 }
 
 TEST_P(AutogradTransformForwardTest, SplitForward) {

--- a/tests/autograd/test_autograd_transform_forward.cc
+++ b/tests/autograd/test_autograd_transform_forward.cc
@@ -4,7 +4,6 @@
 #include "gtest/gtest.h"
 
 #include "infini_train/include/autograd/transform.h"
-#include "infini_train/include/core/runtime/device_guard.h"
 #include "infini_train/include/nn/parallel/global.h"
 #include "infini_train/include/tensor.h"
 
@@ -13,18 +12,6 @@
 using namespace infini_train;
 
 class AutogradTransformForwardTest : public infini_train::test::InfiniTrainTest {};
-
-namespace {
-void ExpectValues(const std::shared_ptr<Tensor> &tensor, const std::vector<float> &expected) {
-    auto cpu = std::make_shared<Tensor>(tensor->Dims(), tensor->Dtype(), Device());
-    cpu->CopyFrom(tensor);
-    core::GetDeviceGuardImpl(tensor->GetDevice().type())->SynchronizeDevice(tensor->GetDevice());
-
-    ASSERT_EQ(cpu->NumElements(), expected.size());
-    const float *actual = static_cast<const float *>(cpu->DataPtr());
-    for (size_t i = 0; i < expected.size(); ++i) { EXPECT_FLOAT_EQ(actual[i], expected[i]); }
-}
-} // namespace
 
 TEST_P(AutogradTransformForwardTest, TransposeForward) {
     auto a = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice(), true);
@@ -43,7 +30,7 @@ TEST_P(AutogradTransformForwardTest, SliceForward) {
                                                       std::vector<int64_t>{1, 1});
     auto result = slice_fn->Apply({a});
     EXPECT_EQ(result.size(), 1);
-    ExpectValues(result[0], {5.0f, 6.0f, 9.0f, 10.0f});
+    test::ExpectTensorEqual(result[0], {5.0f, 6.0f, 9.0f, 10.0f});
 }
 
 TEST_P(AutogradTransformForwardTest, SplitForward) {

--- a/tests/checkpoint/test_checkpoint_serialization.cc
+++ b/tests/checkpoint/test_checkpoint_serialization.cc
@@ -47,9 +47,7 @@ TEST_P(CheckpointSerializationTest, SaveAndLoadModelFP32) {
     EXPECT_EQ(loaded.global_step, 42);
     EXPECT_EQ(loaded.consumed_batches, 100);
 
-    auto w1_cpu = model2->parameter("weight")->To(Device());
-    const float *data = static_cast<const float *>(w1_cpu.DataPtr());
-    for (int i = 0; i < 6; ++i) { EXPECT_NEAR(data[i], 0.42f, 1e-6); }
+    test::ExpectTensorNear(model2->parameter("weight"), 0.42f, 1e-6f);
 
     std::filesystem::remove_all(dir);
 }

--- a/tests/common/test_utils.h
+++ b/tests/common/test_utils.h
@@ -18,56 +18,55 @@ namespace test {
 // Use when the operation should preserve or deterministically reproduce FP32 values,
 // such as fill/copy and data movement or simple arithmetic with the same rounding path.
 // This overload checks the element count and flat order, but not the tensor shape.
-inline void ExpectTensorEqual(const std::shared_ptr<Tensor> &tensor, const std::vector<float> &expected) {
-    ASSERT_NE(tensor, nullptr);
-    ASSERT_EQ(tensor->Dtype(), DataType::kFLOAT32);
+inline void ExpectTensorFloatEqual(const std::shared_ptr<Tensor> &val1, const std::vector<float> &val2) {
+    ASSERT_NE(val1, nullptr);
+    ASSERT_EQ(val1->Dtype(), DataType::kFLOAT32);
 
-    auto cpu = tensor->To(Device());
-    ASSERT_EQ(cpu.NumElements(), expected.size());
-    const float *actual = static_cast<const float *>(cpu.DataPtr());
-    for (size_t i = 0; i < expected.size(); ++i) {
-        EXPECT_FLOAT_EQ(actual[i], expected[i]) << "Mismatch at flat index " << i;
+    auto val1_cpu = val1->To(Device());
+    ASSERT_EQ(val1_cpu.NumElements(), val2.size());
+    const float *val1_data = static_cast<const float *>(val1_cpu.DataPtr());
+    for (size_t i = 0; i < val2.size(); ++i) {
+        EXPECT_FLOAT_EQ(val1_data[i], val2[i]) << "Mismatch at flat index " << i;
     }
 }
 
-inline void ExpectTensorEqual(const std::shared_ptr<Tensor> &tensor, float expected) {
-    ASSERT_NE(tensor, nullptr);
-    ASSERT_EQ(tensor->Dtype(), DataType::kFLOAT32);
+inline void ExpectTensorFloatEqual(const std::shared_ptr<Tensor> &val1, float val2) {
+    ASSERT_NE(val1, nullptr);
+    ASSERT_EQ(val1->Dtype(), DataType::kFLOAT32);
 
-    auto cpu = tensor->To(Device());
-    const float *actual = static_cast<const float *>(cpu.DataPtr());
-    for (size_t i = 0; i < cpu.NumElements(); ++i) {
-        EXPECT_FLOAT_EQ(actual[i], expected) << "Mismatch at flat index " << i;
+    auto val1_cpu = val1->To(Device());
+    const float *val1_data = static_cast<const float *>(val1_cpu.DataPtr());
+    for (size_t i = 0; i < val1_cpu.NumElements(); ++i) {
+        EXPECT_FLOAT_EQ(val1_data[i], val2) << "Mismatch at flat index " << i;
     }
 }
 
-// Compares flattened FP32 values using the caller-provided absolute tolerance.
+// Compares flattened FP32 values using the caller-provided absolute error bound.
 // Use for numerically computed results whose rounding can vary with operation order or backend,
-// such as reductions, normalization, softmax, and loss calculations. The tolerance is not relative.
+// such as reductions, normalization, softmax, and loss calculations. abs_error is an absolute, not relative, bound.
 // This overload checks the element count and flat order, but not the tensor shape.
-inline void ExpectTensorNear(const std::shared_ptr<Tensor> &tensor, const std::vector<float> &expected,
-                             float tolerance) {
-    ASSERT_NE(tensor, nullptr);
-    ASSERT_EQ(tensor->Dtype(), DataType::kFLOAT32);
-    ASSERT_GE(tolerance, 0.0f);
+inline void ExpectTensorNear(const std::shared_ptr<Tensor> &val1, const std::vector<float> &val2, float abs_error) {
+    ASSERT_NE(val1, nullptr);
+    ASSERT_EQ(val1->Dtype(), DataType::kFLOAT32);
+    ASSERT_GE(abs_error, 0.0f);
 
-    auto cpu = tensor->To(Device());
-    ASSERT_EQ(cpu.NumElements(), expected.size());
-    const float *actual = static_cast<const float *>(cpu.DataPtr());
-    for (size_t i = 0; i < expected.size(); ++i) {
-        EXPECT_NEAR(actual[i], expected[i], tolerance) << "Mismatch at flat index " << i;
+    auto val1_cpu = val1->To(Device());
+    ASSERT_EQ(val1_cpu.NumElements(), val2.size());
+    const float *val1_data = static_cast<const float *>(val1_cpu.DataPtr());
+    for (size_t i = 0; i < val2.size(); ++i) {
+        EXPECT_NEAR(val1_data[i], val2[i], abs_error) << "Mismatch at flat index " << i;
     }
 }
 
-inline void ExpectTensorNear(const std::shared_ptr<Tensor> &tensor, float expected, float tolerance) {
-    ASSERT_NE(tensor, nullptr);
-    ASSERT_EQ(tensor->Dtype(), DataType::kFLOAT32);
-    ASSERT_GE(tolerance, 0.0f);
+inline void ExpectTensorNear(const std::shared_ptr<Tensor> &val1, float val2, float abs_error) {
+    ASSERT_NE(val1, nullptr);
+    ASSERT_EQ(val1->Dtype(), DataType::kFLOAT32);
+    ASSERT_GE(abs_error, 0.0f);
 
-    auto cpu = tensor->To(Device());
-    const float *actual = static_cast<const float *>(cpu.DataPtr());
-    for (size_t i = 0; i < cpu.NumElements(); ++i) {
-        EXPECT_NEAR(actual[i], expected, tolerance) << "Mismatch at flat index " << i;
+    auto val1_cpu = val1->To(Device());
+    const float *val1_data = static_cast<const float *>(val1_cpu.DataPtr());
+    for (size_t i = 0; i < val1_cpu.NumElements(); ++i) {
+        EXPECT_NEAR(val1_data[i], val2, abs_error) << "Mismatch at flat index " << i;
     }
 }
 

--- a/tests/common/test_utils.h
+++ b/tests/common/test_utils.h
@@ -1,14 +1,75 @@
 #pragma once
 
+#include <memory>
+#include <vector>
+
 #if defined(USE_CUDA)
 #include <cuda_runtime_api.h>
 #endif
 
 #include "infini_train/include/device.h"
+#include "infini_train/include/tensor.h"
 #include "gtest/gtest.h"
 
 namespace infini_train {
 namespace test {
+
+// Compares flattened FP32 values with EXPECT_FLOAT_EQ (up to 4 ULPs, not bitwise equality).
+// Use when the operation should preserve or deterministically reproduce FP32 values,
+// such as fill/copy and data movement or simple arithmetic with the same rounding path.
+// This overload checks the element count and flat order, but not the tensor shape.
+inline void ExpectTensorEqual(const std::shared_ptr<Tensor> &tensor, const std::vector<float> &expected) {
+    ASSERT_NE(tensor, nullptr);
+    ASSERT_EQ(tensor->Dtype(), DataType::kFLOAT32);
+
+    auto cpu = tensor->To(Device());
+    ASSERT_EQ(cpu.NumElements(), expected.size());
+    const float *actual = static_cast<const float *>(cpu.DataPtr());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_FLOAT_EQ(actual[i], expected[i]) << "Mismatch at flat index " << i;
+    }
+}
+
+inline void ExpectTensorEqual(const std::shared_ptr<Tensor> &tensor, float expected) {
+    ASSERT_NE(tensor, nullptr);
+    ASSERT_EQ(tensor->Dtype(), DataType::kFLOAT32);
+
+    auto cpu = tensor->To(Device());
+    const float *actual = static_cast<const float *>(cpu.DataPtr());
+    for (size_t i = 0; i < cpu.NumElements(); ++i) {
+        EXPECT_FLOAT_EQ(actual[i], expected) << "Mismatch at flat index " << i;
+    }
+}
+
+// Compares flattened FP32 values using the caller-provided absolute tolerance.
+// Use for numerically computed results whose rounding can vary with operation order or backend,
+// such as reductions, normalization, softmax, and loss calculations. The tolerance is not relative.
+// This overload checks the element count and flat order, but not the tensor shape.
+inline void ExpectTensorNear(const std::shared_ptr<Tensor> &tensor, const std::vector<float> &expected,
+                             float tolerance) {
+    ASSERT_NE(tensor, nullptr);
+    ASSERT_EQ(tensor->Dtype(), DataType::kFLOAT32);
+    ASSERT_GE(tolerance, 0.0f);
+
+    auto cpu = tensor->To(Device());
+    ASSERT_EQ(cpu.NumElements(), expected.size());
+    const float *actual = static_cast<const float *>(cpu.DataPtr());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_NEAR(actual[i], expected[i], tolerance) << "Mismatch at flat index " << i;
+    }
+}
+
+inline void ExpectTensorNear(const std::shared_ptr<Tensor> &tensor, float expected, float tolerance) {
+    ASSERT_NE(tensor, nullptr);
+    ASSERT_EQ(tensor->Dtype(), DataType::kFLOAT32);
+    ASSERT_GE(tolerance, 0.0f);
+
+    auto cpu = tensor->To(Device());
+    const float *actual = static_cast<const float *>(cpu.DataPtr());
+    for (size_t i = 0; i < cpu.NumElements(); ++i) {
+        EXPECT_NEAR(actual[i], expected, tolerance) << "Mismatch at flat index " << i;
+    }
+}
 
 #if defined(USE_CUDA)
 #define REQUIRE_MIN_DEVICES(n)                                                                                         \

--- a/tests/tensor/cpu_only/test_tensor_copy.cc
+++ b/tests/tensor/cpu_only/test_tensor_copy.cc
@@ -18,5 +18,5 @@ TEST_F(TensorCopyCpuTest, CopiesCPUToCPU) {
         = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, Device(Device::DeviceType::kCPU, 0));
     source->Fill(1.0f);
     target->CopyFrom(source);
-    test::ExpectTensorEqual(target, 1.0f);
+    test::ExpectTensorFloatEqual(target, 1.0f);
 }

--- a/tests/tensor/cpu_only/test_tensor_copy.cc
+++ b/tests/tensor/cpu_only/test_tensor_copy.cc
@@ -5,6 +5,8 @@
 
 #include "infini_train/include/tensor.h"
 
+#include "tests/common/test_utils.h"
+
 using namespace infini_train;
 
 class TensorCopyCpuTest : public ::testing::Test {};
@@ -16,6 +18,5 @@ TEST_F(TensorCopyCpuTest, CopiesCPUToCPU) {
         = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, Device(Device::DeviceType::kCPU, 0));
     source->Fill(1.0f);
     target->CopyFrom(source);
-    auto *target_data = static_cast<float *>(target->DataPtr());
-    for (int i = 0; i < 6; ++i) { EXPECT_FLOAT_EQ(target_data[i], 1.0f); }
+    test::ExpectTensorEqual(target, 1.0f);
 }

--- a/tests/tensor/test_tensor_delete.cc
+++ b/tests/tensor/test_tensor_delete.cc
@@ -25,17 +25,10 @@ TEST_P(TensorDeleteTest, MoveTransferKeepsData) {
     auto tensor = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice());
     tensor->Fill(5.0f);
 
-    // Verify data via CPU copy for any device.
-    auto cpu_copy
-        = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, Device(Device::DeviceType::kCPU, 0));
-    cpu_copy->CopyFrom(tensor);
-
     auto moved = std::move(tensor);
     EXPECT_EQ(tensor, nullptr);
     ASSERT_NE(moved, nullptr);
-
-    auto *data = static_cast<float *>(cpu_copy->DataPtr());
-    for (int i = 0; i < 6; ++i) { EXPECT_FLOAT_EQ(data[i], 5.0f); }
+    test::ExpectTensorEqual(moved, 5.0f);
 }
 
 TEST_P(TensorDeleteTest, NullifiesPointerOnMove) {

--- a/tests/tensor/test_tensor_delete.cc
+++ b/tests/tensor/test_tensor_delete.cc
@@ -28,7 +28,7 @@ TEST_P(TensorDeleteTest, MoveTransferKeepsData) {
     auto moved = std::move(tensor);
     EXPECT_EQ(tensor, nullptr);
     ASSERT_NE(moved, nullptr);
-    test::ExpectTensorEqual(moved, 5.0f);
+    test::ExpectTensorFloatEqual(moved, 5.0f);
 }
 
 TEST_P(TensorDeleteTest, NullifiesPointerOnMove) {


### PR DESCRIPTION
## Summary

- defer loss host synchronization until after backward in GPT-2, Llama3, MNIST, and pipeline training
- skip zero initialization where CUDA kernels or cuBLAS fully overwrite output tensors
- add numerical CPU and CUDA coverage for the affected operators

## Test

<img width="1133" height="1481" alt="image" src="https://github.com/user-attachments/assets/32c6dfbc-efe3-40b8-aea7-43693dbc1830" />

<img width="864" height="1448" alt="image" src="https://github.com/user-attachments/assets/d7bf583d-214c-4df8-8feb-c907aa4cee88" />
