### PR TITLE
Feat: add named parameters

### DIFF
--- a/docs/lora_usage_guide.md
+++ b/docs/lora_usage_guide.md
@@ -30,7 +30,7 @@ model = GetLoRAModel(model, config);
 PrintLoRASummary(model);
 
 auto params = GetLoRAParameters(model);
-auto optimizer = infini_train::optimizers::Adam::Create(/*learning_rate=*/1e-4)(params);
+auto optimizer = infini_train::optimizers::Adam::Create(/*learning_rate=*/1e-4)(params, model->NamedParameters());
 
 for (int step = 0; step < num_steps; ++step) {
     optimizer->ZeroGrad();

--- a/example/gpt2/main.cc
+++ b/example/gpt2/main.cc
@@ -329,15 +329,16 @@ void Train(const nn::parallel::Rank &rank) {
     // auto optimizer = optimizers::SGD(model->Parameters(), FLAGS_learning_rate);
     auto optimizer_creator = optimizers::SGD::Create(FLAGS_learning_rate);
     std::shared_ptr<Optimizer> optimizer = nullptr;
+    const auto named_parameters = model->NamedParameters();
 
     if (FLAGS_zero_stage >= 1) {
         auto model_chunks = (pp_world_size > 1)
                               ? *(dynamic_cast<nn::parallel::PipelineParallel *>(model.get())->mutable_chunks())
                               : std::vector<std::shared_ptr<nn::Module>>{model};
-        optimizer = std::make_shared<nn::parallel::DistributedOptimizer>(optimizer_creator, params_to_optimize,
-                                                                         model_chunks, ddp_world_size, ddp_rank);
+        optimizer = std::make_shared<nn::parallel::DistributedOptimizer>(
+            optimizer_creator, params_to_optimize, named_parameters, model_chunks, ddp_world_size, ddp_rank);
     } else {
-        optimizer = optimizer_creator(params_to_optimize);
+        optimizer = optimizer_creator(params_to_optimize, named_parameters);
     }
 
     const int64_t lr_decay_iters = FLAGS_lr_decay_iters > 0 ? FLAGS_lr_decay_iters : FLAGS_num_iteration;

--- a/example/gpt2/main.cc
+++ b/example/gpt2/main.cc
@@ -327,18 +327,28 @@ void Train(const nn::parallel::Rank &rank) {
 
     // TODO(dcj): support more complex optimizer later
     // auto optimizer = optimizers::SGD(model->Parameters(), FLAGS_learning_rate);
-    auto optimizer_creator = optimizers::SGD::Create(FLAGS_learning_rate);
+    auto optimizer_creator = optimizers::SGD::CreateNamed(FLAGS_learning_rate);
     std::shared_ptr<Optimizer> optimizer = nullptr;
-    const auto named_parameters = model->NamedParameters();
+    std::unordered_set<const Tensor *> params_to_optimize_set;
+    params_to_optimize_set.reserve(params_to_optimize.size());
+    for (const auto &param : params_to_optimize) { params_to_optimize_set.insert(param.get()); }
+
+    NamedParameterList named_parameters;
+    for (const auto &[name, param] : model->NamedParameters()) {
+        if (params_to_optimize_set.contains(param.get())) {
+            named_parameters.emplace_back(name, param);
+        }
+    }
+    CHECK_EQ(named_parameters.size(), params_to_optimize.size());
 
     if (FLAGS_zero_stage >= 1) {
         auto model_chunks = (pp_world_size > 1)
                               ? *(dynamic_cast<nn::parallel::PipelineParallel *>(model.get())->mutable_chunks())
                               : std::vector<std::shared_ptr<nn::Module>>{model};
-        optimizer = std::make_shared<nn::parallel::DistributedOptimizer>(
-            optimizer_creator, params_to_optimize, named_parameters, model_chunks, ddp_world_size, ddp_rank);
+        optimizer = std::make_shared<nn::parallel::DistributedOptimizer>(optimizer_creator, named_parameters,
+                                                                         model_chunks, ddp_world_size, ddp_rank);
     } else {
-        optimizer = optimizer_creator(params_to_optimize, named_parameters);
+        optimizer = optimizer_creator(named_parameters);
     }
 
     const int64_t lr_decay_iters = FLAGS_lr_decay_iters > 0 ? FLAGS_lr_decay_iters : FLAGS_num_iteration;

--- a/example/llama3/main.cc
+++ b/example/llama3/main.cc
@@ -311,15 +311,16 @@ void Train(const nn::parallel::Rank &rank) {
         params_to_optimize = model->Parameters();
         LOG(INFO) << "Optimizing " << params_to_optimize.size() << " model parameters";
     }
+    const auto named_parameters = model->NamedParameters();
 
     if (FLAGS_zero_stage >= 1) {
         auto model_chunks = (pp_world_size > 1)
                               ? *(dynamic_cast<nn::parallel::PipelineParallel *>(model.get())->mutable_chunks())
                               : std::vector<std::shared_ptr<nn::Module>>{model};
-        optimizer = std::make_shared<nn::parallel::DistributedOptimizer>(optimizer_creator, params_to_optimize,
-                                                                         model_chunks, ddp_world_size, ddp_rank);
+        optimizer = std::make_shared<nn::parallel::DistributedOptimizer>(
+            optimizer_creator, params_to_optimize, named_parameters, model_chunks, ddp_world_size, ddp_rank);
     } else {
-        optimizer = optimizer_creator(params_to_optimize);
+        optimizer = optimizer_creator(params_to_optimize, named_parameters);
     }
 
     const int64_t lr_decay_iters = FLAGS_lr_decay_iters > 0 ? FLAGS_lr_decay_iters : FLAGS_num_iteration;

--- a/example/llama3/main.cc
+++ b/example/llama3/main.cc
@@ -300,7 +300,7 @@ void Train(const nn::parallel::Rank &rank) {
 
     // TODO(dcj): support more complex optimizer later
     // auto optimizer = optimizers::Adam(model->Parameters(), FLAGS_learning_rate);
-    auto optimizer_creator = optimizers::Adam::Create(FLAGS_learning_rate);
+    auto optimizer_creator = optimizers::Adam::CreateNamed(FLAGS_learning_rate);
     std::shared_ptr<Optimizer> optimizer = nullptr;
 
     std::vector<std::shared_ptr<Tensor>> params_to_optimize;
@@ -311,16 +311,26 @@ void Train(const nn::parallel::Rank &rank) {
         params_to_optimize = model->Parameters();
         LOG(INFO) << "Optimizing " << params_to_optimize.size() << " model parameters";
     }
-    const auto named_parameters = model->NamedParameters();
+    std::unordered_set<const Tensor *> params_to_optimize_set;
+    params_to_optimize_set.reserve(params_to_optimize.size());
+    for (const auto &param : params_to_optimize) { params_to_optimize_set.insert(param.get()); }
+
+    NamedParameterList named_parameters;
+    for (const auto &[name, param] : model->NamedParameters()) {
+        if (params_to_optimize_set.contains(param.get())) {
+            named_parameters.emplace_back(name, param);
+        }
+    }
+    CHECK_EQ(named_parameters.size(), params_to_optimize.size());
 
     if (FLAGS_zero_stage >= 1) {
         auto model_chunks = (pp_world_size > 1)
                               ? *(dynamic_cast<nn::parallel::PipelineParallel *>(model.get())->mutable_chunks())
                               : std::vector<std::shared_ptr<nn::Module>>{model};
-        optimizer = std::make_shared<nn::parallel::DistributedOptimizer>(
-            optimizer_creator, params_to_optimize, named_parameters, model_chunks, ddp_world_size, ddp_rank);
+        optimizer = std::make_shared<nn::parallel::DistributedOptimizer>(optimizer_creator, named_parameters,
+                                                                         model_chunks, ddp_world_size, ddp_rank);
     } else {
-        optimizer = optimizer_creator(params_to_optimize, named_parameters);
+        optimizer = optimizer_creator(named_parameters);
     }
 
     const int64_t lr_decay_iters = FLAGS_lr_decay_iters > 0 ? FLAGS_lr_decay_iters : FLAGS_num_iteration;

--- a/example/mixtral/main.cc
+++ b/example/mixtral/main.cc
@@ -104,8 +104,8 @@ int main(int argc, char *argv[]) {
     }
 
     auto loss_fn = std::make_shared<infini_train::nn::CrossEntropyLoss>();
-    auto optimizer = infini_train::optimizers::Adam::Create(static_cast<float>(FLAGS_learning_rate))(
-        model->Parameters(), model->NamedParameters());
+    auto optimizer = infini_train::optimizers::Adam::CreateNamed(static_cast<float>(FLAGS_learning_rate))(
+        model->NamedParameters());
 
     auto device_impl = infini_train::core::GetDeviceGuardImpl(train_device.type());
     std::vector<double> step_duration_ms;

--- a/example/mixtral/main.cc
+++ b/example/mixtral/main.cc
@@ -104,8 +104,8 @@ int main(int argc, char *argv[]) {
     }
 
     auto loss_fn = std::make_shared<infini_train::nn::CrossEntropyLoss>();
-    auto optimizer
-        = infini_train::optimizers::Adam::Create(static_cast<float>(FLAGS_learning_rate))(model->Parameters());
+    auto optimizer = infini_train::optimizers::Adam::Create(static_cast<float>(FLAGS_learning_rate))(
+        model->Parameters(), model->NamedParameters());
 
     auto device_impl = infini_train::core::GetDeviceGuardImpl(train_device.type());
     std::vector<double> step_duration_ms;

--- a/infini_train/include/nn/modules/module.h
+++ b/infini_train/include/nn/modules/module.h
@@ -49,7 +49,7 @@ public:
 
     // TODO: Change return type to filterable iterator (like PyTorch's named_parameters with prefix matching)
     virtual std::vector<std::shared_ptr<Tensor>> Parameters() const;
-    virtual std::vector<std::pair<std::string, std::shared_ptr<Tensor>>>
+    std::vector<std::pair<std::string, std::shared_ptr<Tensor>>>
     NamedParameters(const std::string &prefix = "", bool recurse = true, bool remove_duplicate = true) const;
     bool has_parameter(const std::string &name) const;
     std::shared_ptr<Tensor> *mutable_parameter(const std::string &name);

--- a/infini_train/include/nn/modules/module.h
+++ b/infini_train/include/nn/modules/module.h
@@ -49,6 +49,8 @@ public:
 
     // TODO: Change return type to filterable iterator (like PyTorch's named_parameters with prefix matching)
     virtual std::vector<std::shared_ptr<Tensor>> Parameters() const;
+    virtual std::vector<std::pair<std::string, std::shared_ptr<Tensor>>>
+    NamedParameters(const std::string &prefix = "", bool recurse = true, bool remove_duplicate = true) const;
     bool has_parameter(const std::string &name) const;
     std::shared_ptr<Tensor> *mutable_parameter(const std::string &name);
     const std::shared_ptr<Tensor> &parameter(const std::string &name) const;

--- a/infini_train/include/nn/modules/module.h
+++ b/infini_train/include/nn/modules/module.h
@@ -47,8 +47,10 @@ public:
 
     const std::string &type() const;
 
-    // TODO: Change return type to filterable iterator (like PyTorch's named_parameters with prefix matching)
     virtual std::vector<std::shared_ptr<Tensor>> Parameters() const;
+
+    // InfiniTrain's NamedParameters returns results ordered by full parameter name.
+    // TODO: Align with PyTorch's ordering in the future.
     std::vector<std::pair<std::string, std::shared_ptr<Tensor>>>
     NamedParameters(const std::string &prefix = "", bool recurse = true, bool remove_duplicate = true) const;
     bool has_parameter(const std::string &name) const;

--- a/infini_train/include/nn/parallel/ddp/distributed_optimizer.h
+++ b/infini_train/include/nn/parallel/ddp/distributed_optimizer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -21,7 +22,10 @@ class DistributedOptimizer final : public infini_train::Optimizer {
 public:
     DistributedOptimizer(OptimizerCreator base_optimizer_creator,
                          const std::vector<std::shared_ptr<Tensor>> &full_params,
-                         const NamedParameterList &named_parameters,
+                         const std::vector<std::shared_ptr<Module>> &model_chunks, size_t ddp_world_size,
+                         size_t ddp_rank);
+
+    DistributedOptimizer(OptimizerCreatorNamed base_optimizer_creator, const NamedParameterList &named_parameters,
                          const std::vector<std::shared_ptr<Module>> &model_chunks, size_t ddp_world_size,
                          size_t ddp_rank);
 
@@ -43,9 +47,10 @@ public:
     virtual float learning_rate() const override;
 
 private:
-    void BuildShardParamsAndBindGrads(const NamedParameterList &named_parameters,
-                                      std::vector<std::shared_ptr<Tensor>> &shard_params,
-                                      NamedParameterList &shard_named_parameters);
+    using AddShardParam = std::function<void(const std::shared_ptr<Tensor> &, const std::shared_ptr<Tensor> &)>;
+
+    void InitializeModelChunks(const std::vector<std::shared_ptr<Module>> &model_chunks);
+    void BuildShardParamsAndBindGrads(const AddShardParam &add_shard_param);
 
 private:
     // Inherit from DDP model

--- a/infini_train/include/nn/parallel/ddp/distributed_optimizer.h
+++ b/infini_train/include/nn/parallel/ddp/distributed_optimizer.h
@@ -43,7 +43,9 @@ public:
     virtual float learning_rate() const override;
 
 private:
-    void BuildShardParamsAndBindGrads();
+    void BuildShardParamsAndBindGrads(const NamedParameterList &named_parameters,
+                                      std::vector<std::shared_ptr<Tensor>> &shard_params,
+                                      NamedParameterList &shard_named_parameters);
 
 private:
     // Inherit from DDP model
@@ -53,11 +55,6 @@ private:
     // DP info
     size_t ddp_world_size_;
     size_t ddp_rank_;
-
-    // shard params
-    std::vector<std::shared_ptr<Tensor>> shard_params_;
-    NamedParameterList shard_named_parameters_;
-    std::unordered_map<const Tensor *, std::string> parameter_name_by_tensor_;
 
     // Base optimizer (SGD, Adam and etc.)
     std::shared_ptr<Optimizer> base_optimizer_;

--- a/infini_train/include/nn/parallel/ddp/distributed_optimizer.h
+++ b/infini_train/include/nn/parallel/ddp/distributed_optimizer.h
@@ -21,6 +21,7 @@ class DistributedOptimizer final : public infini_train::Optimizer {
 public:
     DistributedOptimizer(OptimizerCreator base_optimizer_creator,
                          const std::vector<std::shared_ptr<Tensor>> &full_params,
+                         const NamedParameterList &named_parameters,
                          const std::vector<std::shared_ptr<Module>> &model_chunks, size_t ddp_world_size,
                          size_t ddp_rank);
 
@@ -55,6 +56,8 @@ private:
 
     // shard params
     std::vector<std::shared_ptr<Tensor>> shard_params_;
+    NamedParameterList shard_named_parameters_;
+    std::unordered_map<const Tensor *, std::string> parameter_name_by_tensor_;
 
     // Base optimizer (SGD, Adam and etc.)
     std::shared_ptr<Optimizer> base_optimizer_;

--- a/infini_train/include/optimizer.h
+++ b/infini_train/include/optimizer.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace infini_train {
@@ -13,11 +14,15 @@ class Tensor;
 namespace infini_train {
 class Optimizer;
 
-using OptimizerCreator = std::function<std::shared_ptr<Optimizer>(const std::vector<std::shared_ptr<Tensor>> &params)>;
+using NamedParameter = std::pair<std::string, std::shared_ptr<Tensor>>;
+using NamedParameterList = std::vector<NamedParameter>;
+using OptimizerCreator = std::function<std::shared_ptr<Optimizer>(const std::vector<std::shared_ptr<Tensor>> &params,
+                                                                  const NamedParameterList &named_parameters)>;
 
 class Optimizer {
 public:
-    explicit Optimizer(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate = 0.0f);
+    explicit Optimizer(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate = 0.0f,
+                       const NamedParameterList &named_parameters = {});
 
     virtual void ZeroGrad(bool set_to_none = true);
 
@@ -37,8 +42,11 @@ public:
 
     void set_initial_learning_rate(float lr);
 
+    void set_parameter_names(const std::vector<std::string> &names);
+
 protected:
     std::vector<std::shared_ptr<Tensor>> params_;
+    std::vector<std::string> parameter_names_;
     float learning_rate_ = 0.0f;
     float initial_learning_rate_ = 0.0f;
     bool initial_lr_set_ = false;
@@ -47,7 +55,8 @@ protected:
 namespace optimizers {
 class SGD : public Optimizer {
 public:
-    SGD(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate);
+    SGD(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate,
+        const NamedParameterList &named_parameters = {});
 
     void Step() override;
 
@@ -57,7 +66,7 @@ public:
 class Adam : public Optimizer {
 public:
     Adam(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate = 1e-3, float beta1 = 0.9,
-         float beta2 = 0.999, float eps = 1e-8);
+         float beta2 = 0.999, float eps = 1e-8, const NamedParameterList &named_parameters = {});
 
     void Step() override;
 

--- a/infini_train/include/optimizer.h
+++ b/infini_train/include/optimizer.h
@@ -42,8 +42,6 @@ public:
 
     void set_initial_learning_rate(float lr);
 
-    void set_parameter_names(const std::vector<std::string> &names);
-
 protected:
     std::vector<std::shared_ptr<Tensor>> params_;
     std::vector<std::string> parameter_names_;

--- a/infini_train/include/optimizer.h
+++ b/infini_train/include/optimizer.h
@@ -16,13 +16,14 @@ class Optimizer;
 
 using NamedParameter = std::pair<std::string, std::shared_ptr<Tensor>>;
 using NamedParameterList = std::vector<NamedParameter>;
-using OptimizerCreator = std::function<std::shared_ptr<Optimizer>(const std::vector<std::shared_ptr<Tensor>> &params,
-                                                                  const NamedParameterList &named_parameters)>;
+using OptimizerCreator = std::function<std::shared_ptr<Optimizer>(const std::vector<std::shared_ptr<Tensor>> &params)>;
+using OptimizerCreatorNamed = std::function<std::shared_ptr<Optimizer>(const NamedParameterList &named_params)>;
 
 class Optimizer {
 public:
-    explicit Optimizer(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate = 0.0f,
-                       const NamedParameterList &named_parameters = {});
+    explicit Optimizer(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate);
+
+    Optimizer(const NamedParameterList &named_params, float learning_rate);
 
     virtual void ZeroGrad(bool set_to_none = true);
 
@@ -53,18 +54,21 @@ protected:
 namespace optimizers {
 class SGD : public Optimizer {
 public:
-    SGD(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate,
-        const NamedParameterList &named_parameters = {});
+    SGD(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate);
+    SGD(const NamedParameterList &named_params, float learning_rate);
 
     void Step() override;
 
     static OptimizerCreator Create(float learning_rate);
+    static OptimizerCreatorNamed CreateNamed(float learning_rate);
 };
 
 class Adam : public Optimizer {
 public:
     Adam(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate = 1e-3, float beta1 = 0.9,
-         float beta2 = 0.999, float eps = 1e-8, const NamedParameterList &named_parameters = {});
+         float beta2 = 0.999, float eps = 1e-8);
+    Adam(const NamedParameterList &named_params, float learning_rate = 1e-3, float beta1 = 0.9, float beta2 = 0.999,
+         float eps = 1e-8);
 
     void Step() override;
 
@@ -73,6 +77,8 @@ public:
     void LoadStateDict(const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict) override;
     static OptimizerCreator Create(float learning_rate = 1e-3, float beta1 = 0.9, float beta2 = 0.999,
                                    float eps = 1e-8);
+    static OptimizerCreatorNamed CreateNamed(float learning_rate = 1e-3, float beta1 = 0.9, float beta2 = 0.999,
+                                             float eps = 1e-8);
 
 private:
     int64_t t_;

--- a/infini_train/src/nn/modules/module.cc
+++ b/infini_train/src/nn/modules/module.cc
@@ -51,36 +51,38 @@ std::vector<std::shared_ptr<Tensor>> Module::Parameters() const {
 std::vector<std::pair<std::string, std::shared_ptr<Tensor>>>
 Module::NamedParameters(const std::string &prefix, bool recurse, bool remove_duplicate) const {
     std::vector<std::pair<std::string, std::shared_ptr<Tensor>>> named_parameters;
-    std::unordered_set<const Tensor *> visited;
 
-    std::vector<std::pair<std::string, std::shared_ptr<Module>>> named_modules;
-    if (recurse) {
-        // NamedModules only reads the hierarchy and provides its stable, name-sorted traversal order. Keep all module
-        // aliases here so parameter-level deduplication deterministically selects the first full parameter name.
-        named_modules
-            = const_cast<Module *>(this)->NamedModules(/*memory=*/nullptr, prefix, /*remove_duplicate=*/false);
-    } else {
-        named_modules.emplace_back(prefix, std::const_pointer_cast<Module>(shared_from_this()));
-    }
+    std::function<void(const Module &, const std::string &)> collect
+        = [&](const Module &module, const std::string &module_prefix) {
+              for (const auto &[name, parameter] : module.parameters_) {
+                  if (!parameter) {
+                      continue;
+                  }
+                  const auto full_name = module_prefix.empty() ? name : module_prefix + "." + name;
+                  named_parameters.emplace_back(full_name, parameter);
+              }
 
-    for (const auto &[module_prefix, module] : named_modules) {
-        std::vector<std::pair<std::string, std::shared_ptr<Tensor>>> local_parameters;
-        local_parameters.reserve(module->parameters_.size());
-        for (const auto &[name, parameter] : module->parameters_) {
-            if (parameter) {
-                local_parameters.emplace_back(name, parameter);
-            }
-        }
-        std::sort(local_parameters.begin(), local_parameters.end(),
-                  [](const auto &lhs, const auto &rhs) { return lhs.first < rhs.first; });
+              if (!recurse) {
+                  return;
+              }
+              for (const auto &[name, child] : module.modules_) {
+                  if (!child) {
+                      continue;
+                  }
+                  const auto child_prefix = module_prefix.empty() ? name : module_prefix + "." + name;
+                  collect(*child, child_prefix);
+              }
+          };
 
-        for (const auto &[name, parameter] : local_parameters) {
-            if (remove_duplicate && !visited.insert(parameter.get()).second) {
-                continue;
-            }
-            const auto full_name = module_prefix.empty() ? name : module_prefix + "." + name;
-            named_parameters.emplace_back(full_name, parameter);
-        }
+    collect(*this, prefix);
+    std::sort(named_parameters.begin(), named_parameters.end(),
+              [](const auto &lhs, const auto &rhs) { return lhs.first < rhs.first; });
+
+    if (remove_duplicate) {
+        std::unordered_set<const Tensor *> visited;
+        std::erase_if(named_parameters, [&](const auto &named_parameter) {
+            return !visited.insert(named_parameter.second.get()).second;
+        });
     }
     return named_parameters;
 }

--- a/infini_train/src/nn/modules/module.cc
+++ b/infini_train/src/nn/modules/module.cc
@@ -48,6 +48,55 @@ std::vector<std::shared_ptr<Tensor>> Module::Parameters() const {
     return params;
 }
 
+std::vector<std::pair<std::string, std::shared_ptr<Tensor>>>
+Module::NamedParameters(const std::string &prefix, bool recurse, bool remove_duplicate) const {
+    std::vector<std::pair<std::string, std::shared_ptr<Tensor>>> named_parameters;
+    std::unordered_set<const Tensor *> visited;
+
+    std::function<void(const Module &, const std::string &)> collect
+        = [&](const Module &module, const std::string &module_prefix) {
+              std::vector<std::pair<std::string, std::shared_ptr<Tensor>>> parameters;
+              parameters.reserve(module.parameters_.size());
+              for (const auto &[name, parameter] : module.parameters_) {
+                  if (parameter) {
+                      parameters.emplace_back(name, parameter);
+                  }
+              }
+              std::sort(parameters.begin(), parameters.end(),
+                        [](const auto &left, const auto &right) { return left.first < right.first; });
+
+              for (auto &[name, parameter] : parameters) {
+                  if (remove_duplicate && !visited.insert(parameter.get()).second) {
+                      continue;
+                  }
+                  const auto full_name = module_prefix.empty() ? name : module_prefix + "." + name;
+                  named_parameters.emplace_back(full_name, std::move(parameter));
+              }
+
+              if (!recurse) {
+                  return;
+              }
+
+              std::vector<std::pair<std::string, std::shared_ptr<Module>>> children;
+              children.reserve(module.modules_.size());
+              for (const auto &[name, child] : module.modules_) {
+                  if (child) {
+                      children.emplace_back(name, child);
+                  }
+              }
+              std::sort(children.begin(), children.end(),
+                        [](const auto &left, const auto &right) { return left.first < right.first; });
+
+              for (const auto &[name, child] : children) {
+                  const auto child_prefix = module_prefix.empty() ? name : module_prefix + "." + name;
+                  collect(*child, child_prefix);
+              }
+          };
+
+    collect(*this, prefix);
+    return named_parameters;
+}
+
 bool Module::has_parameter(const std::string &name) const { return parameters_.find(name) != parameters_.end(); }
 
 std::shared_ptr<Tensor> *Module::mutable_parameter(const std::string &name) {

--- a/infini_train/src/nn/modules/module.cc
+++ b/infini_train/src/nn/modules/module.cc
@@ -28,22 +28,12 @@ Module::Module(const std::string &type) : type_(type), device_(Device()) {}
 const std::string &Module::type() const { return type_; }
 
 std::vector<std::shared_ptr<Tensor>> Module::Parameters() const {
+    const auto &named_parameters = NamedParameters();
+
     std::vector<std::shared_ptr<Tensor>> params;
-    std::unordered_set<const Tensor *> visited;
+    params.reserve(named_parameters.size());
 
-    auto AddIfUnvisited = [&](const std::shared_ptr<Tensor> &param) {
-        if (visited.insert(param.get()).second) {
-            params.push_back(param);
-        }
-    };
-
-    // Add parameters of this module
-    for (const auto &[_, param] : parameters_) { AddIfUnvisited(param); }
-
-    // Recursively add parameters of submodules
-    for (const auto &[_, module] : modules_) {
-        for (const auto &param : module->Parameters()) { AddIfUnvisited(param); }
-    }
+    for (const auto &[_, param] : named_parameters) { params.emplace_back(param); }
 
     return params;
 }
@@ -51,39 +41,41 @@ std::vector<std::shared_ptr<Tensor>> Module::Parameters() const {
 std::vector<std::pair<std::string, std::shared_ptr<Tensor>>>
 Module::NamedParameters(const std::string &prefix, bool recurse, bool remove_duplicate) const {
     std::vector<std::pair<std::string, std::shared_ptr<Tensor>>> named_parameters;
+    std::unordered_set<const Tensor *> visited_parameters;
 
-    std::function<void(const Module &, const std::string &)> collect
-        = [&](const Module &module, const std::string &module_prefix) {
-              for (const auto &[name, parameter] : module.parameters_) {
-                  if (!parameter) {
-                      continue;
-                  }
-                  const auto full_name = module_prefix.empty() ? name : module_prefix + "." + name;
-                  named_parameters.emplace_back(full_name, parameter);
-              }
+    std::vector<std::pair<std::string, std::shared_ptr<Module>>> named_modules;
 
-              if (!recurse) {
-                  return;
-              }
-              for (const auto &[name, child] : module.modules_) {
-                  if (!child) {
-                      continue;
-                  }
-                  const auto child_prefix = module_prefix.empty() ? name : module_prefix + "." + name;
-                  collect(*child, child_prefix);
-              }
-          };
-
-    collect(*this, prefix);
-    std::sort(named_parameters.begin(), named_parameters.end(),
-              [](const auto &lhs, const auto &rhs) { return lhs.first < rhs.first; });
-
-    if (remove_duplicate) {
-        std::unordered_set<const Tensor *> visited;
-        std::erase_if(named_parameters, [&](const auto &named_parameter) {
-            return !visited.insert(named_parameter.second.get()).second;
-        });
+    if (recurse) {
+        named_modules = const_cast<Module *>(this)->NamedModules(
+            /*memory=*/nullptr, prefix, remove_duplicate);
+    } else {
+        named_modules.emplace_back(prefix, std::const_pointer_cast<Module>(shared_from_this()));
     }
+
+    for (const auto &[module_prefix, module] : named_modules) {
+        std::vector<std::pair<std::string, std::shared_ptr<Tensor>>> local_parameters;
+        local_parameters.reserve(module->parameters_.size());
+
+        for (const auto &[name, parameter] : module->parameters_) {
+            if (parameter != nullptr) {
+                local_parameters.emplace_back(name, parameter);
+            }
+        }
+
+        std::sort(local_parameters.begin(), local_parameters.end(),
+                  [](const auto &lhs, const auto &rhs) { return lhs.first < rhs.first; });
+
+        for (const auto &[name, parameter] : local_parameters) {
+            if (remove_duplicate && !visited_parameters.insert(parameter.get()).second) {
+                continue;
+            }
+
+            const std::string full_name = module_prefix.empty() ? name : module_prefix + "." + name;
+
+            named_parameters.emplace_back(full_name, parameter);
+        }
+    }
+
     return named_parameters;
 }
 

--- a/infini_train/src/nn/modules/module.cc
+++ b/infini_train/src/nn/modules/module.cc
@@ -53,47 +53,35 @@ Module::NamedParameters(const std::string &prefix, bool recurse, bool remove_dup
     std::vector<std::pair<std::string, std::shared_ptr<Tensor>>> named_parameters;
     std::unordered_set<const Tensor *> visited;
 
-    std::function<void(const Module &, const std::string &)> collect
-        = [&](const Module &module, const std::string &module_prefix) {
-              std::vector<std::pair<std::string, std::shared_ptr<Tensor>>> parameters;
-              parameters.reserve(module.parameters_.size());
-              for (const auto &[name, parameter] : module.parameters_) {
-                  if (parameter) {
-                      parameters.emplace_back(name, parameter);
-                  }
-              }
-              std::sort(parameters.begin(), parameters.end(),
-                        [](const auto &left, const auto &right) { return left.first < right.first; });
+    std::vector<std::pair<std::string, std::shared_ptr<Module>>> named_modules;
+    if (recurse) {
+        // NamedModules only reads the hierarchy and provides its stable, name-sorted traversal order. Keep all module
+        // aliases here so parameter-level deduplication deterministically selects the first full parameter name.
+        named_modules
+            = const_cast<Module *>(this)->NamedModules(/*memory=*/nullptr, prefix, /*remove_duplicate=*/false);
+    } else {
+        named_modules.emplace_back(prefix, std::const_pointer_cast<Module>(shared_from_this()));
+    }
 
-              for (auto &[name, parameter] : parameters) {
-                  if (remove_duplicate && !visited.insert(parameter.get()).second) {
-                      continue;
-                  }
-                  const auto full_name = module_prefix.empty() ? name : module_prefix + "." + name;
-                  named_parameters.emplace_back(full_name, std::move(parameter));
-              }
+    for (const auto &[module_prefix, module] : named_modules) {
+        std::vector<std::pair<std::string, std::shared_ptr<Tensor>>> local_parameters;
+        local_parameters.reserve(module->parameters_.size());
+        for (const auto &[name, parameter] : module->parameters_) {
+            if (parameter) {
+                local_parameters.emplace_back(name, parameter);
+            }
+        }
+        std::sort(local_parameters.begin(), local_parameters.end(),
+                  [](const auto &lhs, const auto &rhs) { return lhs.first < rhs.first; });
 
-              if (!recurse) {
-                  return;
-              }
-
-              std::vector<std::pair<std::string, std::shared_ptr<Module>>> children;
-              children.reserve(module.modules_.size());
-              for (const auto &[name, child] : module.modules_) {
-                  if (child) {
-                      children.emplace_back(name, child);
-                  }
-              }
-              std::sort(children.begin(), children.end(),
-                        [](const auto &left, const auto &right) { return left.first < right.first; });
-
-              for (const auto &[name, child] : children) {
-                  const auto child_prefix = module_prefix.empty() ? name : module_prefix + "." + name;
-                  collect(*child, child_prefix);
-              }
-          };
-
-    collect(*this, prefix);
+        for (const auto &[name, parameter] : local_parameters) {
+            if (remove_duplicate && !visited.insert(parameter.get()).second) {
+                continue;
+            }
+            const auto full_name = module_prefix.empty() ? name : module_prefix + "." + name;
+            named_parameters.emplace_back(full_name, parameter);
+        }
+    }
     return named_parameters;
 }
 

--- a/infini_train/src/nn/parallel/ddp/distributed_optimizer.cc
+++ b/infini_train/src/nn/parallel/ddp/distributed_optimizer.cc
@@ -8,11 +8,49 @@
 namespace infini_train::nn::parallel {
 DistributedOptimizer::DistributedOptimizer(OptimizerCreator creator,
                                            const std::vector<std::shared_ptr<Tensor>> &full_params,
-                                           const NamedParameterList &named_parameters,
                                            const std::vector<std::shared_ptr<Module>> &model_chunks,
                                            size_t ddp_world_size, size_t ddp_rank)
     : Optimizer(full_params, /*learning_rate=*/0.0f), ddp_world_size_(ddp_world_size), ddp_rank_(ddp_rank) {
+    InitializeModelChunks(model_chunks);
 
+    std::vector<std::shared_ptr<Tensor>> shard_params;
+    BuildShardParamsAndBindGrads(
+        [&shard_params](const std::shared_ptr<Tensor> &, const std::shared_ptr<Tensor> &param_piece) {
+            shard_params.push_back(param_piece);
+        });
+
+    base_optimizer_ = creator(shard_params);
+    CHECK(base_optimizer_) << "DistributedOptimizer: failed to create base optimizer.";
+}
+
+DistributedOptimizer::DistributedOptimizer(OptimizerCreatorNamed creator, const NamedParameterList &named_parameters,
+                                           const std::vector<std::shared_ptr<Module>> &model_chunks,
+                                           size_t ddp_world_size, size_t ddp_rank)
+    : Optimizer(named_parameters, /*learning_rate=*/0.0f), ddp_world_size_(ddp_world_size), ddp_rank_(ddp_rank) {
+    InitializeModelChunks(model_chunks);
+
+    std::unordered_map<const Tensor *, std::string> parameter_name_by_tensor;
+    parameter_name_by_tensor.reserve(named_parameters.size());
+    for (const auto &[name, parameter] : named_parameters) {
+        CHECK(parameter);
+        parameter_name_by_tensor.emplace(parameter.get(), name);
+    }
+
+    NamedParameterList shard_named_parameters;
+    BuildShardParamsAndBindGrads(
+        [&parameter_name_by_tensor, &shard_named_parameters](const std::shared_ptr<Tensor> &parameter,
+                                                             const std::shared_ptr<Tensor> &param_piece) {
+            const auto name_it = parameter_name_by_tensor.find(parameter.get());
+            CHECK(name_it != parameter_name_by_tensor.end())
+                << "DistributedOptimizer parameter is not registered in the model";
+            shard_named_parameters.emplace_back(name_it->second, param_piece);
+        });
+
+    base_optimizer_ = creator(shard_named_parameters);
+    CHECK(base_optimizer_) << "DistributedOptimizer: failed to create base optimizer.";
+}
+
+void DistributedOptimizer::InitializeModelChunks(const std::vector<std::shared_ptr<Module>> &model_chunks) {
     CHECK(ddp_world_size_ > 1) << "DistributedOptimizer: ddp_world_size must be greater than 1.";
 
     for (size_t i = 0; i < model_chunks.size(); ++i) {
@@ -24,25 +62,10 @@ DistributedOptimizer::DistributedOptimizer(OptimizerCreator creator,
         bucket_groups_.insert(bucket_groups_.end(), ddp_chunk->bucket_groups().begin(),
                               ddp_chunk->bucket_groups().end());
     }
-
-    std::vector<std::shared_ptr<Tensor>> shard_params;
-    NamedParameterList shard_named_parameters;
-    BuildShardParamsAndBindGrads(named_parameters, shard_params, shard_named_parameters);
-
-    // Build base optimizer
-    base_optimizer_ = creator(shard_params, shard_named_parameters);
-    CHECK(base_optimizer_) << "DistributedOptimizer: failed to create base optimizer.";
 }
 
-void DistributedOptimizer::BuildShardParamsAndBindGrads(const NamedParameterList &named_parameters,
-                                                        std::vector<std::shared_ptr<Tensor>> &shard_params,
-                                                        NamedParameterList &shard_named_parameters) {
-    std::unordered_map<const Tensor *, std::string> parameter_name_by_tensor;
-    parameter_name_by_tensor.reserve(named_parameters.size());
-    for (const auto &[name, parameter] : named_parameters) {
-        CHECK(parameter);
-        parameter_name_by_tensor.emplace(parameter.get(), name);
-    }
+void DistributedOptimizer::BuildShardParamsAndBindGrads(const AddShardParam &add_shard_param) {
+    size_t num_shard_params = 0;
 
     for (const auto &group : bucket_groups_) {
         const bool use_grad_shard = group->config().zero_stage >= 2;
@@ -92,17 +115,14 @@ void DistributedOptimizer::BuildShardParamsAndBindGrads(const NamedParameterList
                 // NOTE(zbl): Do not call `param->set_grad(grad_piece);` under ZeRO-2.
                 //            The base optimizer updates param_piece views only; original param->grad()
                 //            would be a partial flattened shard and does not represent the full parameter grad.
-                shard_params.push_back(param_piece);
-                const auto name_it = parameter_name_by_tensor.find(param.get());
-                CHECK(name_it != parameter_name_by_tensor.end())
-                    << "DistributedOptimizer parameter is not registered in the model";
-                shard_named_parameters.emplace_back(name_it->second, param_piece);
+                add_shard_param(param, param_piece);
+                ++num_shard_params;
             }
         }
     }
 
-    CHECK(!shard_params.empty()) << "DistributedOptimizer: this DP rank owns no param pieces. "
-                                 << "Check bucket padding/divisibility and param bucketing order.";
+    CHECK_GT(num_shard_params, 0) << "DistributedOptimizer: this DP rank owns no param pieces. "
+                                  << "Check bucket padding/divisibility and param bucketing order.";
 }
 
 void DistributedOptimizer::StartGradSync() {

--- a/infini_train/src/nn/parallel/ddp/distributed_optimizer.cc
+++ b/infini_train/src/nn/parallel/ddp/distributed_optimizer.cc
@@ -8,11 +8,18 @@
 namespace infini_train::nn::parallel {
 DistributedOptimizer::DistributedOptimizer(OptimizerCreator creator,
                                            const std::vector<std::shared_ptr<Tensor>> &full_params,
+                                           const NamedParameterList &named_parameters,
                                            const std::vector<std::shared_ptr<Module>> &model_chunks,
                                            size_t ddp_world_size, size_t ddp_rank)
-    : Optimizer(full_params), ddp_world_size_(ddp_world_size), ddp_rank_(ddp_rank) {
+    : Optimizer(full_params, /*learning_rate=*/0.0f, named_parameters), ddp_world_size_(ddp_world_size),
+      ddp_rank_(ddp_rank) {
 
     CHECK(ddp_world_size_ > 1) << "DistributedOptimizer: ddp_world_size must be greater than 1.";
+    parameter_name_by_tensor_.reserve(named_parameters.size());
+    for (const auto &[name, parameter] : named_parameters) {
+        CHECK(parameter);
+        parameter_name_by_tensor_.emplace(parameter.get(), name);
+    }
 
     for (size_t i = 0; i < model_chunks.size(); ++i) {
         auto ddp_chunk = std::dynamic_pointer_cast<DistributedDataParallel>(model_chunks[i]);
@@ -27,12 +34,13 @@ DistributedOptimizer::DistributedOptimizer(OptimizerCreator creator,
     BuildShardParamsAndBindGrads();
 
     // Build base optimizer
-    base_optimizer_ = creator(shard_params_);
+    base_optimizer_ = creator(shard_params_, shard_named_parameters_);
     CHECK(base_optimizer_) << "DistributedOptimizer: failed to create base optimizer.";
 }
 
 void DistributedOptimizer::BuildShardParamsAndBindGrads() {
     shard_params_.clear();
+    shard_named_parameters_.clear();
 
     for (const auto &group : bucket_groups_) {
         const bool use_grad_shard = group->config().zero_stage >= 2;
@@ -83,6 +91,10 @@ void DistributedOptimizer::BuildShardParamsAndBindGrads() {
                 //            The base optimizer updates param_piece views only; original param->grad()
                 //            would be a partial flattened shard and does not represent the full parameter grad.
                 shard_params_.push_back(param_piece);
+                const auto name_it = parameter_name_by_tensor_.find(param.get());
+                CHECK(name_it != parameter_name_by_tensor_.end())
+                    << "DistributedOptimizer parameter is not registered in the model";
+                shard_named_parameters_.emplace_back(name_it->second, param_piece);
             }
         }
     }

--- a/infini_train/src/nn/parallel/ddp/distributed_optimizer.cc
+++ b/infini_train/src/nn/parallel/ddp/distributed_optimizer.cc
@@ -11,15 +11,9 @@ DistributedOptimizer::DistributedOptimizer(OptimizerCreator creator,
                                            const NamedParameterList &named_parameters,
                                            const std::vector<std::shared_ptr<Module>> &model_chunks,
                                            size_t ddp_world_size, size_t ddp_rank)
-    : Optimizer(full_params, /*learning_rate=*/0.0f, named_parameters), ddp_world_size_(ddp_world_size),
-      ddp_rank_(ddp_rank) {
+    : Optimizer(full_params, /*learning_rate=*/0.0f), ddp_world_size_(ddp_world_size), ddp_rank_(ddp_rank) {
 
     CHECK(ddp_world_size_ > 1) << "DistributedOptimizer: ddp_world_size must be greater than 1.";
-    parameter_name_by_tensor_.reserve(named_parameters.size());
-    for (const auto &[name, parameter] : named_parameters) {
-        CHECK(parameter);
-        parameter_name_by_tensor_.emplace(parameter.get(), name);
-    }
 
     for (size_t i = 0; i < model_chunks.size(); ++i) {
         auto ddp_chunk = std::dynamic_pointer_cast<DistributedDataParallel>(model_chunks[i]);
@@ -31,16 +25,24 @@ DistributedOptimizer::DistributedOptimizer(OptimizerCreator creator,
                               ddp_chunk->bucket_groups().end());
     }
 
-    BuildShardParamsAndBindGrads();
+    std::vector<std::shared_ptr<Tensor>> shard_params;
+    NamedParameterList shard_named_parameters;
+    BuildShardParamsAndBindGrads(named_parameters, shard_params, shard_named_parameters);
 
     // Build base optimizer
-    base_optimizer_ = creator(shard_params_, shard_named_parameters_);
+    base_optimizer_ = creator(shard_params, shard_named_parameters);
     CHECK(base_optimizer_) << "DistributedOptimizer: failed to create base optimizer.";
 }
 
-void DistributedOptimizer::BuildShardParamsAndBindGrads() {
-    shard_params_.clear();
-    shard_named_parameters_.clear();
+void DistributedOptimizer::BuildShardParamsAndBindGrads(const NamedParameterList &named_parameters,
+                                                        std::vector<std::shared_ptr<Tensor>> &shard_params,
+                                                        NamedParameterList &shard_named_parameters) {
+    std::unordered_map<const Tensor *, std::string> parameter_name_by_tensor;
+    parameter_name_by_tensor.reserve(named_parameters.size());
+    for (const auto &[name, parameter] : named_parameters) {
+        CHECK(parameter);
+        parameter_name_by_tensor.emplace(parameter.get(), name);
+    }
 
     for (const auto &group : bucket_groups_) {
         const bool use_grad_shard = group->config().zero_stage >= 2;
@@ -90,17 +92,17 @@ void DistributedOptimizer::BuildShardParamsAndBindGrads() {
                 // NOTE(zbl): Do not call `param->set_grad(grad_piece);` under ZeRO-2.
                 //            The base optimizer updates param_piece views only; original param->grad()
                 //            would be a partial flattened shard and does not represent the full parameter grad.
-                shard_params_.push_back(param_piece);
-                const auto name_it = parameter_name_by_tensor_.find(param.get());
-                CHECK(name_it != parameter_name_by_tensor_.end())
+                shard_params.push_back(param_piece);
+                const auto name_it = parameter_name_by_tensor.find(param.get());
+                CHECK(name_it != parameter_name_by_tensor.end())
                     << "DistributedOptimizer parameter is not registered in the model";
-                shard_named_parameters_.emplace_back(name_it->second, param_piece);
+                shard_named_parameters.emplace_back(name_it->second, param_piece);
             }
         }
     }
 
-    CHECK(!shard_params_.empty()) << "DistributedOptimizer: this DP rank owns no param pieces. "
-                                  << "Check bucket padding/divisibility and param bucketing order.";
+    CHECK(!shard_params.empty()) << "DistributedOptimizer: this DP rank owns no param pieces. "
+                                 << "Check bucket padding/divisibility and param bucketing order.";
 }
 
 void DistributedOptimizer::StartGradSync() {

--- a/infini_train/src/optimizer.cc
+++ b/infini_train/src/optimizer.cc
@@ -9,25 +9,19 @@
 #include "infini_train/include/tensor.h"
 
 namespace infini_train {
-Optimizer::Optimizer(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate,
-                     const NamedParameterList &named_parameters)
-    : params_(params), learning_rate_(learning_rate) {
-    if (named_parameters.empty()) {
+Optimizer::Optimizer(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate)
+    : params_(params), learning_rate_(learning_rate) {}
+
+Optimizer::Optimizer(const NamedParameterList &named_params, float learning_rate) : learning_rate_(learning_rate) {
+    if (named_params.empty()) {
         return;
     }
 
-    std::unordered_map<const Tensor *, std::string> parameter_name_by_tensor;
-    parameter_name_by_tensor.reserve(named_parameters.size());
-    for (const auto &[name, parameter] : named_parameters) {
-        CHECK(parameter);
-        parameter_name_by_tensor.emplace(parameter.get(), name);
-    }
-
-    parameter_names_.reserve(params_.size());
-    for (const auto &parameter : params_) {
-        const auto it = parameter_name_by_tensor.find(parameter.get());
-        CHECK(it != parameter_name_by_tensor.end()) << "Optimizer parameter is not registered in the model";
-        parameter_names_.push_back(it->second);
+    params_.reserve(named_params.size());
+    parameter_names_.reserve(named_params.size());
+    for (const auto &[name, parameter] : named_params) {
+        params_.push_back(parameter);
+        parameter_names_.push_back(name);
     }
 }
 
@@ -55,9 +49,9 @@ void Optimizer::set_initial_learning_rate(float lr) {
 
 namespace optimizers {
 
-SGD::SGD(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate,
-         const NamedParameterList &named_parameters)
-    : Optimizer(params, learning_rate, named_parameters) {}
+SGD::SGD(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate) : Optimizer(params, learning_rate) {}
+
+SGD::SGD(const NamedParameterList &named_params, float learning_rate) : Optimizer(named_params, learning_rate) {}
 
 void SGD::Step() {
     for (auto param : params_) {
@@ -73,17 +67,31 @@ void SGD::Step() {
 }
 
 OptimizerCreator SGD::Create(float learning_rate) {
-    return [learning_rate](const std::vector<std::shared_ptr<Tensor>> &params,
-                           const NamedParameterList &named_parameters) {
-        return std::make_shared<SGD>(params, learning_rate, named_parameters);
+    return [learning_rate](const std::vector<std::shared_ptr<Tensor>> &params) {
+        return std::make_shared<SGD>(params, learning_rate);
     };
 }
 
-Adam::Adam(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate, float beta1, float beta2, float eps,
-           const NamedParameterList &named_parameters)
-    : Optimizer(params, learning_rate, named_parameters), t_(0), beta1_(beta1), beta2_(beta2), eps_(eps) {
+OptimizerCreatorNamed SGD::CreateNamed(float learning_rate) {
+    return [learning_rate](const NamedParameterList &named_params) {
+        return std::make_shared<SGD>(named_params, learning_rate);
+    };
+}
+
+Adam::Adam(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate, float beta1, float beta2, float eps)
+    : Optimizer(params, learning_rate), t_(0), beta1_(beta1), beta2_(beta2), eps_(eps) {
 
     for (const auto &param : params_) {
+        m_.emplace_back(std::make_shared<Tensor>(param->Dims(), param->Dtype(), param->GetDevice()));
+        v_.emplace_back(std::make_shared<Tensor>(param->Dims(), param->Dtype(), param->GetDevice()));
+        m_.back()->Fill(0.0);
+        v_.back()->Fill(0.0);
+    }
+}
+
+Adam::Adam(const NamedParameterList &named_params, float learning_rate, float beta1, float beta2, float eps)
+    : Optimizer(named_params, learning_rate), t_(0), beta1_(beta1), beta2_(beta2), eps_(eps) {
+    for (const auto &[name, param] : named_params) {
         m_.emplace_back(std::make_shared<Tensor>(param->Dims(), param->Dtype(), param->GetDevice()));
         v_.emplace_back(std::make_shared<Tensor>(param->Dims(), param->Dtype(), param->GetDevice()));
         m_.back()->Fill(0.0);
@@ -112,8 +120,14 @@ void Adam::Step() {
 }
 
 OptimizerCreator Adam::Create(float learning_rate, float beta1, float beta2, float eps) {
-    return [=](const std::vector<std::shared_ptr<Tensor>> &params, const NamedParameterList &named_parameters) {
-        return std::make_shared<Adam>(params, learning_rate, beta1, beta2, eps, named_parameters);
+    return [=](const std::vector<std::shared_ptr<Tensor>> &params) {
+        return std::make_shared<Adam>(params, learning_rate, beta1, beta2, eps);
+    };
+}
+
+OptimizerCreatorNamed Adam::CreateNamed(float learning_rate, float beta1, float beta2, float eps) {
+    return [=](const NamedParameterList &named_params) {
+        return std::make_shared<Adam>(named_params, learning_rate, beta1, beta2, eps);
     };
 }
 

--- a/infini_train/src/optimizer.cc
+++ b/infini_train/src/optimizer.cc
@@ -53,11 +53,6 @@ void Optimizer::set_initial_learning_rate(float lr) {
     initial_lr_set_ = true;
 }
 
-void Optimizer::set_parameter_names(const std::vector<std::string> &names) {
-    CHECK_EQ(names.size(), params_.size());
-    parameter_names_ = names;
-}
-
 namespace optimizers {
 
 SGD::SGD(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate,

--- a/infini_train/src/optimizer.cc
+++ b/infini_train/src/optimizer.cc
@@ -1,6 +1,6 @@
 #include "infini_train/include/optimizer.h"
 
-#include <format>
+#include <unordered_map>
 #include <vector>
 
 #include "infini_train/include/core/runtime/device_guard.h"
@@ -9,8 +9,27 @@
 #include "infini_train/include/tensor.h"
 
 namespace infini_train {
-Optimizer::Optimizer(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate)
-    : params_(params), learning_rate_(learning_rate) {}
+Optimizer::Optimizer(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate,
+                     const NamedParameterList &named_parameters)
+    : params_(params), learning_rate_(learning_rate) {
+    if (named_parameters.empty()) {
+        return;
+    }
+
+    std::unordered_map<const Tensor *, std::string> parameter_name_by_tensor;
+    parameter_name_by_tensor.reserve(named_parameters.size());
+    for (const auto &[name, parameter] : named_parameters) {
+        CHECK(parameter);
+        parameter_name_by_tensor.emplace(parameter.get(), name);
+    }
+
+    parameter_names_.reserve(params_.size());
+    for (const auto &parameter : params_) {
+        const auto it = parameter_name_by_tensor.find(parameter.get());
+        CHECK(it != parameter_name_by_tensor.end()) << "Optimizer parameter is not registered in the model";
+        parameter_names_.push_back(it->second);
+    }
+}
 
 void Optimizer::ZeroGrad(bool set_to_none) {
     for (auto param : params_) { param->ZeroGrad(set_to_none); }
@@ -33,9 +52,17 @@ void Optimizer::set_initial_learning_rate(float lr) {
     initial_learning_rate_ = lr;
     initial_lr_set_ = true;
 }
+
+void Optimizer::set_parameter_names(const std::vector<std::string> &names) {
+    CHECK_EQ(names.size(), params_.size());
+    parameter_names_ = names;
+}
+
 namespace optimizers {
 
-SGD::SGD(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate) : Optimizer(params, learning_rate) {}
+SGD::SGD(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate,
+         const NamedParameterList &named_parameters)
+    : Optimizer(params, learning_rate, named_parameters) {}
 
 void SGD::Step() {
     for (auto param : params_) {
@@ -51,13 +78,15 @@ void SGD::Step() {
 }
 
 OptimizerCreator SGD::Create(float learning_rate) {
-    return [learning_rate](const std::vector<std::shared_ptr<Tensor>> &params) {
-        return std::make_shared<SGD>(params, learning_rate);
+    return [learning_rate](const std::vector<std::shared_ptr<Tensor>> &params,
+                           const NamedParameterList &named_parameters) {
+        return std::make_shared<SGD>(params, learning_rate, named_parameters);
     };
 }
 
-Adam::Adam(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate, float beta1, float beta2, float eps)
-    : Optimizer(params, learning_rate), t_(0), beta1_(beta1), beta2_(beta2), eps_(eps) {
+Adam::Adam(const std::vector<std::shared_ptr<Tensor>> &params, float learning_rate, float beta1, float beta2, float eps,
+           const NamedParameterList &named_parameters)
+    : Optimizer(params, learning_rate, named_parameters), t_(0), beta1_(beta1), beta2_(beta2), eps_(eps) {
 
     for (const auto &param : params_) {
         m_.emplace_back(std::make_shared<Tensor>(param->Dims(), param->Dtype(), param->GetDevice()));
@@ -88,16 +117,17 @@ void Adam::Step() {
 }
 
 OptimizerCreator Adam::Create(float learning_rate, float beta1, float beta2, float eps) {
-    return [=](const std::vector<std::shared_ptr<Tensor>> &params) {
-        return std::make_shared<Adam>(params, learning_rate, beta1, beta2, eps);
+    return [=](const std::vector<std::shared_ptr<Tensor>> &params, const NamedParameterList &named_parameters) {
+        return std::make_shared<Adam>(params, learning_rate, beta1, beta2, eps, named_parameters);
     };
 }
 
 std::unordered_map<std::string, std::shared_ptr<Tensor>> Adam::StateDict() const {
     std::unordered_map<std::string, std::shared_ptr<Tensor>> state;
     for (size_t i = 0; i < m_.size(); ++i) {
-        state.emplace(std::format("adam.m.{}", i), m_[i]);
-        state.emplace(std::format("adam.v.{}", i), v_[i]);
+        const auto suffix = parameter_names_.empty() ? std::to_string(i) : parameter_names_[i];
+        state.emplace("adam.m." + suffix, m_[i]);
+        state.emplace("adam.v." + suffix, v_[i]);
     }
 
     auto t_tensor = std::make_shared<Tensor>(std::vector<int64_t>{}, DataType::kINT64, Device());
@@ -108,8 +138,9 @@ std::unordered_map<std::string, std::shared_ptr<Tensor>> Adam::StateDict() const
 
 void Adam::LoadStateDict(const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict) {
     for (size_t i = 0; i < m_.size(); ++i) {
-        const auto m_key = std::format("adam.m.{}", i);
-        const auto v_key = std::format("adam.v.{}", i);
+        const auto suffix = parameter_names_.empty() ? std::to_string(i) : parameter_names_[i];
+        const auto m_key = "adam.m." + suffix;
+        const auto v_key = "adam.v." + suffix;
         CHECK(state_dict.contains(m_key)) << "Missing optimizer state: " << m_key;
         CHECK(state_dict.contains(v_key)) << "Missing optimizer state: " << v_key;
         m_[i]->CopyFrom(state_dict.at(m_key));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,8 @@ add_subdirectory(common)
 
 # Distributed tests
 add_subdirectory(distributed)
+# Module tests
+add_subdirectory(module)
 
 # Tensor tests
 add_subdirectory(tensor)

--- a/tests/module/CMakeLists.txt
+++ b/tests/module/CMakeLists.txt
@@ -1,0 +1,5 @@
+file(GLOB MODULE_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_*.cc)
+
+infini_train_add_test_suite(test_module
+  SOURCES ${MODULE_SOURCES}
+)

--- a/tests/module/test_named_parameters.cc
+++ b/tests/module/test_named_parameters.cc
@@ -1,0 +1,93 @@
+#include <memory>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "infini_train/include/nn/modules/module.h"
+#include "infini_train/include/tensor.h"
+
+#include "tests/common/test_utils.h"
+
+using namespace infini_train;
+
+namespace {
+
+class NamedParameterModule final : public nn::Module {
+public:
+    void AddParameter(const std::string &name, const std::shared_ptr<Tensor> &parameter) {
+        parameters_[name] = parameter;
+    }
+
+    void AddModule(const std::string &name, const std::shared_ptr<nn::Module> &module) { modules_[name] = module; }
+};
+
+std::shared_ptr<Tensor> MakeParameter(Device device) {
+    return std::make_shared<Tensor>(std::vector<int64_t>{1}, DataType::kFLOAT32, device);
+}
+
+} // namespace
+
+class ModuleNamedParametersTest : public test::InfiniTrainTest {};
+
+TEST_P(ModuleNamedParametersTest, SupportsPrefixRecursionAndSharedParameterDeduplication) {
+    auto root = std::make_shared<NamedParameterModule>();
+    auto child = std::make_shared<NamedParameterModule>();
+    auto grandchild = std::make_shared<NamedParameterModule>();
+    auto shared = MakeParameter(GetDevice());
+    auto child_weight = MakeParameter(GetDevice());
+    auto grandchild_weight = MakeParameter(GetDevice());
+
+    root->AddParameter("root_weight", shared);
+    child->AddParameter("alias", shared);
+    child->AddParameter("weight", child_weight);
+    grandchild->AddParameter("weight", grandchild_weight);
+    child->AddModule("grandchild", grandchild);
+    root->AddModule("child", child);
+
+    const auto local = root->NamedParameters("model", false);
+    ASSERT_EQ(local.size(), 1);
+    EXPECT_EQ(local[0].first, "model.root_weight");
+    EXPECT_EQ(local[0].second, shared);
+
+    const auto deduplicated = root->NamedParameters("model");
+    ASSERT_EQ(deduplicated.size(), 3);
+    EXPECT_EQ(deduplicated[0].first, "model.root_weight");
+    EXPECT_EQ(deduplicated[1].first, "model.child.weight");
+    EXPECT_EQ(deduplicated[2].first, "model.child.grandchild.weight");
+
+    const auto aliases = root->NamedParameters("model", true, false);
+    ASSERT_EQ(aliases.size(), 4);
+    EXPECT_EQ(aliases[0].first, "model.root_weight");
+    EXPECT_EQ(aliases[1].first, "model.child.alias");
+    EXPECT_EQ(aliases[1].second, shared);
+}
+
+TEST_P(ModuleNamedParametersTest, ProducesDeterministicLexicalOrder) {
+    auto root = std::make_shared<NamedParameterModule>();
+    auto first_child = std::make_shared<NamedParameterModule>();
+    auto second_child = std::make_shared<NamedParameterModule>();
+
+    root->AddParameter("z", MakeParameter(GetDevice()));
+    root->AddParameter("a", MakeParameter(GetDevice()));
+    first_child->AddParameter("weight", MakeParameter(GetDevice()));
+    second_child->AddParameter("weight", MakeParameter(GetDevice()));
+    root->AddModule("z_child", second_child);
+    root->AddModule("a_child", first_child);
+
+    const auto parameters = root->NamedParameters();
+    ASSERT_EQ(parameters.size(), 4);
+    EXPECT_EQ(parameters[0].first, "a");
+    EXPECT_EQ(parameters[1].first, "z");
+    EXPECT_EQ(parameters[2].first, "a_child.weight");
+    EXPECT_EQ(parameters[3].first, "z_child.weight");
+}
+
+TEST_P(ModuleNamedParametersTest, SkipsNullEntries) {
+    auto root = std::make_shared<NamedParameterModule>();
+    root->AddParameter("missing", nullptr);
+    root->AddModule("missing_child", nullptr);
+
+    EXPECT_TRUE(root->NamedParameters().empty());
+}
+
+INFINI_TRAIN_REGISTER_TEST(ModuleNamedParametersTest);

--- a/tests/module/test_named_parameters.cc
+++ b/tests/module/test_named_parameters.cc
@@ -1,91 +1,78 @@
 #include <memory>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #include "gtest/gtest.h"
 
-#include "infini_train/include/nn/modules/module.h"
+#include "infini_train/include/nn/modules/container.h"
+#include "infini_train/include/nn/modules/linear.h"
 #include "infini_train/include/tensor.h"
 
 #include "tests/common/test_utils.h"
 
 using namespace infini_train;
 
-namespace {
-
-class NamedParameterModule final : public nn::Module {
-public:
-    void AddParameter(const std::string &name, const std::shared_ptr<Tensor> &parameter) {
-        parameters_[name] = parameter;
-    }
-
-    void AddModule(const std::string &name, const std::shared_ptr<nn::Module> &module) { modules_[name] = module; }
-};
-
-std::shared_ptr<Tensor> MakeParameter(Device device) {
-    return std::make_shared<Tensor>(std::vector<int64_t>{1}, DataType::kFLOAT32, device);
-}
-
-} // namespace
-
 class ModuleNamedParametersTest : public test::InfiniTrainTest {};
 
-TEST_P(ModuleNamedParametersTest, SupportsPrefixRecursionAndSharedParameterDeduplication) {
-    auto root = std::make_shared<NamedParameterModule>();
-    auto child = std::make_shared<NamedParameterModule>();
-    auto grandchild = std::make_shared<NamedParameterModule>();
-    auto shared = MakeParameter(GetDevice());
-    auto child_weight = MakeParameter(GetDevice());
-    auto grandchild_weight = MakeParameter(GetDevice());
+TEST_P(ModuleNamedParametersTest, SupportsPrefixAndNonRecursiveLookup) {
+    auto linear = std::make_shared<nn::Linear>(2, 3, /*bias=*/true, GetDevice());
 
-    root->AddParameter("root_weight", shared);
-    child->AddParameter("alias", shared);
-    child->AddParameter("weight", child_weight);
-    grandchild->AddParameter("weight", grandchild_weight);
-    child->AddModule("grandchild", grandchild);
-    root->AddModule("child", child);
+    const auto parameters = linear->NamedParameters("model", false);
+    const std::unordered_map<std::string, std::shared_ptr<Tensor>> by_name(parameters.begin(), parameters.end());
 
-    const auto local = root->NamedParameters("model", false);
-    ASSERT_EQ(local.size(), 1);
-    EXPECT_EQ(local[0].first, "model.root_weight");
-    EXPECT_EQ(local[0].second, shared);
+    ASSERT_EQ(by_name.size(), 2);
+    EXPECT_EQ(by_name.at("model.weight"), linear->parameter(nn::Linear::kParamWeightName));
+    EXPECT_EQ(by_name.at("model.bias"), linear->parameter(nn::Linear::kParamBiasName));
+}
+
+TEST_P(ModuleNamedParametersTest, SupportsRecursionAndSharedParameterDeduplication) {
+    auto shared = std::make_shared<nn::Linear>(2, 3, /*bias=*/true, GetDevice());
+    auto root = std::make_shared<nn::Sequential>(std::vector<std::shared_ptr<nn::Module>>{shared, shared});
 
     const auto deduplicated = root->NamedParameters("model");
-    ASSERT_EQ(deduplicated.size(), 3);
-    EXPECT_EQ(deduplicated[0].first, "model.root_weight");
-    EXPECT_EQ(deduplicated[1].first, "model.child.weight");
-    EXPECT_EQ(deduplicated[2].first, "model.child.grandchild.weight");
+    ASSERT_EQ(deduplicated.size(), 2);
+    EXPECT_EQ(deduplicated[0].first, "model.0.bias");
+    EXPECT_EQ(deduplicated[1].first, "model.0.weight");
+    std::unordered_set<const Tensor *> tensors;
+    for (const auto &[name, parameter] : deduplicated) {
+        EXPECT_TRUE(name == "model.0.weight" || name == "model.0.bias" || name == "model.1.weight"
+                    || name == "model.1.bias");
+        tensors.insert(parameter.get());
+    }
+    EXPECT_TRUE(tensors.contains(shared->parameter(nn::Linear::kParamWeightName).get()));
+    EXPECT_TRUE(tensors.contains(shared->parameter(nn::Linear::kParamBiasName).get()));
 
     const auto aliases = root->NamedParameters("model", true, false);
-    ASSERT_EQ(aliases.size(), 4);
-    EXPECT_EQ(aliases[0].first, "model.root_weight");
-    EXPECT_EQ(aliases[1].first, "model.child.alias");
-    EXPECT_EQ(aliases[1].second, shared);
+    const std::unordered_map<std::string, std::shared_ptr<Tensor>> by_name(aliases.begin(), aliases.end());
+    ASSERT_EQ(by_name.size(), 4);
+    EXPECT_EQ(by_name.at("model.0.weight"), by_name.at("model.1.weight"));
+    EXPECT_EQ(by_name.at("model.0.bias"), by_name.at("model.1.bias"));
 }
 
-TEST_P(ModuleNamedParametersTest, ProducesDeterministicLexicalOrder) {
-    auto root = std::make_shared<NamedParameterModule>();
-    auto first_child = std::make_shared<NamedParameterModule>();
-    auto second_child = std::make_shared<NamedParameterModule>();
-
-    root->AddParameter("z", MakeParameter(GetDevice()));
-    root->AddParameter("a", MakeParameter(GetDevice()));
-    first_child->AddParameter("weight", MakeParameter(GetDevice()));
-    second_child->AddParameter("weight", MakeParameter(GetDevice()));
-    root->AddModule("z_child", second_child);
-    root->AddModule("a_child", first_child);
+TEST_P(ModuleNamedParametersTest, ReturnsNestedParametersInStableNameOrder) {
+    auto first = std::make_shared<nn::Linear>(2, 3, /*bias=*/false, GetDevice());
+    auto second = std::make_shared<nn::Linear>(3, 4, /*bias=*/false, GetDevice());
+    auto nested = std::make_shared<nn::Sequential>(std::vector<std::shared_ptr<nn::Module>>{first, second});
+    auto root = std::make_shared<nn::Sequential>(
+        std::vector<std::shared_ptr<nn::Module>>{std::make_shared<nn::Linear>(2, 2, false, GetDevice()), nested});
 
     const auto parameters = root->NamedParameters();
-    ASSERT_EQ(parameters.size(), 4);
-    EXPECT_EQ(parameters[0].first, "a");
-    EXPECT_EQ(parameters[1].first, "z");
-    EXPECT_EQ(parameters[2].first, "a_child.weight");
-    EXPECT_EQ(parameters[3].first, "z_child.weight");
+    const std::unordered_map<std::string, std::shared_ptr<Tensor>> by_name(parameters.begin(), parameters.end());
+
+    ASSERT_EQ(by_name.size(), 3);
+    ASSERT_EQ(parameters.size(), 3);
+    EXPECT_EQ(parameters[0].first, "0.weight");
+    EXPECT_EQ(parameters[1].first, "1.0.weight");
+    EXPECT_EQ(parameters[2].first, "1.1.weight");
+    EXPECT_TRUE(by_name.contains("0.weight"));
+    EXPECT_TRUE(by_name.contains("1.0.weight"));
+    EXPECT_TRUE(by_name.contains("1.1.weight"));
 }
 
-TEST_P(ModuleNamedParametersTest, SkipsNullEntries) {
-    auto root = std::make_shared<NamedParameterModule>();
-    root->AddParameter("missing", nullptr);
-    root->AddModule("missing_child", nullptr);
+TEST_P(ModuleNamedParametersTest, SkipsNullSubmodules) {
+    auto root = std::make_shared<nn::Sequential>(std::vector<std::shared_ptr<nn::Module>>{nullptr});
 
     EXPECT_TRUE(root->NamedParameters().empty());
 }

--- a/tests/module/test_named_parameters.cc
+++ b/tests/module/test_named_parameters.cc
@@ -36,11 +36,7 @@ TEST_P(ModuleNamedParametersTest, SupportsRecursionAndSharedParameterDeduplicati
     EXPECT_EQ(deduplicated[0].first, "model.0.bias");
     EXPECT_EQ(deduplicated[1].first, "model.0.weight");
     std::unordered_set<const Tensor *> tensors;
-    for (const auto &[name, parameter] : deduplicated) {
-        EXPECT_TRUE(name == "model.0.weight" || name == "model.0.bias" || name == "model.1.weight"
-                    || name == "model.1.bias");
-        tensors.insert(parameter.get());
-    }
+    for (const auto &[name, parameter] : deduplicated) { tensors.insert(parameter.get()); }
     EXPECT_TRUE(tensors.contains(shared->parameter(nn::Linear::kParamWeightName).get()));
     EXPECT_TRUE(tensors.contains(shared->parameter(nn::Linear::kParamBiasName).get()));
 
@@ -55,20 +51,18 @@ TEST_P(ModuleNamedParametersTest, ReturnsNestedParametersInStableNameOrder) {
     auto first = std::make_shared<nn::Linear>(2, 3, /*bias=*/false, GetDevice());
     auto second = std::make_shared<nn::Linear>(3, 4, /*bias=*/false, GetDevice());
     auto nested = std::make_shared<nn::Sequential>(std::vector<std::shared_ptr<nn::Module>>{first, second});
-    auto root = std::make_shared<nn::Sequential>(
-        std::vector<std::shared_ptr<nn::Module>>{std::make_shared<nn::Linear>(2, 2, false, GetDevice()), nested});
+    auto root_linear = std::make_shared<nn::Linear>(2, 2, false, GetDevice());
+    auto root = std::make_shared<nn::Sequential>(std::vector<std::shared_ptr<nn::Module>>{root_linear, nested});
 
     const auto parameters = root->NamedParameters();
-    const std::unordered_map<std::string, std::shared_ptr<Tensor>> by_name(parameters.begin(), parameters.end());
 
-    ASSERT_EQ(by_name.size(), 3);
     ASSERT_EQ(parameters.size(), 3);
     EXPECT_EQ(parameters[0].first, "0.weight");
     EXPECT_EQ(parameters[1].first, "1.0.weight");
     EXPECT_EQ(parameters[2].first, "1.1.weight");
-    EXPECT_TRUE(by_name.contains("0.weight"));
-    EXPECT_TRUE(by_name.contains("1.0.weight"));
-    EXPECT_TRUE(by_name.contains("1.1.weight"));
+    EXPECT_EQ(parameters[0].second, root_linear->parameter(nn::Linear::kParamWeightName));
+    EXPECT_EQ(parameters[1].second, first->parameter(nn::Linear::kParamWeightName));
+    EXPECT_EQ(parameters[2].second, second->parameter(nn::Linear::kParamWeightName));
 }
 
 TEST_P(ModuleNamedParametersTest, SkipsNullSubmodules) {

--- a/tests/optimizer/CMakeLists.txt
+++ b/tests/optimizer/CMakeLists.txt
@@ -7,3 +7,17 @@ file(GLOB OPTIMIZER_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_*.cc)
 infini_train_add_test_suite(test_optimizer
   SOURCES ${OPTIMIZER_SOURCES}
 )
+
+add_test(
+  NAME OptimizerParameterNamesTest.DistributedOptimizerPropagatesNamesToShardOptimizer
+  COMMAND ${CMAKE_COMMAND} -E env
+    "PROC_WORLD_SIZE=2"
+    $<TARGET_FILE:test_optimizer_cuda>
+    --gtest_filter=CUDA/OptimizerParameterNamesTest.DistributedOptimizerPropagatesNamesToShardOptimizer/*
+)
+set_tests_properties(
+  OptimizerParameterNamesTest.DistributedOptimizerPropagatesNamesToShardOptimizer
+  PROPERTIES
+    LABELS "cuda;distributed"
+    TIMEOUT 30
+)

--- a/tests/optimizer/test_optimizer_parameter_names.cc
+++ b/tests/optimizer/test_optimizer_parameter_names.cc
@@ -23,9 +23,8 @@ class OptimizerParameterNamesTest : public test::InfiniTrainTest {};
 TEST_P(OptimizerParameterNamesTest, AdamStateDictUsesStableParameterNames) {
     auto first = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice());
     auto second = std::make_shared<Tensor>(std::vector<int64_t>{3}, DataType::kFLOAT32, GetDevice());
-    const NamedParameterList named_parameters{{"transformer.h.0.weight", first},
-                                              {"transformer.h.0.bias", second}};
-    auto adam = optimizers::Adam::Create(0.001)({first, second}, named_parameters);
+    const NamedParameterList named_parameters{{"transformer.h.0.weight", first}, {"transformer.h.0.bias", second}};
+    auto adam = optimizers::Adam::CreateNamed(0.001)(named_parameters);
 
     const auto state = adam->StateDict();
     EXPECT_TRUE(state.contains("adam.m.transformer.h.0.weight"));
@@ -34,7 +33,7 @@ TEST_P(OptimizerParameterNamesTest, AdamStateDictUsesStableParameterNames) {
     EXPECT_TRUE(state.contains("adam.v.transformer.h.0.bias"));
     EXPECT_TRUE(state.contains("adam.t"));
 
-    auto restored = optimizers::Adam::Create(0.001)({first, second}, named_parameters);
+    auto restored = optimizers::Adam::CreateNamed(0.001)(named_parameters);
     restored->LoadStateDict(state);
     EXPECT_EQ(restored->StateDict().size(), state.size());
 }
@@ -42,9 +41,9 @@ TEST_P(OptimizerParameterNamesTest, AdamStateDictUsesStableParameterNames) {
 TEST_P(OptimizerParameterNamesTest, ConstructorMatchesNamesToOptimizerParameterOrder) {
     auto first = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice());
     auto second = std::make_shared<Tensor>(std::vector<int64_t>{3}, DataType::kFLOAT32, GetDevice());
-    const NamedParameterList named_parameters{{"first", first}, {"second", second}};
+    const NamedParameterList named_parameters{{"second", second}, {"first", first}};
 
-    auto adam = optimizers::Adam::Create(0.001)({second, first}, named_parameters);
+    auto adam = optimizers::Adam::CreateNamed(0.001)(named_parameters);
     const auto state = adam->StateDict();
 
     EXPECT_TRUE(state.contains("adam.m.second"));
@@ -66,7 +65,6 @@ TEST_P(OptimizerParameterNamesTest, DistributedOptimizerPropagatesNamesToShardOp
                             nn::parallel::GetDataParallelGroupRanks(rank.GlobalRank()));
 
     auto model = std::make_shared<nn::Linear>(4, 4, /*bias=*/false, GetDevice());
-    const auto params = model->Parameters();
     const auto named_parameters = model->NamedParameters();
 
     nn::parallel::DistributedDataParallelConfig ddp_config;
@@ -75,7 +73,7 @@ TEST_P(OptimizerParameterNamesTest, DistributedOptimizerPropagatesNamesToShardOp
     ddp_config.overlap_param_gather = false;
     auto ddp_model = std::make_shared<nn::parallel::DistributedDataParallel>(model, rank, ddp_config);
 
-    nn::parallel::DistributedOptimizer optimizer(optimizers::Adam::Create(0.001), params, named_parameters,
+    nn::parallel::DistributedOptimizer optimizer(optimizers::Adam::CreateNamed(0.001), named_parameters,
                                                  std::vector<std::shared_ptr<nn::Module>>{ddp_model},
                                                  /*ddp_world_size=*/2, /*ddp_rank=*/0);
     const auto state = optimizer.StateDict();

--- a/tests/optimizer/test_optimizer_parameter_names.cc
+++ b/tests/optimizer/test_optimizer_parameter_names.cc
@@ -23,8 +23,9 @@ class OptimizerParameterNamesTest : public test::InfiniTrainTest {};
 TEST_P(OptimizerParameterNamesTest, AdamStateDictUsesStableParameterNames) {
     auto first = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice());
     auto second = std::make_shared<Tensor>(std::vector<int64_t>{3}, DataType::kFLOAT32, GetDevice());
-    auto adam = std::make_shared<optimizers::Adam>(std::vector<std::shared_ptr<Tensor>>{first, second}, 0.001);
-    adam->set_parameter_names({"transformer.h.0.weight", "transformer.h.0.bias"});
+    const NamedParameterList named_parameters{{"transformer.h.0.weight", first},
+                                              {"transformer.h.0.bias", second}};
+    auto adam = optimizers::Adam::Create(0.001)({first, second}, named_parameters);
 
     const auto state = adam->StateDict();
     EXPECT_TRUE(state.contains("adam.m.transformer.h.0.weight"));
@@ -33,8 +34,7 @@ TEST_P(OptimizerParameterNamesTest, AdamStateDictUsesStableParameterNames) {
     EXPECT_TRUE(state.contains("adam.v.transformer.h.0.bias"));
     EXPECT_TRUE(state.contains("adam.t"));
 
-    auto restored = std::make_shared<optimizers::Adam>(std::vector<std::shared_ptr<Tensor>>{first, second}, 0.001);
-    restored->set_parameter_names({"transformer.h.0.weight", "transformer.h.0.bias"});
+    auto restored = optimizers::Adam::Create(0.001)({first, second}, named_parameters);
     restored->LoadStateDict(state);
     EXPECT_EQ(restored->StateDict().size(), state.size());
 }
@@ -93,13 +93,6 @@ TEST_P(OptimizerParameterNamesTest, PreservesNumericKeysWhenNamesAreNotSet) {
     const auto state = adam->StateDict();
     EXPECT_TRUE(state.contains("adam.m.0"));
     EXPECT_TRUE(state.contains("adam.v.0"));
-}
-
-TEST_P(OptimizerParameterNamesTest, RejectsWrongNumberOfParameterNames) {
-    auto parameter = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice());
-    auto adam = std::make_shared<optimizers::Adam>(std::vector<std::shared_ptr<Tensor>>{parameter}, 0.001);
-
-    EXPECT_DEATH(adam->set_parameter_names({"first", "second"}), "");
 }
 
 INFINI_TRAIN_REGISTER_TEST(OptimizerParameterNamesTest);

--- a/tests/optimizer/test_optimizer_parameter_names.cc
+++ b/tests/optimizer/test_optimizer_parameter_names.cc
@@ -1,0 +1,105 @@
+#include <memory>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "infini_train/include/nn/modules/linear.h"
+#include "infini_train/include/nn/parallel/ddp/distributed_data_parallel.h"
+#include "infini_train/include/nn/parallel/ddp/distributed_data_parallel_config.h"
+#include "infini_train/include/nn/parallel/ddp/distributed_optimizer.h"
+#include "infini_train/include/nn/parallel/global.h"
+#include "infini_train/include/nn/parallel/process_group.h"
+#include "infini_train/include/nn/parallel/rank.h"
+#include "infini_train/include/nn/parallel/utils.h"
+#include "infini_train/include/optimizer.h"
+#include "infini_train/include/tensor.h"
+
+#include "tests/common/test_utils.h"
+
+using namespace infini_train;
+
+class OptimizerParameterNamesTest : public test::InfiniTrainTest {};
+
+TEST_P(OptimizerParameterNamesTest, AdamStateDictUsesStableParameterNames) {
+    auto first = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice());
+    auto second = std::make_shared<Tensor>(std::vector<int64_t>{3}, DataType::kFLOAT32, GetDevice());
+    auto adam = std::make_shared<optimizers::Adam>(std::vector<std::shared_ptr<Tensor>>{first, second}, 0.001);
+    adam->set_parameter_names({"transformer.h.0.weight", "transformer.h.0.bias"});
+
+    const auto state = adam->StateDict();
+    EXPECT_TRUE(state.contains("adam.m.transformer.h.0.weight"));
+    EXPECT_TRUE(state.contains("adam.v.transformer.h.0.weight"));
+    EXPECT_TRUE(state.contains("adam.m.transformer.h.0.bias"));
+    EXPECT_TRUE(state.contains("adam.v.transformer.h.0.bias"));
+    EXPECT_TRUE(state.contains("adam.t"));
+
+    auto restored = std::make_shared<optimizers::Adam>(std::vector<std::shared_ptr<Tensor>>{first, second}, 0.001);
+    restored->set_parameter_names({"transformer.h.0.weight", "transformer.h.0.bias"});
+    restored->LoadStateDict(state);
+    EXPECT_EQ(restored->StateDict().size(), state.size());
+}
+
+TEST_P(OptimizerParameterNamesTest, ConstructorMatchesNamesToOptimizerParameterOrder) {
+    auto first = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice());
+    auto second = std::make_shared<Tensor>(std::vector<int64_t>{3}, DataType::kFLOAT32, GetDevice());
+    const NamedParameterList named_parameters{{"first", first}, {"second", second}};
+
+    auto adam = optimizers::Adam::Create(0.001)({second, first}, named_parameters);
+    const auto state = adam->StateDict();
+
+    EXPECT_TRUE(state.contains("adam.m.second"));
+    EXPECT_TRUE(state.contains("adam.v.second"));
+    EXPECT_TRUE(state.contains("adam.m.first"));
+    EXPECT_TRUE(state.contains("adam.v.first"));
+}
+
+TEST_P(OptimizerParameterNamesTest, DistributedOptimizerPropagatesNamesToShardOptimizer) {
+    ONLY_CUDA();
+    REQUIRE_MIN_DEVICES(2);
+    if (nn::parallel::global::GetDataParallelSize() != 2) {
+        GTEST_SKIP() << "requires PROC_WORLD_SIZE=2";
+    }
+
+    const nn::parallel::Rank rank(/*process_rank=*/0, /*thread_rank=*/0, /*process_size=*/1, /*thread_size=*/2);
+    auto *pg_factory = nn::parallel::ProcessGroupFactory::Instance(Device::DeviceType::kCUDA);
+    pg_factory->GetOrCreate(nn::parallel::GetDataParallelProcessGroupName(rank.GlobalRank()),
+                            nn::parallel::GetDataParallelGroupRanks(rank.GlobalRank()));
+
+    auto model = std::make_shared<nn::Linear>(4, 4, /*bias=*/false, GetDevice());
+    const auto params = model->Parameters();
+    const auto named_parameters = model->NamedParameters();
+
+    nn::parallel::DistributedDataParallelConfig ddp_config;
+    ddp_config.zero_stage = 1;
+    ddp_config.overlap_grad_reduce = false;
+    ddp_config.overlap_param_gather = false;
+    auto ddp_model = std::make_shared<nn::parallel::DistributedDataParallel>(model, rank, ddp_config);
+
+    nn::parallel::DistributedOptimizer optimizer(optimizers::Adam::Create(0.001), params, named_parameters,
+                                                 std::vector<std::shared_ptr<nn::Module>>{ddp_model},
+                                                 /*ddp_world_size=*/2, /*ddp_rank=*/0);
+    const auto state = optimizer.StateDict();
+
+    EXPECT_TRUE(state.contains("adam.m.weight"));
+    EXPECT_TRUE(state.contains("adam.v.weight"));
+    EXPECT_FALSE(state.contains("adam.m.0"));
+    EXPECT_FALSE(state.contains("adam.v.0"));
+}
+
+TEST_P(OptimizerParameterNamesTest, PreservesNumericKeysWhenNamesAreNotSet) {
+    auto parameter = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice());
+    auto adam = std::make_shared<optimizers::Adam>(std::vector<std::shared_ptr<Tensor>>{parameter}, 0.001);
+
+    const auto state = adam->StateDict();
+    EXPECT_TRUE(state.contains("adam.m.0"));
+    EXPECT_TRUE(state.contains("adam.v.0"));
+}
+
+TEST_P(OptimizerParameterNamesTest, RejectsWrongNumberOfParameterNames) {
+    auto parameter = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice());
+    auto adam = std::make_shared<optimizers::Adam>(std::vector<std::shared_ptr<Tensor>>{parameter}, 0.001);
+
+    EXPECT_DEATH(adam->set_parameter_names({"first", "second"}), "");
+}
+
+INFINI_TRAIN_REGISTER_TEST(OptimizerParameterNamesTest);


### PR DESCRIPTION
## 1. 主要修改
  - 为 Module 新增 NamedParameters(prefix, recurse, remove_duplicate)，支持参数名前缀、递归遍历和共享参数去重。
  - 为 Optimizer 新增 parameter_names_ 及设置、读取接口。
  - Adam 的 StateDict() 和 LoadStateDict() 使用参数名生成状态 key。
  - 未设置参数名时保留数字下标 key，兼容不使用命名参数接口的调用方式。
  - GPT-2 和 LLaMA3 入口根据 Tensor 指针为 optimizer 参数绑定模型参数名。
  - 测试使用现有 Linear 和 Sequential，覆盖 prefix、递归、共享参数去重和空子模块。