### PR TITLE
Feat/checkpoint resharding

### DIFF
--- a/example/gpt2/main.cc
+++ b/example/gpt2/main.cc
@@ -405,6 +405,7 @@ void Train(const nn::parallel::Rank &rank) {
             .tp_size = tp_world_size,
             .sp_size = sp_world_size,
             .pp_size = pp_world_size,
+            .vpp_size = static_cast<int>(FLAGS_virtual_pipeline_parallel),
             .checkpoint_root_dir = FLAGS_save,
             .max_checkpoint_keep = FLAGS_max_checkpoint_keep,
             .rank = rank,

--- a/example/llama3/main.cc
+++ b/example/llama3/main.cc
@@ -387,6 +387,7 @@ void Train(const nn::parallel::Rank &rank) {
             .tp_size = tp_world_size,
             .sp_size = sp_world_size,
             .pp_size = pp_world_size,
+            .vpp_size = static_cast<int>(FLAGS_virtual_pipeline_parallel),
             .checkpoint_root_dir = FLAGS_save,
             .max_checkpoint_keep = FLAGS_max_checkpoint_keep,
             .rank = rank,

--- a/infini_train/include/checkpoint/checkpoint.h
+++ b/infini_train/include/checkpoint/checkpoint.h
@@ -32,6 +32,7 @@ struct TrainerState {
     int tp_size = 1;
     int sp_size = 1;
     int pp_size = 1;
+    int vpp_size = 1;
 };
 
 class Checkpoint {
@@ -63,6 +64,7 @@ public:
             int pp_size = 1;
             int dp_size = 1;
             int sp_size = 1;
+            int vpp_size = 1;
         } parallel_config;
 
         struct TensorEntry {

--- a/infini_train/include/checkpoint/checkpoint.h
+++ b/infini_train/include/checkpoint/checkpoint.h
@@ -6,6 +6,11 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
+
+#include "infini_train/include/checkpoint/save_planner.h"
+#include "infini_train/include/checkpoint/shard_spec.h"
+#include "infini_train/include/lr_scheduler.h"
 
 namespace infini_train {
 class Optimizer;
@@ -37,9 +42,69 @@ public:
     static void Load(const std::filesystem::path &checkpoint_dir, nn::Module &model, Optimizer *optimizer,
                      TrainerState &state, LRScheduler *lr_scheduler);
 
+    static void SaveSharded(const std::filesystem::path &checkpoint_dir, const checkpoint::ShardedStateDict &sharded_sd,
+                            const std::vector<checkpoint::WriteItem> &write_items,
+                            const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict,
+                            const std::unordered_map<std::string, std::shared_ptr<Tensor>> &optimizer_state,
+                            const TrainerState &state, int global_rank);
+
+    static void SaveStateDictFile(const std::filesystem::path &path,
+                                  const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict);
+
+    static std::unordered_map<std::string, std::shared_ptr<Tensor>>
+    LoadStateDictFile(const std::filesystem::path &path);
+
+    struct CheckpointMetadata {
+        int version = 0;
+        int64_t iteration = 0;
+
+        struct ParallelConfig {
+            int tp_size = 1;
+            int pp_size = 1;
+            int dp_size = 1;
+            int sp_size = 1;
+        } parallel_config;
+
+        struct TensorEntry {
+            std::string key;
+            std::string dtype_str;
+            std::vector<int64_t> global_shape;
+            std::vector<int64_t> local_shape;
+            std::vector<int64_t> global_offset;
+            std::vector<int> axis_fragmentations;
+            std::vector<checkpoint::ShardSegment> segments;
+            std::string file;
+            uint64_t offset = 0;
+            uint64_t byte_size = 0;
+            std::vector<int> stored_on_ranks;
+            int pp_rank = 0;
+        };
+
+        std::vector<TensorEntry> tensors;
+        bool has_metadata = false;
+    };
+
+    static CheckpointMetadata LoadMetadata(const std::filesystem::path &checkpoint_dir);
+    static void SaveMetadataFile(const std::filesystem::path &path, const CheckpointMetadata &metadata);
+
+    // Public LR-scheduler serialization helpers used by checkpoint_manager.
+    static void SaveLRSchedulerStateFile(const std::filesystem::path &path, const LRSchedulerStateDict &state_dict);
+    static LRSchedulerStateDict LoadLRSchedulerStateFile(const std::filesystem::path &path);
+
+    // Public trainer-state serialization helpers used by checkpoint_manager.
+    static void SaveTrainerStateFile(const std::filesystem::path &path, const TrainerState &state);
+    static TrainerState LoadTrainerStateFile(const std::filesystem::path &path);
+
 private:
-    static void SaveStateDict(const std::filesystem::path &path,
-                              const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict);
+    struct SavedTensorLocation {
+        uint64_t data_offset = 0;
+        uint64_t byte_size = 0;
+    };
+    using SavedTensorLocations = std::unordered_map<std::string, SavedTensorLocation>;
+
+    static SavedTensorLocations
+    SaveStateDict(const std::filesystem::path &path,
+                  const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict);
 
     static std::unordered_map<std::string, std::shared_ptr<Tensor>> LoadStateDict(const std::filesystem::path &path);
 

--- a/infini_train/include/checkpoint/checkpoint_manager.h
+++ b/infini_train/include/checkpoint/checkpoint_manager.h
@@ -49,6 +49,7 @@ struct SaveCheckpointArgs {
     int tp_size = 1;
     int sp_size = 1;
     int pp_size = 1;
+    int vpp_size = 1;
     std::filesystem::path checkpoint_root_dir;
     size_t max_checkpoint_keep = 0;
     const nn::parallel::Rank &rank;

--- a/infini_train/include/checkpoint/checkpoint_manager.h
+++ b/infini_train/include/checkpoint/checkpoint_manager.h
@@ -6,7 +6,6 @@
 #include <memory>
 
 #include "infini_train/include/checkpoint/checkpoint.h"
-#include "infini_train/include/dataloader.h"
 #include "infini_train/include/nn/modules/module.h"
 #include "infini_train/include/nn/parallel/rank.h"
 #include "infini_train/include/optimizer.h"

--- a/infini_train/include/checkpoint/load_planner.h
+++ b/infini_train/include/checkpoint/load_planner.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "infini_train/include/checkpoint/checkpoint.h"
+#include "infini_train/include/checkpoint/shard_spec.h"
+#include "infini_train/include/datatype.h"
+
+namespace infini_train::checkpoint {
+
+// One storage-region transfer from a saved shard into a target local tensor.
+struct ReadItem {
+    std::string key;
+    std::string filename;
+    DataType dtype = DataType::kFLOAT32;
+    std::vector<int64_t> global_shape;
+    uint64_t byte_size = 0;
+    uint64_t data_offset = 0;
+    int shard_dim = -1;
+    int64_t source_offset = 0;
+    int64_t target_offset = 0;
+    int64_t length = 0;
+    std::vector<int64_t> source_shape;
+};
+
+// All reads required to materialize one target local tensor.
+struct TargetTensorPlan {
+    std::string key;
+    DataType dtype = DataType::kFLOAT32;
+    std::vector<int64_t> global_shape;
+    std::vector<int64_t> target_shape;
+    int shard_dim = -1;
+    int64_t trailing_zero_fill = 0;
+    std::vector<ReadItem> reads;
+};
+
+// Complete load plan for one rank.
+struct LoadPlan {
+    std::map<std::string, TargetTensorPlan> tensors;
+};
+
+class LoadPlanner {
+public:
+    // Compute saved-to-target overlaps from explicit global shard coordinates.
+    static LoadPlan PlanReshard(const Checkpoint::CheckpointMetadata &metadata,
+                                const ShardedStateDict &target_state_dict);
+};
+
+} // namespace infini_train::checkpoint

--- a/infini_train/include/checkpoint/load_strategy.h
+++ b/infini_train/include/checkpoint/load_strategy.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "infini_train/include/checkpoint/load_planner.h"
+
+namespace infini_train {
+class Tensor;
+}
+
+namespace infini_train::checkpoint {
+
+using LoadedStateDict = std::unordered_map<std::string, std::shared_ptr<Tensor>>;
+
+class LoadStrategy {
+public:
+    virtual ~LoadStrategy() = default;
+    virtual LoadedStateDict Execute(const std::filesystem::path &checkpoint_dir, const LoadPlan &plan) = 0;
+};
+
+/// Reads source regions directly from metadata offsets while caching one open stream per file.
+class IndexedRegionLoadStrategy final : public LoadStrategy {
+public:
+    LoadedStateDict Execute(const std::filesystem::path &checkpoint_dir, const LoadPlan &plan) override;
+};
+
+} // namespace infini_train::checkpoint

--- a/infini_train/include/checkpoint/reshard.h
+++ b/infini_train/include/checkpoint/reshard.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <filesystem>
+
+#include "infini_train/include/checkpoint/checkpoint.h"
+
+namespace infini_train {
+class LRScheduler;
+class Optimizer;
+namespace nn {
+class Module;
+}
+} // namespace infini_train
+
+namespace infini_train::checkpoint {
+
+// Restore this rank's target model shards from a distributed checkpoint.
+void LoadDistributedCheckpoint(const std::filesystem::path &checkpoint_dir, nn::Module &model, Optimizer *optimizer,
+                               TrainerState &state, LRScheduler *lr_scheduler,
+                               const Checkpoint::CheckpointMetadata &metadata);
+
+} // namespace infini_train::checkpoint

--- a/infini_train/include/checkpoint/save_planner.h
+++ b/infini_train/include/checkpoint/save_planner.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "infini_train/include/checkpoint/shard_spec.h"
+#include "infini_train/include/datatype.h"
+
+namespace infini_train {
+class Tensor;
+}
+
+namespace infini_train::checkpoint {
+
+// Physical write description for one local tensor shard.
+struct WriteItem {
+    std::string key;
+    std::string filename;   // "model.ckpt" or "optimizer.ckpt"
+    uint64_t offset = 0;    // Planned byte offset in the checkpoint file.
+    uint64_t byte_size = 0; // Tensor payload size in bytes.
+    DataType dtype = DataType::kFLOAT32;
+    std::vector<int64_t> local_shape;
+    std::vector<int64_t> global_offset;
+    std::vector<int> axis_fragmentations;
+    int rank = 0;
+};
+
+// Build the local tensor write layout from a ShardedStateDict.
+class SavePlanner {
+public:
+    static std::vector<WriteItem> Plan(const ShardedStateDict &sd, int rank);
+};
+
+ShardedStateDict
+BuildOptimizerShardedStateDict(const ShardedStateDict &model_state,
+                               const std::unordered_map<std::string, std::shared_ptr<Tensor>> &optimizer_state);
+
+// Return the number of payload bytes required by a tensor.
+inline uint64_t TensorByteSize(DataType dtype, const std::vector<int64_t> &shape) {
+    uint64_t numel = 1;
+    for (auto d : shape) { numel *= static_cast<uint64_t>(d); }
+    switch (dtype) {
+    case DataType::kBFLOAT16:
+    case DataType::kFLOAT16:
+        return numel * 2;
+    case DataType::kFLOAT32:
+        return numel * 4;
+    case DataType::kFLOAT64:
+    case DataType::kINT64:
+    case DataType::kUINT64:
+        return numel * 8;
+    case DataType::kINT32:
+    case DataType::kUINT32:
+        return numel * 4;
+    case DataType::kINT16:
+    case DataType::kUINT16:
+        return numel * 2;
+    case DataType::kINT8:
+    case DataType::kUINT8:
+    case DataType::kBOOL:
+        return numel;
+    default:
+        return numel * 4;
+    }
+}
+
+// Compute one rank's balanced interval, including non-divisible dimensions.
+inline std::pair<int64_t, int64_t> GetRankSliceRange(int64_t global_size, int world_size, int rank) {
+    int64_t per_rank = global_size / world_size;
+    int64_t remainder = global_size % world_size;
+    int64_t start = rank * per_rank + std::min<int64_t>(rank, remainder);
+    int64_t local_size = per_rank + (rank < remainder ? 1 : 0);
+    return {start, local_size};
+}
+
+} // namespace infini_train::checkpoint

--- a/infini_train/include/checkpoint/shard_spec.h
+++ b/infini_train/include/checkpoint/shard_spec.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "glog/logging.h"
+
+#include "infini_train/include/datatype.h"
+
+namespace infini_train::checkpoint {
+
+struct ShardSegment {
+    int64_t global_offset = 0;
+    int64_t local_offset = 0;
+    int64_t length = 0;
+
+    bool operator==(const ShardSegment &other) const = default;
+};
+
+// Logical tensor shard metadata, aligned with Megatron-LM's ShardedTensor model.
+struct ShardedTensor {
+    std::string key;
+    std::string local_key;
+    DataType dtype = DataType::kFLOAT32;
+    std::vector<int64_t> global_shape;
+    std::vector<int64_t> local_shape;
+    std::vector<int64_t> global_offset;
+    std::vector<int> axis_fragmentations;
+    // Optional disjoint regions along the single fragmented axis. This is used
+    // by layouts such as rank-local [Q, K, V], which are not one contiguous
+    // slice of the logical global [Q, K, V] tensor.
+    std::vector<ShardSegment> segments;
+
+    bool operator==(const ShardedTensor &other) const {
+        return key == other.key && local_key == other.local_key && dtype == other.dtype
+            && global_shape == other.global_shape && local_shape == other.local_shape
+            && global_offset == other.global_offset && axis_fragmentations == other.axis_fragmentations
+            && segments == other.segments;
+    }
+};
+
+struct ShardedStateDict {
+    std::map<std::string, ShardedTensor> tensors;
+
+    void Merge(ShardedStateDict &&other) {
+        for (auto &[key, info] : other.tensors) {
+            const auto display_key = key;
+            const auto [_, inserted] = tensors.emplace(std::move(key), std::move(info));
+            CHECK(inserted) << "Duplicate sharded state-dict key: " << display_key;
+        }
+    }
+};
+
+} // namespace infini_train::checkpoint

--- a/infini_train/include/nn/lora/lora_parallel_linear.h
+++ b/infini_train/include/nn/lora/lora_parallel_linear.h
@@ -34,6 +34,8 @@ public:
 
     std::vector<std::shared_ptr<Tensor>> Forward(const std::vector<std::shared_ptr<Tensor>> &input_tensors) override;
 
+    checkpoint::ShardedStateDict ShardedStateDict(const std::string &prefix = "") const override;
+
     void MergeWeights();
     void UnmergeWeights();
     bool IsMerged() const;
@@ -73,6 +75,8 @@ public:
     LoRARowParallelLinear(std::shared_ptr<parallel::RowParallelLinear> base_module, const LoRAConfig &config);
 
     std::vector<std::shared_ptr<Tensor>> Forward(const std::vector<std::shared_ptr<Tensor>> &input_tensors) override;
+
+    checkpoint::ShardedStateDict ShardedStateDict(const std::string &prefix = "") const override;
 
     void MergeWeights();
     void UnmergeWeights();

--- a/infini_train/include/nn/modules/module.h
+++ b/infini_train/include/nn/modules/module.h
@@ -6,6 +6,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "infini_train/include/checkpoint/shard_spec.h"
 #include "infini_train/include/datatype.h"
 #include "infini_train/include/device.h"
 
@@ -51,7 +52,7 @@ public:
 
     // InfiniTrain's NamedParameters returns results ordered by full parameter name.
     // TODO: Align with PyTorch's ordering in the future.
-    std::vector<std::pair<std::string, std::shared_ptr<Tensor>>>
+    virtual std::vector<std::pair<std::string, std::shared_ptr<Tensor>>>
     NamedParameters(const std::string &prefix = "", bool recurse = true, bool remove_duplicate = true) const;
     bool has_parameter(const std::string &name) const;
     std::shared_ptr<Tensor> *mutable_parameter(const std::string &name);
@@ -63,11 +64,14 @@ public:
     std::shared_ptr<Module> &mutable_module(const std::string &name);
     const Module &module(const std::string &name) const;
 
-    std::unordered_map<std::string, std::shared_ptr<Tensor>> StateDict() const;
+    virtual std::unordered_map<std::string, std::shared_ptr<Tensor>> StateDict() const;
+
+    // Return state-dict metadata with global shard coordinates.
+    virtual checkpoint::ShardedStateDict ShardedStateDict(const std::string &prefix = "") const;
 
     // Current behavior: missing keys / shape / dtype mismatches are FATAL errors; unexpected keys in state_dict are
     // WARNING-only and silently ignored.
-    void LoadStateDict(const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict);
+    virtual void LoadStateDict(const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict);
 
     // operator() calls hooks and Forward
     std::vector<std::shared_ptr<Tensor>> operator()(const std::vector<std::shared_ptr<Tensor>> &input_tensors);

--- a/infini_train/include/nn/modules/transformer/causal_self_attention.h
+++ b/infini_train/include/nn/modules/transformer/causal_self_attention.h
@@ -21,6 +21,8 @@ public:
     std::vector<std::shared_ptr<infini_train::Tensor>>
     Forward(const std::vector<std::shared_ptr<infini_train::Tensor>> &x) override;
 
+    checkpoint::ShardedStateDict ShardedStateDict(const std::string &prefix = "") const override;
+
 private:
     TransformerConfig config_;
     int64_t n_head_ = 0;

--- a/infini_train/include/nn/modules/transformer/transformer.h
+++ b/infini_train/include/nn/modules/transformer/transformer.h
@@ -78,6 +78,11 @@ public:
 
     const TransformerConfig &Config() const { return config_; }
 
+    checkpoint::ShardedStateDict ShardedStateDict(const std::string &prefix = "") const override;
+    std::vector<std::pair<std::string, std::shared_ptr<Tensor>>>
+    NamedParameters(const std::string &prefix = "", bool recurse = true, bool remove_duplicate = true) const override;
+    void LoadStateDict(const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict) override;
+
 private:
     const TransformerConfig config_;
     const infini_train::nn::parallel::StageInfo stage_info_;

--- a/infini_train/include/nn/parallel/ddp/distributed_data_parallel.h
+++ b/infini_train/include/nn/parallel/ddp/distributed_data_parallel.h
@@ -30,6 +30,11 @@ public:
     std::vector<std::shared_ptr<Tensor>> Forward(const std::vector<std::shared_ptr<Tensor>> &input_tensors) override;
 
     std::shared_ptr<nn::Module> module() const;
+    std::vector<std::pair<std::string, std::shared_ptr<Tensor>>>
+    NamedParameters(const std::string &prefix = "", bool recurse = true, bool remove_duplicate = true) const override;
+    std::unordered_map<std::string, std::shared_ptr<Tensor>> StateDict() const override;
+    checkpoint::ShardedStateDict ShardedStateDict(const std::string &prefix = "") const override;
+    void LoadStateDict(const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict) override;
 
     DistributedDataParallelConfig ddp_config() const { return ddp_config_; }
 

--- a/infini_train/include/nn/parallel/pp/pipeline_parallel.h
+++ b/infini_train/include/nn/parallel/pp/pipeline_parallel.h
@@ -40,6 +40,12 @@ public:
 
     std::vector<std::shared_ptr<Module>> *mutable_chunks();
 
+    std::unordered_map<std::string, std::shared_ptr<Tensor>> StateDict() const override;
+    std::vector<std::pair<std::string, std::shared_ptr<Tensor>>>
+    NamedParameters(const std::string &prefix = "", bool recurse = true, bool remove_duplicate = true) const override;
+    checkpoint::ShardedStateDict ShardedStateDict(const std::string &prefix = "") const override;
+    void LoadStateDict(const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict) override;
+
 private:
     void BuildPipelineStage(const std::vector<std::vector<int64_t>> &recv_shape, Device device,
                             std::vector<std::shared_ptr<Module>> &&chunks);

--- a/infini_train/include/nn/parallel/tensor_parallel.h
+++ b/infini_train/include/nn/parallel/tensor_parallel.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "infini_train/include/autograd/function.h"
+#include "infini_train/include/checkpoint/shard_spec.h"
 #include "infini_train/include/nn/modules/module.h"
 #include "infini_train/include/nn/parallel/process_group.h"
 
@@ -37,6 +38,8 @@ public:
     bool skip_bias_add() const;
     bool sequence_parallel() const;
 
+    checkpoint::ShardedStateDict ShardedStateDict(const std::string &prefix = "") const override;
+
 protected:
     bool bias_ = true;
     bool gather_output_ = false;     // whether to return full local output tensor after forward (need gather)
@@ -66,6 +69,8 @@ public:
     bool skip_bias_add() const;
     bool sequence_parallel() const;
 
+    checkpoint::ShardedStateDict ShardedStateDict(const std::string &prefix = "") const override;
+
 protected:
     bool bias_ = true;
     bool reduce_output_ = false;     // whether to return full local output tensor after forward (need reduce)
@@ -84,6 +89,8 @@ public:
     VocabParallelEmbedding(int64_t num_embeddings, int64_t embedding_dim, bool reduce_scatter_embeddings);
 
     std::vector<std::shared_ptr<Tensor>> Forward(const std::vector<std::shared_ptr<Tensor>> &input_tensors) override;
+
+    checkpoint::ShardedStateDict ShardedStateDict(const std::string &prefix = "") const override;
 
 private:
     bool reduce_scatter_embeddings_ = false; // whether to perform ReduceScatter after embedding lookup

--- a/infini_train/include/nn/parallel/tensor_parallel.h
+++ b/infini_train/include/nn/parallel/tensor_parallel.h
@@ -95,6 +95,8 @@ public:
 private:
     bool reduce_scatter_embeddings_ = false; // whether to perform ReduceScatter after embedding lookup
 
+    int64_t vocab_size_global_ = 0;
+
     int64_t embedding_dim_ = 0;
 
     int64_t vocab_size_per_partition_ = 0;

--- a/infini_train/src/checkpoint/checkpoint.cc
+++ b/infini_train/src/checkpoint/checkpoint.cc
@@ -241,7 +241,8 @@ void Checkpoint::Load(const std::filesystem::path &checkpoint_dir, nn::Module &m
 
     LOG(ERROR) << "[CKPT] Load done: global_step=" << state.global_step
                << ", consumed_train_samples=" << state.consumed_train_samples << ", topology(ddp,tp,sp,pp)=("
-               << state.ddp_size << "," << state.tp_size << "," << state.sp_size << "," << state.pp_size << ")";
+               << state.ddp_size << "," << state.tp_size << "," << state.sp_size << "," << state.pp_size << ","
+               << state.vpp_size << ")";
 }
 
 Checkpoint::SavedTensorLocations
@@ -335,7 +336,8 @@ void Checkpoint::SaveTrainerState(const std::filesystem::path &path, const Train
     ofs << "  \"ddp_size\": " << state.ddp_size << ",\n";
     ofs << "  \"tp_size\": " << state.tp_size << ",\n";
     ofs << "  \"sp_size\": " << state.sp_size << ",\n";
-    ofs << "  \"pp_size\": " << state.pp_size << "\n";
+    ofs << "  \"pp_size\": " << state.pp_size << ",\n";
+    ofs << "  \"vpp_size\": " << state.vpp_size << "\n";
     ofs << "}\n";
 }
 
@@ -357,6 +359,7 @@ TrainerState Checkpoint::LoadTrainerState(const std::filesystem::path &path) {
     state.tp_size = ExtractNumberField<int>(content, "tp_size", 1);
     state.sp_size = ExtractNumberField<int>(content, "sp_size", 1);
     state.pp_size = ExtractNumberField<int>(content, "pp_size", 1);
+    state.vpp_size = ExtractNumberField<int>(content, "vpp_size", 1);
     return state;
 }
 
@@ -447,7 +450,8 @@ void Checkpoint::SaveSharded(const std::filesystem::path &checkpoint_dir,
         ofs << "    \"tp_size\": " << state.tp_size << ",\n";
         ofs << "    \"pp_size\": " << state.pp_size << ",\n";
         ofs << "    \"dp_size\": " << state.ddp_size << ",\n";
-        ofs << "    \"sp_size\": " << state.sp_size << "\n";
+        ofs << "    \"sp_size\": " << state.sp_size << ",\n";
+        ofs << "    \"vpp_size\": " << state.vpp_size << "\n";
         ofs << "  },\n";
         ofs << "  \"model_config\": {\n";
         ofs << "    \"n_layer\": " << state.n_layer << ",\n";
@@ -569,6 +573,7 @@ static Checkpoint::CheckpointMetadata LoadSingleMetadata(const std::filesystem::
     meta.parallel_config.pp_size = ExtractNumberField<int>(content, "pp_size", 1);
     meta.parallel_config.dp_size = ExtractNumberField<int>(content, "dp_size", 1);
     meta.parallel_config.sp_size = ExtractNumberField<int>(content, "sp_size", 1);
+    meta.parallel_config.vpp_size = ExtractNumberField<int>(content, "vpp_size", 1);
 
     // Locate the tensors array.
     auto tensors_key = content.find("\"tensors\"");
@@ -771,7 +776,8 @@ void Checkpoint::SaveMetadataFile(const std::filesystem::path &path, const Check
     ofs << "    \"tp_size\": " << metadata.parallel_config.tp_size << ",\n";
     ofs << "    \"pp_size\": " << metadata.parallel_config.pp_size << ",\n";
     ofs << "    \"dp_size\": " << metadata.parallel_config.dp_size << ",\n";
-    ofs << "    \"sp_size\": " << metadata.parallel_config.sp_size << "\n";
+    ofs << "    \"sp_size\": " << metadata.parallel_config.sp_size << ",\n";
+    ofs << "    \"vpp_size\": " << metadata.parallel_config.vpp_size << "\n";
     ofs << "  },\n";
     ofs << "  \"tensors\": [\n";
     for (size_t i = 0; i < metadata.tensors.size(); ++i) {

--- a/infini_train/src/checkpoint/checkpoint.cc
+++ b/infini_train/src/checkpoint/checkpoint.cc
@@ -1,5 +1,6 @@
 #include "infini_train/include/checkpoint/checkpoint.h"
 
+#include <algorithm>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -11,8 +12,10 @@
 
 #include "glog/logging.h"
 
+#include "infini_train/include/checkpoint/save_planner.h"
 #include "infini_train/include/lr_scheduler.h"
 #include "infini_train/include/nn/modules/module.h"
+#include "infini_train/include/nn/parallel/global.h"
 #include "infini_train/include/optimizer.h"
 #include "infini_train/include/tensor.h"
 
@@ -241,13 +244,15 @@ void Checkpoint::Load(const std::filesystem::path &checkpoint_dir, nn::Module &m
                << state.ddp_size << "," << state.tp_size << "," << state.sp_size << "," << state.pp_size << ")";
 }
 
-void Checkpoint::SaveStateDict(const std::filesystem::path &path,
-                               const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict) {
+Checkpoint::SavedTensorLocations
+Checkpoint::SaveStateDict(const std::filesystem::path &path,
+                          const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict) {
     std::ofstream ofs(path, std::ios::binary);
     CHECK(ofs.is_open()) << "Failed to open checkpoint file: " << path;
 
     uint32_t magic = kCkptMagic;
     uint32_t version = kCkptVersion;
+    SavedTensorLocations locations;
     uint32_t count = static_cast<uint32_t>(state_dict.size());
     ofs.write(reinterpret_cast<const char *>(&magic), sizeof(magic));
     ofs.write(reinterpret_cast<const char *>(&version), sizeof(version));
@@ -267,8 +272,14 @@ void Checkpoint::SaveStateDict(const std::filesystem::path &path,
         Tensor cpu_tensor = tensor->To(Device());
         uint64_t bytes = static_cast<uint64_t>(cpu_tensor.SizeInBytes());
         ofs.write(reinterpret_cast<const char *>(&bytes), sizeof(bytes));
+        const auto data_offset = ofs.tellp();
+        CHECK(data_offset != std::streampos(-1)) << "Failed to record tensor offset for " << name;
+        locations.emplace(
+            name, SavedTensorLocation{.data_offset = static_cast<uint64_t>(static_cast<std::streamoff>(data_offset)),
+                                      .byte_size = bytes});
         ofs.write(reinterpret_cast<const char *>(cpu_tensor.DataPtr()), static_cast<std::streamsize>(bytes));
     }
+    return locations;
 }
 
 std::unordered_map<std::string, std::shared_ptr<Tensor>> Checkpoint::LoadStateDict(const std::filesystem::path &path) {
@@ -347,5 +358,463 @@ TrainerState Checkpoint::LoadTrainerState(const std::filesystem::path &path) {
     state.sp_size = ExtractNumberField<int>(content, "sp_size", 1);
     state.pp_size = ExtractNumberField<int>(content, "pp_size", 1);
     return state;
+}
+
+void Checkpoint::SaveTrainerStateFile(const std::filesystem::path &path, const TrainerState &state) {
+    SaveTrainerState(path, state);
+}
+
+TrainerState Checkpoint::LoadTrainerStateFile(const std::filesystem::path &path) { return LoadTrainerState(path); }
+
+void Checkpoint::SaveLRSchedulerStateFile(const std::filesystem::path &path, const LRSchedulerStateDict &state_dict) {
+    SaveLRSchedulerState(path, state_dict);
+}
+
+LRSchedulerStateDict Checkpoint::LoadLRSchedulerStateFile(const std::filesystem::path &path) {
+    return LoadLRSchedulerState(path);
+}
+
+void Checkpoint::SaveStateDictFile(const std::filesystem::path &path,
+                                   const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict) {
+    SaveStateDict(path, state_dict);
+}
+
+std::unordered_map<std::string, std::shared_ptr<Tensor>>
+Checkpoint::LoadStateDictFile(const std::filesystem::path &path) {
+    return LoadStateDict(path);
+}
+
+// -----------------------------------------------------------------------------
+// Save local shards and a temporary rank manifest from a ShardedStateDict.
+// -----------------------------------------------------------------------------
+
+static std::string DataTypeToString(DataType dt) {
+    auto it = kDataTypeToDesc.find(dt);
+    if (it != kDataTypeToDesc.end()) {
+        return it->second;
+    }
+    return "fp32";
+}
+
+void Checkpoint::SaveSharded(const std::filesystem::path &checkpoint_dir,
+                             const checkpoint::ShardedStateDict &sharded_sd,
+                             const std::vector<checkpoint::WriteItem> &write_items,
+                             const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict,
+                             const std::unordered_map<std::string, std::shared_ptr<Tensor>> &optimizer_state,
+                             const TrainerState &state, int global_rank) {
+    std::filesystem::create_directories(checkpoint_dir);
+    LOG(INFO) << "[CKPT] SaveSharded begin: dir=" << checkpoint_dir << ", global_step=" << state.global_step
+              << ", rank=" << global_rank;
+
+    SavedTensorLocations model_file_index;
+    SavedTensorLocations optimizer_file_index;
+
+    // Save model tensors separately from optimizer tensors.
+    {
+        std::unordered_map<std::string, std::shared_ptr<Tensor>> filtered_sd;
+        for (const auto &[key, info] : sharded_sd.tensors) {
+            // Optimizer tensors are serialized separately.
+            if (key.starts_with("adam.")) {
+                continue;
+            }
+            // Match metadata keys to the local tensor payloads.
+            const auto &local_key = info.local_key.empty() ? key : info.local_key;
+            auto it = state_dict.find(local_key);
+            if (it != state_dict.end()) {
+                filtered_sd.emplace(key, it->second);
+            }
+        }
+        if (!filtered_sd.empty()) {
+            model_file_index = SaveStateDict(checkpoint_dir / "model.ckpt", filtered_sd);
+        }
+    }
+
+    // Save the rank-local optimizer state.
+    if (!optimizer_state.empty()) {
+        optimizer_file_index = SaveStateDict(checkpoint_dir / "optimizer.ckpt", optimizer_state);
+    }
+
+    // Write the temporary rank manifest.
+    {
+        std::ofstream ofs(checkpoint_dir / "metadata.json");
+        CHECK(ofs.is_open()) << "Failed to open metadata.json: " << checkpoint_dir / "metadata.json";
+
+        ofs << "{\n";
+        ofs << "  \"version\": 3,\n";
+        ofs << "  \"format\": \"infinitrain_sharded\",\n";
+        ofs << "  \"iteration\": " << state.global_step << ",\n";
+        ofs << "  \"parallel_config\": {\n";
+        ofs << "    \"tp_size\": " << state.tp_size << ",\n";
+        ofs << "    \"pp_size\": " << state.pp_size << ",\n";
+        ofs << "    \"dp_size\": " << state.ddp_size << ",\n";
+        ofs << "    \"sp_size\": " << state.sp_size << "\n";
+        ofs << "  },\n";
+        ofs << "  \"model_config\": {\n";
+        ofs << "    \"n_layer\": " << state.n_layer << ",\n";
+        ofs << "    \"n_head\": " << state.n_head << ",\n";
+        ofs << "    \"n_kv_head\": " << state.n_kv_head << ",\n";
+        ofs << "    \"n_embd\": " << state.n_embd << ",\n";
+        ofs << "    \"vocab_size\": " << state.vocab_size << "\n";
+        ofs << "  },\n";
+        ofs << "  \"tensors\": [\n";
+
+        std::vector<const checkpoint::WriteItem *> emitted_items;
+        for (const auto &item : write_items) {
+            if (sharded_sd.tensors.contains(item.key)) {
+                emitted_items.push_back(&item);
+            }
+        }
+        int dp_rank = 0, tp_rank = 0, pp_rank = 0;
+        nn::parallel::global::GetCoordOf(global_rank, dp_rank, tp_rank, pp_rank);
+        for (size_t i = 0; i < emitted_items.size(); ++i) {
+            const auto &item = *emitted_items[i];
+            const auto it = sharded_sd.tensors.find(item.key);
+            const auto &file_index = item.filename == "optimizer.ckpt" ? optimizer_file_index : model_file_index;
+            const auto storage_it = file_index.find(item.key);
+            CHECK(storage_it != file_index.end()) << "Missing stored tensor metadata for " << item.key;
+            const auto &storage = storage_it->second;
+            CHECK_EQ(storage.byte_size, item.byte_size);
+
+            ofs << "    {\n";
+            ofs << "      \"key\": \"" << item.key << "\",\n";
+            ofs << "      \"dtype\": \"" << DataTypeToString(item.dtype) << "\",\n";
+
+            // global_shape
+            ofs << "      \"global_shape\": [";
+            const auto &gs = it->second.global_shape;
+            for (size_t j = 0; j < gs.size(); ++j) { ofs << gs[j] << (j + 1 < gs.size() ? ", " : ""); }
+            ofs << "],\n";
+
+            ofs << "      \"local_shape\": [";
+            const auto &ls = it->second.local_shape;
+            for (size_t j = 0; j < ls.size(); ++j) { ofs << ls[j] << (j + 1 < ls.size() ? ", " : ""); }
+            ofs << "],\n";
+
+            ofs << "      \"global_offset\": [";
+            for (size_t j = 0; j < it->second.global_offset.size(); ++j) {
+                ofs << it->second.global_offset[j] << (j + 1 < it->second.global_offset.size() ? ", " : "");
+            }
+            ofs << "],\n";
+            ofs << "      \"axis_fragmentations\": [";
+            for (size_t j = 0; j < it->second.axis_fragmentations.size(); ++j) {
+                ofs << it->second.axis_fragmentations[j] << (j + 1 < it->second.axis_fragmentations.size() ? ", " : "");
+            }
+            ofs << "],\n";
+            auto write_segments = [&](const char *name, auto member) {
+                ofs << "      \"" << name << "\": [";
+                for (size_t j = 0; j < it->second.segments.size(); ++j) {
+                    ofs << it->second.segments[j].*member << (j + 1 < it->second.segments.size() ? ", " : "");
+                }
+                ofs << "],\n";
+            };
+            write_segments("segment_global_offsets", &checkpoint::ShardSegment::global_offset);
+            write_segments("segment_local_offsets", &checkpoint::ShardSegment::local_offset);
+            write_segments("segment_lengths", &checkpoint::ShardSegment::length);
+
+            ofs << "      \"file\": \"" << item.filename << "\",\n";
+            ofs << "      \"offset\": " << storage.data_offset << ",\n";
+            ofs << "      \"byte_size\": " << item.byte_size << ",\n";
+            ofs << "      \"pp_rank\": " << pp_rank << ",\n";
+            ofs << "      \"stored_on_ranks\": [" << global_rank << "]\n";
+            ofs << "    }";
+            if (i + 1 < emitted_items.size()) {
+                ofs << ",";
+            }
+            ofs << "\n";
+        }
+
+        ofs << "  ]\n";
+        ofs << "}\n";
+
+        LOG(INFO) << "[CKPT] metadata.json written";
+    }
+
+    LOG(ERROR) << "[CKPT] SaveSharded done: dir=" << checkpoint_dir;
+}
+
+// Load one manifest or aggregate writer manifests while finalizing a checkpoint.
+static std::string ExtractJsonString(const std::string &obj, const std::string &key) {
+    auto token = std::string("\"") + key + "\"";
+    auto pos = obj.find(token);
+    if (pos == std::string::npos) {
+        return "";
+    }
+    auto q1 = obj.find('"', pos + token.size());
+    if (q1 == std::string::npos) {
+        return "";
+    }
+    auto q2 = obj.find('"', q1 + 1);
+    if (q2 == std::string::npos) {
+        return "";
+    }
+    return obj.substr(q1 + 1, q2 - q1 - 1);
+}
+
+static Checkpoint::CheckpointMetadata LoadSingleMetadata(const std::filesystem::path &checkpoint_dir) {
+    Checkpoint::CheckpointMetadata meta;
+    auto metadata_path = checkpoint_dir / "metadata.json";
+    if (!std::filesystem::exists(metadata_path)) {
+        meta.has_metadata = false;
+        return meta;
+    }
+
+    std::ifstream ifs(metadata_path);
+    CHECK(ifs.is_open()) << "Failed to open metadata.json: " << metadata_path;
+    const std::string content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+
+    meta.has_metadata = true;
+    meta.version = ExtractNumberField<int>(content, "version", 0);
+    meta.iteration = ExtractNumberField<int64_t>(content, "iteration", 0);
+    meta.parallel_config.tp_size = ExtractNumberField<int>(content, "tp_size", 1);
+    meta.parallel_config.pp_size = ExtractNumberField<int>(content, "pp_size", 1);
+    meta.parallel_config.dp_size = ExtractNumberField<int>(content, "dp_size", 1);
+    meta.parallel_config.sp_size = ExtractNumberField<int>(content, "sp_size", 1);
+
+    // Locate the tensors array.
+    auto tensors_key = content.find("\"tensors\"");
+    if (tensors_key == std::string::npos) {
+        return meta;
+    }
+
+    auto array_start = content.find('[', tensors_key);
+    if (array_start == std::string::npos) {
+        return meta;
+    }
+
+    int depth = 1;
+    size_t pos = array_start + 1;
+    while (pos < content.size() && depth > 0) {
+        if (content[pos] == '[') {
+            ++depth;
+        } else if (content[pos] == ']') {
+            --depth;
+        }
+        ++pos;
+    }
+    std::string tensor_block = content.substr(array_start + 1, pos - array_start - 2);
+
+    // Parse each tensor object.
+    size_t obj_pos = 0;
+    while ((obj_pos = tensor_block.find('{', obj_pos)) != std::string::npos) {
+        int object_depth = 1;
+        size_t obj_end = obj_pos + 1;
+        while (obj_end < tensor_block.size() && object_depth > 0) {
+            if (tensor_block[obj_end] == '{') {
+                ++object_depth;
+            }
+            if (tensor_block[obj_end] == '}') {
+                --object_depth;
+            }
+            ++obj_end;
+        }
+        if (obj_end > 0) {
+            --obj_end;
+        }
+        if (obj_end == std::string::npos) {
+            break;
+        }
+
+        std::string obj = tensor_block.substr(obj_pos, obj_end - obj_pos + 1);
+
+        Checkpoint::CheckpointMetadata::TensorEntry entry;
+        entry.key = ExtractJsonString(obj, "key");
+        entry.file = ExtractJsonString(obj, "file");
+        entry.dtype_str = ExtractJsonString(obj, "dtype");
+        entry.offset = ExtractNumberField<uint64_t>(obj, "offset", 0);
+        entry.byte_size = ExtractNumberField<uint64_t>(obj, "byte_size", 0);
+        entry.pp_rank = ExtractNumberField<int>(obj, "pp_rank", 0);
+
+        // global_shape: [x, y, z]
+        auto gs_pos = obj.find("\"global_shape\"");
+        if (gs_pos != std::string::npos) {
+            auto b1 = obj.find('[', gs_pos);
+            auto b2 = obj.find(']', b1);
+            if (b1 != std::string::npos && b2 != std::string::npos) {
+                std::string gs = obj.substr(b1 + 1, b2 - b1 - 1);
+                std::stringstream ss(gs);
+                std::string tok;
+                while (std::getline(ss, tok, ',')) {
+                    try {
+                        entry.global_shape.push_back(std::stoll(tok));
+                    } catch (...) {}
+                }
+            }
+        }
+
+        auto ls_pos = obj.find("\"local_shape\"");
+        if (ls_pos != std::string::npos) {
+            auto b1 = obj.find('[', ls_pos);
+            auto b2 = obj.find(']', b1);
+            std::stringstream ss(obj.substr(b1 + 1, b2 - b1 - 1));
+            std::string tok;
+            while (std::getline(ss, tok, ',')) {
+                try {
+                    entry.local_shape.push_back(std::stoll(tok));
+                } catch (...) {}
+            }
+        }
+
+        auto offset_pos = obj.find("\"global_offset\"");
+        if (offset_pos != std::string::npos) {
+            auto b1 = obj.find('[', offset_pos);
+            auto b2 = obj.find(']', b1);
+            std::stringstream ss(obj.substr(b1 + 1, b2 - b1 - 1));
+            std::string token;
+            while (std::getline(ss, token, ',')) {
+                try {
+                    entry.global_offset.push_back(std::stoll(token));
+                } catch (...) {}
+            }
+        }
+
+        auto fragments_pos = obj.find("\"axis_fragmentations\"");
+        if (fragments_pos != std::string::npos) {
+            auto b1 = obj.find('[', fragments_pos);
+            auto b2 = obj.find(']', b1);
+            std::stringstream ss(obj.substr(b1 + 1, b2 - b1 - 1));
+            std::string token;
+            while (std::getline(ss, token, ',')) {
+                try {
+                    entry.axis_fragmentations.push_back(std::stoi(token));
+                } catch (...) {}
+            }
+        }
+
+        auto extract_int64_array = [&](const char *name) {
+            std::vector<int64_t> values;
+            auto field_pos = obj.find(std::string("\"") + name + "\"");
+            if (field_pos == std::string::npos) {
+                return values;
+            }
+            auto b1 = obj.find('[', field_pos);
+            auto b2 = obj.find(']', b1);
+            if (b1 == std::string::npos || b2 == std::string::npos) {
+                return values;
+            }
+            std::stringstream ss(obj.substr(b1 + 1, b2 - b1 - 1));
+            std::string token;
+            while (std::getline(ss, token, ',')) {
+                try {
+                    values.push_back(std::stoll(token));
+                } catch (...) {}
+            }
+            return values;
+        };
+        const auto segment_global_offsets = extract_int64_array("segment_global_offsets");
+        const auto segment_local_offsets = extract_int64_array("segment_local_offsets");
+        const auto segment_lengths = extract_int64_array("segment_lengths");
+        CHECK_EQ(segment_global_offsets.size(), segment_local_offsets.size());
+        CHECK_EQ(segment_global_offsets.size(), segment_lengths.size());
+        for (size_t i = 0; i < segment_lengths.size(); ++i) {
+            entry.segments.push_back({.global_offset = segment_global_offsets[i],
+                                      .local_offset = segment_local_offsets[i],
+                                      .length = segment_lengths[i]});
+        }
+
+        auto ranks_pos = obj.find("\"stored_on_ranks\"");
+        if (ranks_pos != std::string::npos) {
+            auto b1 = obj.find('[', ranks_pos);
+            auto b2 = obj.find(']', b1);
+            std::stringstream ss(obj.substr(b1 + 1, b2 - b1 - 1));
+            std::string tok;
+            while (std::getline(ss, tok, ',')) {
+                try {
+                    entry.stored_on_ranks.push_back(std::stoi(tok));
+                } catch (...) {}
+            }
+        }
+
+        meta.tensors.push_back(std::move(entry));
+        obj_pos = obj_end + 1;
+    }
+
+    LOG(INFO) << "[CKPT] Loaded metadata.json: " << meta.tensors.size() << " tensors, iteration=" << meta.iteration;
+    return meta;
+}
+
+Checkpoint::CheckpointMetadata Checkpoint::LoadMetadata(const std::filesystem::path &checkpoint_dir) {
+    if (std::filesystem::exists(checkpoint_dir / "metadata.json")) {
+        return LoadSingleMetadata(checkpoint_dir);
+    }
+
+    CheckpointMetadata merged;
+    for (const auto &entry : std::filesystem::directory_iterator(checkpoint_dir)) {
+        if (!entry.is_directory() || !entry.path().filename().string().starts_with("rank_")
+            || !std::filesystem::exists(entry.path() / "metadata.json")) {
+            continue;
+        }
+        auto rank_metadata = LoadSingleMetadata(entry.path());
+        if (!rank_metadata.has_metadata) {
+            continue;
+        }
+        if (!merged.has_metadata) {
+            merged = rank_metadata;
+            merged.tensors.clear();
+        }
+        for (auto &tensor : rank_metadata.tensors) {
+            tensor.file = (entry.path().filename() / tensor.file).generic_string();
+            merged.tensors.push_back(std::move(tensor));
+        }
+    }
+    LOG(INFO) << "[CKPT] Aggregated " << merged.tensors.size() << " tensor shards from rank manifests";
+    return merged;
+}
+
+void Checkpoint::SaveMetadataFile(const std::filesystem::path &path, const CheckpointMetadata &metadata) {
+    std::ofstream ofs(path);
+    CHECK(ofs.is_open()) << "Failed to write checkpoint metadata: " << path;
+    ofs << "{\n";
+    ofs << "  \"version\": 3,\n";
+    ofs << "  \"format\": \"infinitrain_sharded\",\n";
+    ofs << "  \"iteration\": " << metadata.iteration << ",\n";
+    ofs << "  \"parallel_config\": {\n";
+    ofs << "    \"tp_size\": " << metadata.parallel_config.tp_size << ",\n";
+    ofs << "    \"pp_size\": " << metadata.parallel_config.pp_size << ",\n";
+    ofs << "    \"dp_size\": " << metadata.parallel_config.dp_size << ",\n";
+    ofs << "    \"sp_size\": " << metadata.parallel_config.sp_size << "\n";
+    ofs << "  },\n";
+    ofs << "  \"tensors\": [\n";
+    for (size_t i = 0; i < metadata.tensors.size(); ++i) {
+        const auto &tensor = metadata.tensors[i];
+        ofs << "    {\n";
+        ofs << "      \"key\": \"" << tensor.key << "\",\n";
+        ofs << "      \"dtype\": \"" << tensor.dtype_str << "\",\n";
+        auto write_shape = [&](const char *name, const std::vector<int64_t> &shape) {
+            ofs << "      \"" << name << "\": [";
+            for (size_t d = 0; d < shape.size(); ++d) { ofs << shape[d] << (d + 1 < shape.size() ? ", " : ""); }
+            ofs << "],\n";
+        };
+        write_shape("global_shape", tensor.global_shape);
+        write_shape("local_shape", tensor.local_shape);
+        write_shape("global_offset", tensor.global_offset);
+        ofs << "      \"axis_fragmentations\": [";
+        for (size_t d = 0; d < tensor.axis_fragmentations.size(); ++d) {
+            ofs << tensor.axis_fragmentations[d] << (d + 1 < tensor.axis_fragmentations.size() ? ", " : "");
+        }
+        ofs << "],\n";
+        auto write_segments = [&](const char *name, auto member) {
+            ofs << "      \"" << name << "\": [";
+            for (size_t d = 0; d < tensor.segments.size(); ++d) {
+                ofs << tensor.segments[d].*member << (d + 1 < tensor.segments.size() ? ", " : "");
+            }
+            ofs << "],\n";
+        };
+        write_segments("segment_global_offsets", &checkpoint::ShardSegment::global_offset);
+        write_segments("segment_local_offsets", &checkpoint::ShardSegment::local_offset);
+        write_segments("segment_lengths", &checkpoint::ShardSegment::length);
+        ofs << "      \"file\": \"" << tensor.file << "\",\n";
+        ofs << "      \"offset\": " << tensor.offset << ",\n";
+        ofs << "      \"byte_size\": " << tensor.byte_size << ",\n";
+        ofs << "      \"pp_rank\": " << tensor.pp_rank << ",\n";
+        ofs << "      \"stored_on_ranks\": [";
+        for (size_t r = 0; r < tensor.stored_on_ranks.size(); ++r) {
+            ofs << tensor.stored_on_ranks[r] << (r + 1 < tensor.stored_on_ranks.size() ? ", " : "");
+        }
+        ofs << "]\n";
+        ofs << "    }" << (i + 1 < metadata.tensors.size() ? "," : "") << "\n";
+    }
+    ofs << "  ]\n";
+    ofs << "}\n";
+    CHECK(ofs.good()) << "Failed while writing checkpoint metadata: " << path;
 }
 } // namespace infini_train

--- a/infini_train/src/checkpoint/checkpoint_manager.cc
+++ b/infini_train/src/checkpoint/checkpoint_manager.cc
@@ -1,25 +1,93 @@
 #include "infini_train/include/checkpoint/checkpoint_manager.h"
 
-#include <cmath>
-#include <cstdlib>
+#include <algorithm>
+#include <chrono>
 #include <filesystem>
 #include <format>
+#include <fstream>
 #include <limits>
-#include <memory>
-#include <string>
+#include <thread>
 #include <vector>
 
 #include "glog/logging.h"
 
+#include "infini_train/include/checkpoint/checkpoint.h"
+#include "infini_train/include/checkpoint/reshard.h"
+#include "infini_train/include/checkpoint/save_planner.h"
+#include "infini_train/include/lr_scheduler.h"
+#include "infini_train/include/nn/modules/module.h"
 #include "infini_train/include/nn/modules/transformer/transformer_config.h"
 #include "infini_train/include/nn/parallel/global.h"
+#include "infini_train/include/nn/parallel/parallel_functional.h"
+#include "infini_train/include/nn/parallel/work.h"
 #include "infini_train/include/tensor.h"
 
 using namespace infini_train;
 namespace nn = infini_train::nn;
 
-// TODO(jym): ckpt is a new checkpoint format; bin is the legacy format. Keeping both as an interim solution; plan to
-// consolidate into one later.
+namespace {
+
+std::filesystem::path ResolveCheckpointDirectory(const std::filesystem::path &root) {
+    const auto latest_path = root / "latest_checkpointed_iteration.txt";
+    if (!std::filesystem::exists(latest_path)) {
+        return root;
+    }
+    std::ifstream latest(latest_path);
+    int64_t iteration = 0;
+    latest >> iteration;
+    const auto directory = root / std::format("iter_{:07d}", iteration);
+    CHECK(std::filesystem::exists(directory)) << "Latest checkpoint directory does not exist: " << directory;
+    return directory;
+}
+
+void SynchronizeCheckpointRanks(const nn::Module &model) {
+    const auto parameters = model.Parameters();
+    CHECK(!parameters.empty()) << "Cannot synchronize checkpoint save for a model without parameters";
+    auto token = std::make_shared<Tensor>(std::vector<int64_t>{1}, DataType::kFLOAT32, parameters.front()->GetDevice());
+    token->Fill(1.0f);
+    nn::parallel::function::AllReduce(token, nn::parallel::function::ReduceOpType::kSum, nullptr, true)->Synchronize();
+}
+
+void WaitForWriterManifests(const std::filesystem::path &staging_root, int tp_size, int pp_size,
+                            int64_t expected_iteration) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::minutes(10);
+    for (;;) {
+        bool ready = true;
+        for (int pp = 0; pp < pp_size && ready; ++pp) {
+            for (int tp = 0; tp < tp_size; ++tp) {
+                const int rank = nn::parallel::global::GetRankOf(0, tp, pp);
+                const auto manifest = staging_root / std::format("rank_{:06d}", rank) / "metadata.json";
+                if (!std::filesystem::exists(manifest)) {
+                    ready = false;
+                    break;
+                }
+                const auto rank_metadata = Checkpoint::LoadMetadata(manifest.parent_path());
+                if (!rank_metadata.has_metadata || rank_metadata.iteration != expected_iteration) {
+                    ready = false;
+                    break;
+                }
+            }
+        }
+        if (ready) {
+            return;
+        }
+        CHECK(std::chrono::steady_clock::now() < deadline)
+            << "Timed out waiting for checkpoint manifests in " << staging_root;
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+}
+
+void WaitForGlobalMetadata(const std::filesystem::path &metadata_path) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::minutes(10);
+    while (!std::filesystem::exists(metadata_path)) {
+        CHECK(std::chrono::steady_clock::now() < deadline)
+            << "Timed out waiting for global checkpoint metadata: " << metadata_path;
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+}
+
+} // namespace
+
 ResumeFromCheckpointResult ResumeFromCheckpoint(const ResumeFromCheckpointArgs &args) {
     ResumeFromCheckpointResult result;
     if (args.resume_root.empty()) {
@@ -27,97 +95,136 @@ ResumeFromCheckpointResult ResumeFromCheckpoint(const ResumeFromCheckpointArgs &
         return result;
     }
 
-    int ddp_world_size = nn::parallel::global::GetDataParallelSize();
-    int tp_world_size = nn::parallel::global::GetTensorParallelSize();
-    int sp_world_size = nn::parallel::global::GetSequenceParallelEnabled() ? tp_world_size : 1;
-    int pp_world_size = nn::parallel::global::GetPipelineParallelSize();
+    auto checkpoint_dir = ResolveCheckpointDirectory(args.resume_root);
+    CHECK(std::filesystem::exists(checkpoint_dir / "metadata.json"))
+        << "Checkpoint metadata.json not found: " << checkpoint_dir;
+    auto metadata = Checkpoint::LoadMetadata(checkpoint_dir);
 
-    std::filesystem::path resume_dir = args.resume_root;
-    if (args.rank.IsParallel()) {
-        const auto rank_dir = resume_dir / std::format("rank_{:06d}", args.rank.GlobalRank());
-        if (std::filesystem::exists(rank_dir)) {
-            resume_dir = rank_dir;
-        }
-    }
+    CHECK(metadata.has_metadata);
+    CHECK_EQ(metadata.version, 3) << "Unsupported distributed checkpoint version: " << metadata.version;
+    checkpoint::LoadDistributedCheckpoint(checkpoint_dir, *args.model, args.optimizer.get(), args.state,
+                                          args.lr_scheduler.get(), metadata);
 
-    Checkpoint::Load(resume_dir, *args.model, args.optimizer.get(), args.state, args.lr_scheduler.get());
-
+    CHECK_EQ(args.state.n_layer, args.model_config.n_layer);
+    CHECK_EQ(args.state.n_head, args.model_config.n_head);
+    CHECK_EQ(args.state.n_kv_head, args.model_config.n_kv_head);
+    CHECK_EQ(args.state.n_embd, args.model_config.n_embd);
+    CHECK_GE(args.state.vocab_size, args.model_config.original_vocab_size)
+        << "Checkpoint vocabulary cannot represent the configured logical vocabulary";
     result.global_step = static_cast<int>(args.state.global_step);
-
-    CHECK_EQ(args.state.n_layer, args.model_config.n_layer)
-        << "n_layer mismatch: ckpt=" << args.state.n_layer << ", config=" << args.model_config.n_layer;
-    CHECK_EQ(args.state.n_head, args.model_config.n_head)
-        << "n_head mismatch: ckpt=" << args.state.n_head << ", config=" << args.model_config.n_head;
-    CHECK_EQ(args.state.n_kv_head, args.model_config.n_kv_head)
-        << "n_kv_head mismatch: ckpt=" << args.state.n_kv_head << ", config=" << args.model_config.n_kv_head;
-    CHECK_EQ(args.state.n_embd, args.model_config.n_embd)
-        << "n_embd mismatch: ckpt=" << args.state.n_embd << ", config=" << args.model_config.n_embd;
-    CHECK_EQ(args.state.vocab_size, args.model_config.vocab_size)
-        << "vocab_size mismatch: ckpt=" << args.state.vocab_size << ", config=" << args.model_config.vocab_size;
-
-    CHECK_EQ(args.state.ddp_size, ddp_world_size) << "DDP size mismatch: checkpoint has DDP=" << args.state.ddp_size
-                                                  << ", but current run has DDP=" << ddp_world_size;
-    CHECK_EQ(args.state.tp_size, tp_world_size)
-        << "TP size mismatch: checkpoint has TP=" << args.state.tp_size << ", but current run has TP=" << tp_world_size;
-    CHECK_EQ(args.state.sp_size, sp_world_size)
-        << "SP size mismatch: checkpoint has SP=" << args.state.sp_size << ", but current run has SP=" << sp_world_size;
-    CHECK_EQ(args.state.pp_size, pp_world_size)
-        << "PP size mismatch: checkpoint has PP=" << args.state.pp_size << ", but current run has PP=" << pp_world_size;
-
     result.consumed_train_samples = static_cast<size_t>(std::max<int64_t>(args.state.consumed_train_samples, 0));
     if (args.rank.IsMainRank()) {
         LOG(INFO) << std::format("Resume training from step {}, consumed_train_samples {}", args.state.global_step,
                                  args.state.consumed_train_samples);
     }
-
     return result;
 }
 
 void SaveCheckpoint(const SaveCheckpointArgs &args) {
-    const auto ckpt_start = std::chrono::high_resolution_clock::now();
+    const auto checkpoint_start = std::chrono::high_resolution_clock::now();
+    TrainerState state{.global_step = args.global_step,
+                       .consumed_train_samples = static_cast<int64_t>(args.consumed_train_samples),
+                       .n_layer = args.n_layer,
+                       .n_head = args.n_head,
+                       .n_kv_head = args.n_kv_head,
+                       .n_embd = args.n_embd,
+                       .vocab_size = args.vocab_size,
+                       .ddp_size = args.ddp_size,
+                       .tp_size = args.tp_size,
+                       .sp_size = args.sp_size,
+                       .pp_size = args.pp_size};
+    const auto iteration_dir = args.checkpoint_root_dir.empty()
+                                 ? args.save_dir
+                                 : args.checkpoint_root_dir / std::format("iter_{:07d}", args.global_step);
+    std::filesystem::create_directories(iteration_dir);
 
-    TrainerState state;
-    state.global_step = args.global_step;
-    state.consumed_train_samples = static_cast<int64_t>(args.consumed_train_samples);
-    state.n_layer = args.n_layer;
-    state.n_head = args.n_head;
-    state.n_kv_head = args.n_kv_head;
-    state.n_embd = args.n_embd;
-    state.vocab_size = args.vocab_size;
-    state.ddp_size = args.ddp_size;
-    state.tp_size = args.tp_size;
-    state.sp_size = args.sp_size;
-    state.pp_size = args.pp_size;
+    const auto staging_root = iteration_dir / ".metadata_tmp";
+    if (args.rank.IsMainRank()) {
+        std::filesystem::remove_all(staging_root);
+    }
+    SynchronizeCheckpointRanks(args.model);
 
-    Checkpoint::Save(args.save_dir, args.model, args.optimizer, state, args.lr_scheduler);
-
-    const auto ckpt_end = std::chrono::high_resolution_clock::now();
-    const double ckpt_ms = std::chrono::duration<double, std::milli>(ckpt_end - ckpt_start).count();
-
-    if (!args.rank.IsMainRank()) {
+    int dp_rank = 0, tp_rank = 0, pp_rank = 0;
+    nn::parallel::global::GetCoordOf(args.rank.GlobalRank(), dp_rank, tp_rank, pp_rank);
+    if (dp_rank != 0) {
         return;
     }
 
-    LOG(INFO) << std::format("Checkpoint saved at: {} ({:.2f} ms)", args.save_dir.string(), ckpt_ms);
+    const auto rank_dir = iteration_dir / std::format("rank_{:06d}", args.rank.GlobalRank());
+    std::filesystem::create_directories(rank_dir);
+    auto sharded_state = args.model.ShardedStateDict();
+    std::unordered_map<std::string, std::shared_ptr<Tensor>> optimizer_state;
+    if (args.optimizer != nullptr) {
+        optimizer_state = args.optimizer->StateDict();
+        auto optimizer_sharded_state = checkpoint::BuildOptimizerShardedStateDict(sharded_state, optimizer_state);
+        sharded_state.Merge(std::move(optimizer_sharded_state));
+    }
+    auto write_items = checkpoint::SavePlanner::Plan(sharded_state, args.rank.GlobalRank());
+    Checkpoint::SaveSharded(rank_dir, sharded_state, write_items, args.model.StateDict(), optimizer_state, state,
+                            args.rank.GlobalRank());
 
-    // FIXME(jym): Pruning currently relies on lexicographic sorting of directory names.
-    // This only works when step directories use zero-padded names (e.g. checkpoint_step_000042).
-    // If a future change introduces unpadded names, the prune order will be incorrect.
-    // Consider extracting the step number from the directory name and sorting numerically
-    // instead, once the checkpoint naming convention is finalized.
-    if (args.max_checkpoint_keep > 0 && std::filesystem::exists(args.checkpoint_root_dir)) {
-        std::vector<std::filesystem::path> ckpts;
+    const auto staging_rank_dir = staging_root / std::format("rank_{:06d}", args.rank.GlobalRank());
+    std::filesystem::create_directories(staging_rank_dir);
+    const auto local_manifest = staging_rank_dir / "metadata.json";
+    if (std::filesystem::exists(local_manifest)) {
+        std::filesystem::remove(local_manifest);
+    }
+    std::filesystem::rename(rank_dir / "metadata.json", local_manifest);
+
+    if (args.rank.IsMainRank()) {
+        Checkpoint::SaveTrainerStateFile(iteration_dir / "trainer_state.json", state);
+        if (args.lr_scheduler != nullptr) {
+            Checkpoint::SaveLRSchedulerStateFile(iteration_dir / "lr_scheduler.ckpt", args.lr_scheduler->StateDict());
+        }
+        WaitForWriterManifests(staging_root, args.tp_size, args.pp_size, args.global_step);
+        auto global_metadata = Checkpoint::LoadMetadata(staging_root);
+        CHECK(global_metadata.has_metadata);
+        const auto temporary_metadata = iteration_dir / "metadata.json.tmp";
+        const auto final_metadata = iteration_dir / "metadata.json";
+        if (std::filesystem::exists(temporary_metadata)) {
+            std::filesystem::remove(temporary_metadata);
+        }
+        Checkpoint::SaveMetadataFile(temporary_metadata, global_metadata);
+        if (std::filesystem::exists(final_metadata)) {
+            std::filesystem::remove(final_metadata);
+        }
+        std::filesystem::rename(temporary_metadata, final_metadata);
+        std::filesystem::remove_all(staging_root);
+    } else {
+        WaitForGlobalMetadata(iteration_dir / "metadata.json");
+    }
+
+    if (args.rank.IsMainRank() && !args.checkpoint_root_dir.empty()) {
+        const auto latest = args.checkpoint_root_dir / "latest_checkpointed_iteration.txt";
+        const auto temporary_latest = args.checkpoint_root_dir / "latest_checkpointed_iteration.txt.tmp";
+        {
+            std::ofstream output(temporary_latest);
+            CHECK(output.is_open());
+            output << args.global_step;
+        }
+        if (std::filesystem::exists(latest)) {
+            std::filesystem::remove(latest);
+        }
+        std::filesystem::rename(temporary_latest, latest);
+    }
+
+    if (args.rank.IsMainRank() && args.max_checkpoint_keep > 0 && std::filesystem::exists(args.checkpoint_root_dir)) {
+        std::vector<std::filesystem::path> checkpoints;
         for (const auto &entry : std::filesystem::directory_iterator(args.checkpoint_root_dir)) {
-            if (entry.is_directory() && entry.path().filename().string().starts_with("checkpoint_step_")) {
-                ckpts.push_back(entry.path());
+            if (entry.is_directory() && entry.path().filename().string().starts_with("iter_")) {
+                checkpoints.push_back(entry.path());
             }
         }
-        std::sort(ckpts.begin(), ckpts.end());
-        while (ckpts.size() > args.max_checkpoint_keep) {
-            std::filesystem::remove_all(ckpts.front());
-            ckpts.erase(ckpts.begin());
+        std::sort(checkpoints.begin(), checkpoints.end());
+        while (checkpoints.size() > args.max_checkpoint_keep) {
+            std::filesystem::remove_all(checkpoints.front());
+            checkpoints.erase(checkpoints.begin());
         }
     }
+
+    const auto checkpoint_end = std::chrono::high_resolution_clock::now();
+    const double elapsed_ms = std::chrono::duration<double, std::milli>(checkpoint_end - checkpoint_start).count();
+    LOG(INFO) << std::format("Checkpoint saved at: {} ({:.2f} ms)", iteration_dir.string(), elapsed_ms);
 }
 
 size_t DataLoaderBatchesToSkip(size_t consumed_train_samples, size_t local_batch_size, size_t ddp_world_size) {

--- a/infini_train/src/checkpoint/checkpoint_manager.cc
+++ b/infini_train/src/checkpoint/checkpoint_manager.cc
@@ -17,6 +17,7 @@
 #include "infini_train/include/lr_scheduler.h"
 #include "infini_train/include/nn/modules/module.h"
 #include "infini_train/include/nn/modules/transformer/transformer_config.h"
+#include "infini_train/include/nn/parallel/ddp/distributed_optimizer.h"
 #include "infini_train/include/nn/parallel/global.h"
 #include "infini_train/include/nn/parallel/parallel_functional.h"
 #include "infini_train/include/nn/parallel/work.h"
@@ -94,6 +95,8 @@ ResumeFromCheckpointResult ResumeFromCheckpoint(const ResumeFromCheckpointArgs &
         LOG(INFO) << "No checkpoint specified for resume. Starting training from scratch.";
         return result;
     }
+    CHECK(dynamic_cast<nn::parallel::DistributedOptimizer *>(args.optimizer.get()) == nullptr)
+        << "Checkpoint restore does not support DistributedOptimizer/ZeRO optimizer state; use zero_stage=0";
 
     auto checkpoint_dir = ResolveCheckpointDirectory(args.resume_root);
     CHECK(std::filesystem::exists(checkpoint_dir / "metadata.json"))
@@ -121,6 +124,8 @@ ResumeFromCheckpointResult ResumeFromCheckpoint(const ResumeFromCheckpointArgs &
 }
 
 void SaveCheckpoint(const SaveCheckpointArgs &args) {
+    CHECK(dynamic_cast<const nn::parallel::DistributedOptimizer *>(args.optimizer) == nullptr)
+        << "Checkpoint save does not support DistributedOptimizer/ZeRO optimizer state; use zero_stage=0";
     const auto checkpoint_start = std::chrono::high_resolution_clock::now();
     TrainerState state{.global_step = args.global_step,
                        .consumed_train_samples = static_cast<int64_t>(args.consumed_train_samples),
@@ -132,7 +137,8 @@ void SaveCheckpoint(const SaveCheckpointArgs &args) {
                        .ddp_size = args.ddp_size,
                        .tp_size = args.tp_size,
                        .sp_size = args.sp_size,
-                       .pp_size = args.pp_size};
+                       .pp_size = args.pp_size,
+                       .vpp_size = args.vpp_size};
     const auto iteration_dir = args.checkpoint_root_dir.empty()
                                  ? args.save_dir
                                  : args.checkpoint_root_dir / std::format("iter_{:07d}", args.global_step);

--- a/infini_train/src/checkpoint/checkpoint_manager.cc
+++ b/infini_train/src/checkpoint/checkpoint_manager.cc
@@ -98,6 +98,7 @@ ResumeFromCheckpointResult ResumeFromCheckpoint(const ResumeFromCheckpointArgs &
     CHECK(dynamic_cast<nn::parallel::DistributedOptimizer *>(args.optimizer.get()) == nullptr)
         << "Checkpoint restore does not support DistributedOptimizer/ZeRO optimizer state; use zero_stage=0";
 
+    // Resolve the checkpoint generation and load the global shard metadata.
     auto checkpoint_dir = ResolveCheckpointDirectory(args.resume_root);
     CHECK(std::filesystem::exists(checkpoint_dir / "metadata.json"))
         << "Checkpoint metadata.json not found: " << checkpoint_dir;
@@ -105,9 +106,11 @@ ResumeFromCheckpointResult ResumeFromCheckpoint(const ResumeFromCheckpointArgs &
 
     CHECK(metadata.has_metadata);
     CHECK_EQ(metadata.version, 3) << "Unsupported distributed checkpoint version: " << metadata.version;
+    // Reconstruct model and optimizer state for the current parallel topology.
     checkpoint::LoadDistributedCheckpoint(checkpoint_dir, *args.model, args.optimizer.get(), args.state,
                                           args.lr_scheduler.get(), metadata);
 
+    // Validate architecture invariants before restoring training progress.
     CHECK_EQ(args.state.n_layer, args.model_config.n_layer);
     CHECK_EQ(args.state.n_head, args.model_config.n_head);
     CHECK_EQ(args.state.n_kv_head, args.model_config.n_kv_head);
@@ -127,6 +130,7 @@ void SaveCheckpoint(const SaveCheckpointArgs &args) {
     CHECK(dynamic_cast<const nn::parallel::DistributedOptimizer *>(args.optimizer) == nullptr)
         << "Checkpoint save does not support DistributedOptimizer/ZeRO optimizer state; use zero_stage=0";
     const auto checkpoint_start = std::chrono::high_resolution_clock::now();
+    // Snapshot training progress and the topology that produced this checkpoint.
     TrainerState state{.global_step = args.global_step,
                        .consumed_train_samples = static_cast<int64_t>(args.consumed_train_samples),
                        .n_layer = args.n_layer,
@@ -144,6 +148,7 @@ void SaveCheckpoint(const SaveCheckpointArgs &args) {
                                  : args.checkpoint_root_dir / std::format("iter_{:07d}", args.global_step);
     std::filesystem::create_directories(iteration_dir);
 
+    // Reset the manifest staging area before writer ranks publish their metadata.
     const auto staging_root = iteration_dir / ".metadata_tmp";
     if (args.rank.IsMainRank()) {
         std::filesystem::remove_all(staging_root);
@@ -152,12 +157,14 @@ void SaveCheckpoint(const SaveCheckpointArgs &args) {
 
     int dp_rank = 0, tp_rank = 0, pp_rank = 0;
     nn::parallel::global::GetCoordOf(args.rank.GlobalRank(), dp_rank, tp_rank, pp_rank);
+    // DP ranks hold replicas; only one DP replica writes each TP/PP shard.
     if (dp_rank != 0) {
         return;
     }
 
     const auto rank_dir = iteration_dir / std::format("rank_{:06d}", args.rank.GlobalRank());
     std::filesystem::create_directories(rank_dir);
+    // Describe logical shards, plan their physical layout, and write this rank shard.
     auto sharded_state = args.model.ShardedStateDict();
     std::unordered_map<std::string, std::shared_ptr<Tensor>> optimizer_state;
     if (args.optimizer != nullptr) {
@@ -171,6 +178,7 @@ void SaveCheckpoint(const SaveCheckpointArgs &args) {
 
     const auto staging_rank_dir = staging_root / std::format("rank_{:06d}", args.rank.GlobalRank());
     std::filesystem::create_directories(staging_rank_dir);
+    // Stage the local manifest until all writer ranks have completed their shards.
     const auto local_manifest = staging_rank_dir / "metadata.json";
     if (std::filesystem::exists(local_manifest)) {
         std::filesystem::remove(local_manifest);
@@ -182,6 +190,7 @@ void SaveCheckpoint(const SaveCheckpointArgs &args) {
         if (args.lr_scheduler != nullptr) {
             Checkpoint::SaveLRSchedulerStateFile(iteration_dir / "lr_scheduler.ckpt", args.lr_scheduler->StateDict());
         }
+        // Aggregate writer manifests and atomically publish the global metadata.
         WaitForWriterManifests(staging_root, args.tp_size, args.pp_size, args.global_step);
         auto global_metadata = Checkpoint::LoadMetadata(staging_root);
         CHECK(global_metadata.has_metadata);

--- a/infini_train/src/checkpoint/load_planner.cc
+++ b/infini_train/src/checkpoint/load_planner.cc
@@ -1,0 +1,244 @@
+#include "infini_train/include/checkpoint/load_planner.h"
+
+#include <algorithm>
+#include <set>
+#include <tuple>
+#include <unordered_map>
+
+#include "glog/logging.h"
+
+namespace infini_train::checkpoint {
+namespace {
+
+DataType StringToDataType(const std::string &value) {
+    static const std::unordered_map<std::string, DataType> legacy_names = {
+        {"bfloat16", DataType::kBFLOAT16},
+        {"float16", DataType::kFLOAT16},
+        {"float32", DataType::kFLOAT32},
+        {"float64", DataType::kFLOAT64},
+    };
+    if (const auto it = legacy_names.find(value); it != legacy_names.end()) {
+        return it->second;
+    }
+    for (const auto &[dtype, description] : kDataTypeToDesc) {
+        if (description == value) {
+            return dtype;
+        }
+    }
+    LOG(FATAL) << "Unsupported checkpoint tensor dtype: " << value;
+    return DataType::kFLOAT32;
+}
+
+int FragmentedAxis(const std::vector<int> &axis_fragmentations) {
+    int fragmented_axis = -1;
+    for (size_t dim = 0; dim < axis_fragmentations.size(); ++dim) {
+        if (axis_fragmentations[dim] <= 1) {
+            continue;
+        }
+        CHECK_EQ(fragmented_axis, -1) << "Multi-axis checkpoint sharding is not supported yet";
+        fragmented_axis = static_cast<int>(dim);
+    }
+    return fragmented_axis;
+}
+
+bool IsVocabularyTensor(const std::string &key) {
+    std::string parameter_key = key;
+    if (parameter_key.starts_with("adam.m.")) {
+        parameter_key = parameter_key.substr(7);
+    } else if (parameter_key.starts_with("adam.v.")) {
+        parameter_key = parameter_key.substr(7);
+    }
+    return parameter_key == "transformer.wte.weight" || parameter_key == "lm_head.weight";
+}
+
+bool IsPaddingCompatible(const std::string &key, const std::vector<int64_t> &source,
+                         const std::vector<int64_t> &target) {
+    if (!IsVocabularyTensor(key) || source.size() != target.size() || source.empty()) {
+        return false;
+    }
+    for (size_t dim = 1; dim < source.size(); ++dim) {
+        if (source[dim] != target[dim]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void ValidateCoordinates(const std::string &key, const std::vector<int64_t> &global_shape,
+                         const std::vector<int64_t> &local_shape, const std::vector<int64_t> &global_offset,
+                         const std::vector<int> &axis_fragmentations) {
+    CHECK_EQ(global_shape.size(), local_shape.size()) << "Invalid local rank for tensor " << key;
+    CHECK_EQ(global_shape.size(), global_offset.size()) << "Invalid offset rank for tensor " << key;
+    CHECK_EQ(global_shape.size(), axis_fragmentations.size()) << "Invalid fragmentation rank for tensor " << key;
+    for (size_t dim = 0; dim < global_shape.size(); ++dim) {
+        CHECK_GT(global_shape[dim], 0) << "Invalid global shape for tensor " << key;
+        CHECK_GT(local_shape[dim], 0) << "Invalid local shape for tensor " << key;
+        CHECK_GE(global_offset[dim], 0) << "Invalid global offset for tensor " << key;
+        CHECK_LE(global_offset[dim] + local_shape[dim], global_shape[dim])
+            << "Shard exceeds global shape for tensor " << key;
+        CHECK_GE(axis_fragmentations[dim], 1) << "Invalid axis fragmentation for tensor " << key;
+    }
+}
+
+} // namespace
+
+LoadPlan LoadPlanner::PlanReshard(const Checkpoint::CheckpointMetadata &metadata,
+                                  const ShardedStateDict &target_state_dict) {
+    LoadPlan plan;
+    for (const auto &[key, target] : target_state_dict.tensors) {
+        ValidateCoordinates(key, target.global_shape, target.local_shape, target.global_offset,
+                            target.axis_fragmentations);
+        TargetTensorPlan tensor_plan{.key = key,
+                                     .dtype = target.dtype,
+                                     .global_shape = target.global_shape,
+                                     .target_shape = target.local_shape,
+                                     .shard_dim = FragmentedAxis(target.axis_fragmentations)};
+
+        std::vector<const Checkpoint::CheckpointMetadata::TensorEntry *> candidates;
+        for (const auto &entry : metadata.tensors) {
+            if (entry.key == key) {
+                candidates.push_back(&entry);
+            }
+        }
+        CHECK(!candidates.empty()) << "No saved shard found for target tensor: " << key;
+        const int saved_axis = FragmentedAxis(candidates.front()->axis_fragmentations);
+        for (const auto *source : candidates) {
+            ValidateCoordinates(key, source->global_shape, source->local_shape, source->global_offset,
+                                source->axis_fragmentations);
+            CHECK(source->global_shape == target.global_shape
+                  || IsPaddingCompatible(key, source->global_shape, target.global_shape))
+                << "Global shape changed for tensor " << key;
+            CHECK_EQ(FragmentedAxis(source->axis_fragmentations), saved_axis)
+                << "Inconsistent saved shard dimensions for tensor " << key;
+        }
+
+        if (!target.segments.empty()) {
+            if (tensor_plan.shard_dim < 0) {
+                tensor_plan.shard_dim = 0;
+            }
+            int64_t target_covered = 0;
+            for (const auto &target_segment : target.segments) {
+                CHECK_EQ(target_segment.local_offset, target_covered)
+                    << "Gap or overlap in target segments for " << key;
+                CHECK_GT(target_segment.length, 0);
+                CHECK_LE(target_segment.global_offset + target_segment.length,
+                         target.global_shape[tensor_plan.shard_dim]);
+                target_covered += target_segment.length;
+                for (const auto *source : candidates) {
+                    CHECK(!source->segments.empty()) << "Saved checkpoint lacks segmented layout metadata for " << key;
+                    for (const auto &source_segment : source->segments) {
+                        const int64_t overlap_start
+                            = std::max(source_segment.global_offset, target_segment.global_offset);
+                        const int64_t overlap_end = std::min(source_segment.global_offset + source_segment.length,
+                                                             target_segment.global_offset + target_segment.length);
+                        if (overlap_start >= overlap_end) {
+                            continue;
+                        }
+                        tensor_plan.reads.push_back({
+                            .key = key,
+                            .filename = source->file,
+                            .dtype = StringToDataType(source->dtype_str),
+                            .global_shape = source->global_shape,
+                            .byte_size = source->byte_size,
+                            .data_offset = source->offset,
+                            .shard_dim = tensor_plan.shard_dim,
+                            .source_offset = source_segment.local_offset + overlap_start - source_segment.global_offset,
+                            .target_offset = target_segment.local_offset + overlap_start - target_segment.global_offset,
+                            .length = overlap_end - overlap_start,
+                            .source_shape = source->local_shape,
+                        });
+                    }
+                }
+            }
+            CHECK_EQ(target_covered, target.local_shape[tensor_plan.shard_dim])
+                << "Segmented layout does not cover target local tensor " << key;
+            std::sort(
+                tensor_plan.reads.begin(), tensor_plan.reads.end(),
+                [](const ReadItem &left, const ReadItem &right) { return left.target_offset < right.target_offset; });
+            int64_t covered = 0;
+            for (const auto &read : tensor_plan.reads) {
+                CHECK_EQ(read.target_offset, covered) << "Gap or overlap in segmented target plan for " << key;
+                covered += read.length;
+            }
+            CHECK_EQ(covered, target_covered) << "Incomplete segmented target plan for " << key;
+            plan.tensors.emplace(key, std::move(tensor_plan));
+            continue;
+        }
+
+        if (tensor_plan.shard_dim < 0) {
+            tensor_plan.shard_dim = saved_axis;
+        }
+        if (tensor_plan.shard_dim < 0 && candidates.front()->global_shape != target.global_shape) {
+            tensor_plan.shard_dim = 0;
+        }
+        if (saved_axis >= 0 && FragmentedAxis(target.axis_fragmentations) >= 0) {
+            CHECK_EQ(saved_axis, tensor_plan.shard_dim) << "Shard dimension changed for tensor " << key;
+        }
+
+        if (tensor_plan.shard_dim < 0) {
+            const auto *source = candidates.front();
+            tensor_plan.reads.push_back({.key = key,
+                                         .filename = source->file,
+                                         .dtype = StringToDataType(source->dtype_str),
+                                         .global_shape = source->global_shape,
+                                         .byte_size = source->byte_size,
+                                         .data_offset = source->offset,
+                                         .shard_dim = -1,
+                                         .source_shape = source->local_shape});
+            plan.tensors.emplace(key, std::move(tensor_plan));
+            continue;
+        }
+
+        const int dim = tensor_plan.shard_dim;
+        const int64_t target_start = target.global_offset[dim];
+        const int64_t target_length = target.local_shape[dim];
+        const int64_t target_end = target_start + target_length;
+        std::set<std::pair<int64_t, int64_t>> seen_source_ranges;
+
+        for (const auto *source : candidates) {
+            const int64_t saved_start = source->global_offset[dim];
+            const int64_t saved_length = source->local_shape[dim];
+            if (!seen_source_ranges.emplace(saved_start, saved_length).second) {
+                continue;
+            }
+            const int64_t overlap_start = std::max(saved_start, target_start);
+            const int64_t overlap_end = std::min(saved_start + saved_length, target_end);
+            if (overlap_start >= overlap_end) {
+                continue;
+            }
+
+            tensor_plan.reads.push_back({.key = key,
+                                         .filename = source->file,
+                                         .dtype = StringToDataType(source->dtype_str),
+                                         .global_shape = source->global_shape,
+                                         .byte_size = source->byte_size,
+                                         .data_offset = source->offset,
+                                         .shard_dim = dim,
+                                         .source_offset = overlap_start - saved_start,
+                                         .target_offset = overlap_start - target_start,
+                                         .length = overlap_end - overlap_start,
+                                         .source_shape = source->local_shape});
+        }
+
+        std::sort(tensor_plan.reads.begin(), tensor_plan.reads.end(),
+                  [](const ReadItem &left, const ReadItem &right) { return left.target_offset < right.target_offset; });
+        int64_t covered = 0;
+        for (const auto &read : tensor_plan.reads) {
+            CHECK_EQ(read.target_offset, covered) << "Gap or overlap in target shard plan for " << key;
+            covered += read.length;
+        }
+        if (covered < target_length) {
+            CHECK(IsVocabularyTensor(key)) << "Incomplete target shard plan for " << key;
+            CHECK_EQ(dim, 0) << "Vocabulary padding is only supported along dim 0";
+            CHECK_EQ(target_start + covered, candidates.front()->global_shape[0])
+                << "Only trailing vocabulary padding is supported for " << key;
+            tensor_plan.trailing_zero_fill = target_length - covered;
+            covered = target_length;
+        }
+        CHECK_EQ(covered, target_length) << "Incomplete target shard plan for " << key;
+        plan.tensors.emplace(key, std::move(tensor_plan));
+    }
+    return plan;
+}
+
+} // namespace infini_train::checkpoint

--- a/infini_train/src/checkpoint/load_strategy.cc
+++ b/infini_train/src/checkpoint/load_strategy.cc
@@ -1,0 +1,129 @@
+#include "infini_train/include/checkpoint/load_strategy.h"
+
+#include <fstream>
+#include <vector>
+
+#include "glog/logging.h"
+
+#include "infini_train/include/nn/functional.h"
+#include "infini_train/include/tensor.h"
+#include "infini_train/include/utils/string_utils.h"
+
+namespace infini_train::checkpoint {
+namespace {
+
+using FileCache = std::unordered_map<std::string, std::unique_ptr<std::ifstream>>;
+
+std::ifstream &GetFile(FileCache &cache, const std::filesystem::path &checkpoint_dir, const std::string &filename) {
+    auto it = cache.find(filename);
+    if (it == cache.end()) {
+        auto stream = std::make_unique<std::ifstream>(checkpoint_dir / filename, std::ios::binary);
+        CHECK(stream->is_open()) << "Failed to open checkpoint file: " << checkpoint_dir / filename;
+        it = cache.emplace(filename, std::move(stream)).first;
+    }
+    return *it->second;
+}
+
+void ReadAt(std::ifstream &stream, uint64_t offset, void *destination, uint64_t byte_size, const std::string &key,
+            const std::string &filename) {
+    stream.clear();
+    stream.seekg(static_cast<std::streamoff>(offset), std::ios::beg);
+    CHECK(stream.good()) << "Failed to seek tensor " << key << " in " << filename;
+    stream.read(static_cast<char *>(destination), static_cast<std::streamsize>(byte_size));
+    CHECK_EQ(static_cast<uint64_t>(stream.gcount()), byte_size) << "Truncated tensor " << key << " in " << filename;
+}
+
+std::shared_ptr<Tensor> ReadTensor(std::ifstream &stream, const ReadItem &read) {
+    auto tensor = std::make_shared<Tensor>(read.source_shape, read.dtype, Device());
+    CHECK_EQ(read.byte_size, tensor->SizeInBytes())
+        << "Tensor byte size mismatch for " << read.key << " in " << read.filename;
+    ReadAt(stream, read.data_offset, tensor->DataPtr(), read.byte_size, read.key, read.filename);
+    return tensor;
+}
+
+std::shared_ptr<Tensor> ReadTensorRegion(std::ifstream &stream, const ReadItem &read) {
+    CHECK_GE(read.shard_dim, 0);
+    CHECK_LT(read.shard_dim, static_cast<int>(read.source_shape.size()));
+    CHECK_GE(read.source_offset, 0);
+    CHECK_GT(read.length, 0);
+    CHECK_LE(read.source_offset + read.length, read.source_shape[read.shard_dim]);
+
+    uint64_t source_numel = 1;
+    for (const auto size : read.source_shape) {
+        CHECK_GT(size, 0);
+        source_numel *= static_cast<uint64_t>(size);
+    }
+    CHECK_EQ(read.byte_size % source_numel, 0u)
+        << "Invalid tensor byte size for " << read.key << " in " << read.filename;
+    const uint64_t element_size = read.byte_size / source_numel;
+
+    uint64_t outer = 1;
+    for (int dim = 0; dim < read.shard_dim; ++dim) { outer *= static_cast<uint64_t>(read.source_shape[dim]); }
+    uint64_t inner = 1;
+    for (size_t dim = static_cast<size_t>(read.shard_dim + 1); dim < read.source_shape.size(); ++dim) {
+        inner *= static_cast<uint64_t>(read.source_shape[dim]);
+    }
+
+    auto region_shape = read.source_shape;
+    region_shape[read.shard_dim] = read.length;
+    auto tensor = std::make_shared<Tensor>(region_shape, read.dtype, Device());
+    const uint64_t block_bytes = static_cast<uint64_t>(read.length) * inner * element_size;
+    const uint64_t source_stride_bytes
+        = static_cast<uint64_t>(read.source_shape[read.shard_dim]) * inner * element_size;
+    const uint64_t first_block_offset
+        = read.data_offset + static_cast<uint64_t>(read.source_offset) * inner * element_size;
+    CHECK_EQ(outer * block_bytes, tensor->SizeInBytes());
+
+    auto *destination = static_cast<char *>(tensor->DataPtr());
+    for (uint64_t block = 0; block < outer; ++block) {
+        ReadAt(stream, first_block_offset + block * source_stride_bytes, destination + block * block_bytes, block_bytes,
+               read.key, read.filename);
+    }
+    return tensor;
+}
+
+} // namespace
+
+LoadedStateDict IndexedRegionLoadStrategy::Execute(const std::filesystem::path &checkpoint_dir, const LoadPlan &plan) {
+    FileCache file_cache;
+    LoadedStateDict result;
+
+    for (const auto &[key, tensor_plan] : plan.tensors) {
+        CHECK(!tensor_plan.reads.empty()
+              || (tensor_plan.shard_dim >= 0
+                  && tensor_plan.trailing_zero_fill == tensor_plan.target_shape[tensor_plan.shard_dim]))
+            << "No reads or padding planned for target tensor: " << key;
+        std::vector<std::shared_ptr<Tensor>> pieces;
+        pieces.reserve(tensor_plan.reads.size() + (tensor_plan.trailing_zero_fill > 0 ? 1 : 0));
+
+        for (const auto &read : tensor_plan.reads) {
+            CHECK_GT(read.data_offset, 0) << "Checkpoint metadata lacks a valid tensor data offset for " << key
+                                          << "; regenerate the checkpoint with the current format";
+            auto &stream = GetFile(file_cache, checkpoint_dir, read.filename);
+            pieces.push_back(read.shard_dim < 0 ? ReadTensor(stream, read) : ReadTensorRegion(stream, read));
+        }
+
+        if (tensor_plan.trailing_zero_fill > 0) {
+            CHECK_GE(tensor_plan.shard_dim, 0);
+            auto padding_shape = tensor_plan.target_shape;
+            padding_shape[tensor_plan.shard_dim] = tensor_plan.trailing_zero_fill;
+            auto padding = std::make_shared<Tensor>(padding_shape, tensor_plan.dtype, Device());
+            padding->Fill(0.0f);
+            pieces.push_back(std::move(padding));
+        }
+
+        auto target = pieces.front();
+        if (pieces.size() > 1) {
+            CHECK_GE(tensor_plan.shard_dim, 0);
+            target = nn::function::Concat(pieces, tensor_plan.shard_dim)->Contiguous();
+        }
+        CHECK(target->Dims() == tensor_plan.target_shape)
+            << "Target shard shape mismatch for " << key
+            << ": expected=" << utils::DimsToString(tensor_plan.target_shape)
+            << ", got=" << utils::DimsToString(target->Dims());
+        result.emplace(key, std::move(target));
+    }
+    return result;
+}
+
+} // namespace infini_train::checkpoint

--- a/infini_train/src/checkpoint/load_strategy.cc
+++ b/infini_train/src/checkpoint/load_strategy.cc
@@ -100,7 +100,11 @@ LoadedStateDict IndexedRegionLoadStrategy::Execute(const std::filesystem::path &
             CHECK_GT(read.data_offset, 0) << "Checkpoint metadata lacks a valid tensor data offset for " << key
                                           << "; regenerate the checkpoint with the current format";
             auto &stream = GetFile(file_cache, checkpoint_dir, read.filename);
-            pieces.push_back(read.shard_dim < 0 ? ReadTensor(stream, read) : ReadTensorRegion(stream, read));
+            auto piece = read.shard_dim < 0 ? ReadTensor(stream, read) : ReadTensorRegion(stream, read);
+            if (piece->Dtype() != tensor_plan.dtype) {
+                piece = std::make_shared<Tensor>(piece->To(tensor_plan.dtype));
+            }
+            pieces.push_back(std::move(piece));
         }
 
         if (tensor_plan.trailing_zero_fill > 0) {

--- a/infini_train/src/checkpoint/reshard.cc
+++ b/infini_train/src/checkpoint/reshard.cc
@@ -20,12 +20,15 @@ void LoadDistributedCheckpoint(const std::filesystem::path &checkpoint_dir, nn::
                                const Checkpoint::CheckpointMetadata &metadata) {
     CHECK(metadata.has_metadata);
     CHECK_EQ(metadata.version, 3) << "Unsupported distributed checkpoint version: " << metadata.version;
+    // Build this rank's target shard layout and plan overlap reads from the saved source shards.
     auto model_sharded_state = model.ShardedStateDict();
     auto plan = LoadPlanner::PlanReshard(metadata, model_sharded_state);
+    // Execute the read plan, assemble target tensors, and load the reconstructed model state.
     IndexedRegionLoadStrategy strategy;
     auto result = strategy.Execute(checkpoint_dir, plan);
     model.LoadStateDict(result);
 
+    // Restore training progress, but rewrite topology fields to describe the current runtime.
     state = Checkpoint::LoadTrainerStateFile(checkpoint_dir / "trainer_state.json");
     const int current_tp = nn::parallel::global::GetTensorParallelSize();
     const int current_pp = nn::parallel::global::GetPipelineParallelSize();
@@ -36,6 +39,7 @@ void LoadDistributedCheckpoint(const std::filesystem::path &checkpoint_dir, nn::
     state.ddp_size = nn::parallel::global::GetDataParallelSize();
     state.sp_size = nn::parallel::global::GetSequenceParallelEnabled() ? current_tp : 1;
 
+    // Reshard optimizer tensors only when TP or PP changed; otherwise load the matching writer shard directly.
     if (optimizer != nullptr) {
         if (topology_changed) {
             const auto initialized_optimizer_state = optimizer->StateDict();
@@ -60,6 +64,7 @@ void LoadDistributedCheckpoint(const std::filesystem::path &checkpoint_dir, nn::
             optimizer->LoadStateDict(Checkpoint::LoadStateDictFile(optimizer_path));
         }
     }
+    // Scheduler state is topology-independent and can be restored directly.
     if (lr_scheduler != nullptr && std::filesystem::exists(checkpoint_dir / "lr_scheduler.ckpt")) {
         lr_scheduler->LoadStateDict(Checkpoint::LoadLRSchedulerStateFile(checkpoint_dir / "lr_scheduler.ckpt"));
     }

--- a/infini_train/src/checkpoint/reshard.cc
+++ b/infini_train/src/checkpoint/reshard.cc
@@ -1,0 +1,71 @@
+#include "infini_train/include/checkpoint/reshard.h"
+
+#include <filesystem>
+#include <format>
+
+#include "glog/logging.h"
+
+#include "infini_train/include/checkpoint/load_planner.h"
+#include "infini_train/include/checkpoint/load_strategy.h"
+#include "infini_train/include/checkpoint/save_planner.h"
+#include "infini_train/include/lr_scheduler.h"
+#include "infini_train/include/nn/modules/module.h"
+#include "infini_train/include/nn/parallel/global.h"
+#include "infini_train/include/optimizer.h"
+
+namespace infini_train::checkpoint {
+
+void LoadDistributedCheckpoint(const std::filesystem::path &checkpoint_dir, nn::Module &model, Optimizer *optimizer,
+                               TrainerState &state, LRScheduler *lr_scheduler,
+                               const Checkpoint::CheckpointMetadata &metadata) {
+    CHECK(metadata.has_metadata);
+    CHECK_EQ(metadata.version, 3) << "Unsupported distributed checkpoint version: " << metadata.version;
+    auto model_sharded_state = model.ShardedStateDict();
+    auto plan = LoadPlanner::PlanReshard(metadata, model_sharded_state);
+    IndexedRegionLoadStrategy strategy;
+    auto result = strategy.Execute(checkpoint_dir, plan);
+    model.LoadStateDict(result);
+
+    state = Checkpoint::LoadTrainerStateFile(checkpoint_dir / "trainer_state.json");
+    const int current_tp = nn::parallel::global::GetTensorParallelSize();
+    const int current_pp = nn::parallel::global::GetPipelineParallelSize();
+    const bool topology_changed
+        = current_tp != metadata.parallel_config.tp_size || current_pp != metadata.parallel_config.pp_size;
+    state.tp_size = current_tp;
+    state.pp_size = current_pp;
+    state.ddp_size = nn::parallel::global::GetDataParallelSize();
+    state.sp_size = nn::parallel::global::GetSequenceParallelEnabled() ? current_tp : 1;
+
+    if (optimizer != nullptr) {
+        if (topology_changed) {
+            const auto initialized_optimizer_state = optimizer->StateDict();
+            auto optimizer_sharded_state
+                = BuildOptimizerShardedStateDict(model_sharded_state, initialized_optimizer_state);
+            auto optimizer_plan = LoadPlanner::PlanReshard(metadata, optimizer_sharded_state);
+            auto loaded_optimizer_state = strategy.Execute(checkpoint_dir, optimizer_plan);
+            optimizer->LoadStateDict(loaded_optimizer_state);
+            LOG(INFO) << "[CKPT] Resharded " << loaded_optimizer_state.size()
+                      << " optimizer tensors across TP/PP topology change";
+        } else {
+            int dp_rank = 0, tp_rank = 0, pp_rank = 0;
+            nn::parallel::global::GetCoordOf(nn::parallel::global::thread_global_rank, dp_rank, tp_rank, pp_rank);
+            const int writer_rank = nn::parallel::global::GetRankOf(0, tp_rank, pp_rank);
+            const auto optimizer_path = checkpoint_dir / std::format("rank_{:06d}/optimizer.ckpt", writer_rank);
+            CHECK(std::filesystem::exists(optimizer_path))
+                << "Optimizer checkpoint not found for current_rank=" << nn::parallel::global::thread_global_rank
+                << ", coords=(dp=" << dp_rank << ", tp=" << tp_rank << ", pp=" << pp_rank
+                << "), writer_rank=" << writer_rank << ": " << optimizer_path;
+            LOG(INFO) << "[CKPT] Loading optimizer for current_rank=" << nn::parallel::global::thread_global_rank
+                      << " from writer_rank=" << writer_rank << ": " << optimizer_path;
+            optimizer->LoadStateDict(Checkpoint::LoadStateDictFile(optimizer_path));
+        }
+    }
+    if (lr_scheduler != nullptr && std::filesystem::exists(checkpoint_dir / "lr_scheduler.ckpt")) {
+        lr_scheduler->LoadStateDict(Checkpoint::LoadLRSchedulerStateFile(checkpoint_dir / "lr_scheduler.ckpt"));
+    }
+    LOG(INFO) << "[CKPT] Restored " << result.size()
+              << " tensors with overlap reads from TP=" << metadata.parallel_config.tp_size
+              << ", PP=" << metadata.parallel_config.pp_size << " to TP=" << current_tp << ", PP=" << current_pp;
+}
+
+} // namespace infini_train::checkpoint

--- a/infini_train/src/checkpoint/save_planner.cc
+++ b/infini_train/src/checkpoint/save_planner.cc
@@ -1,0 +1,75 @@
+#include "infini_train/include/checkpoint/save_planner.h"
+
+#include "glog/logging.h"
+
+#include "infini_train/include/tensor.h"
+
+namespace infini_train::checkpoint {
+
+ShardedStateDict
+BuildOptimizerShardedStateDict(const ShardedStateDict &model_state,
+                               const std::unordered_map<std::string, std::shared_ptr<Tensor>> &optimizer_state) {
+    ShardedStateDict result;
+    for (const auto &[key, tensor] : optimizer_state) {
+        if (key == "adam.t") {
+            ShardedTensor info;
+            info.key = key;
+            info.local_key = key;
+            info.dtype = tensor->Dtype();
+            info.global_shape = tensor->Dims();
+            info.local_shape = tensor->Dims();
+            info.global_offset.assign(tensor->Dims().size(), 0);
+            info.axis_fragmentations.assign(tensor->Dims().size(), 1);
+            result.tensors.emplace(key, std::move(info));
+            continue;
+        }
+
+        std::string parameter_key;
+        if (key.starts_with("adam.m.")) {
+            parameter_key = key.substr(std::string("adam.m.").size());
+        } else if (key.starts_with("adam.v.")) {
+            parameter_key = key.substr(std::string("adam.v.").size());
+        } else {
+            CHECK(false) << "Unsupported optimizer state key: " << key;
+        }
+
+        auto model_it = model_state.tensors.find(parameter_key);
+        CHECK(model_it != model_state.tensors.end())
+            << "Optimizer state " << key << " has no matching named model parameter. "
+            << "Optimizer resharding requires set_parameter_names().";
+        auto info = model_it->second;
+        info.key = key;
+        info.local_key = key;
+        result.tensors.emplace(key, std::move(info));
+    }
+    return result;
+}
+
+std::vector<WriteItem> SavePlanner::Plan(const ShardedStateDict &sd, int rank) {
+    std::vector<WriteItem> items;
+    uint64_t model_offset = 0;
+    uint64_t optim_offset = 0;
+
+    for (auto &[key, info] : sd.tensors) {
+        bool is_optimizer = key.starts_with("adam.");
+        uint64_t &offset = is_optimizer ? optim_offset : model_offset;
+
+        WriteItem item;
+        item.key = key;
+        item.filename = is_optimizer ? "optimizer.ckpt" : "model.ckpt";
+        item.offset = offset;
+        item.byte_size = TensorByteSize(info.dtype, info.local_shape);
+        item.dtype = info.dtype;
+        item.local_shape = info.local_shape;
+        item.global_offset = info.global_offset;
+        item.axis_fragmentations = info.axis_fragmentations;
+        item.rank = rank;
+
+        items.push_back(std::move(item));
+        offset += items.back().byte_size;
+    }
+
+    return items;
+}
+
+} // namespace infini_train::checkpoint

--- a/infini_train/src/checkpoint/save_planner.cc
+++ b/infini_train/src/checkpoint/save_planner.cc
@@ -36,7 +36,7 @@ BuildOptimizerShardedStateDict(const ShardedStateDict &model_state,
         auto model_it = model_state.tensors.find(parameter_key);
         CHECK(model_it != model_state.tensors.end())
             << "Optimizer state " << key << " has no matching named model parameter. "
-            << "Optimizer resharding requires set_parameter_names().";
+            << "Optimizer resharding requires named parameters.";
         auto info = model_it->second;
         info.key = key;
         info.local_key = key;

--- a/infini_train/src/checkpoint/save_planner.cc
+++ b/infini_train/src/checkpoint/save_planner.cc
@@ -40,6 +40,7 @@ BuildOptimizerShardedStateDict(const ShardedStateDict &model_state,
         auto info = model_it->second;
         info.key = key;
         info.local_key = key;
+        info.dtype = tensor->Dtype();
         result.tensors.emplace(key, std::move(info));
     }
     return result;

--- a/infini_train/src/nn/lora/lora_parallel_linear.cc
+++ b/infini_train/src/nn/lora/lora_parallel_linear.cc
@@ -219,6 +219,32 @@ std::vector<std::shared_ptr<Tensor>> LoRAColumnParallelLinear::LoRAParameters() 
     return {parameters_.at(kParamLoraAName), parameters_.at(kParamLoraBName)};
 }
 
+checkpoint::ShardedStateDict LoRAColumnParallelLinear::ShardedStateDict(const std::string &prefix) const {
+    auto state = parallel::ColumnParallelLinear::ShardedStateDict(prefix);
+    const int tp_size = parallel::global::GetTensorParallelSize();
+
+    const auto &lora_a = parameter(kParamLoraAName);
+    checkpoint::ShardedTensor a;
+    a.key = prefix.empty() ? kParamLoraAName : prefix + "." + kParamLoraAName;
+    a.dtype = lora_a->Dtype();
+    a.global_shape = lora_a->Dims();
+    a.local_shape = lora_a->Dims();
+    a.global_offset = {0, 0};
+    a.axis_fragmentations = {1, 1};
+    state.tensors.emplace(a.key, std::move(a));
+
+    const auto &lora_b = parameter(kParamLoraBName);
+    checkpoint::ShardedTensor b;
+    b.key = prefix.empty() ? kParamLoraBName : prefix + "." + kParamLoraBName;
+    b.dtype = lora_b->Dtype();
+    b.global_shape = {lora_b->Dims()[0] * tp_size, lora_b->Dims()[1]};
+    b.local_shape = lora_b->Dims();
+    b.global_offset = {lora_b->Dims()[0] * parallel::tp_rank, 0};
+    b.axis_fragmentations = {tp_size, 1};
+    state.tensors.emplace(b.key, std::move(b));
+    return state;
+}
+
 bool LoRAColumnParallelLinear::IsMerged() const { return merged_; }
 
 int64_t LoRAColumnParallelLinear::in_features() const { return in_features_; }
@@ -427,6 +453,32 @@ void LoRARowParallelLinear::UnmergeWeights() {
 
 std::vector<std::shared_ptr<Tensor>> LoRARowParallelLinear::LoRAParameters() const {
     return {parameters_.at(kParamLoraAName), parameters_.at(kParamLoraBName)};
+}
+
+checkpoint::ShardedStateDict LoRARowParallelLinear::ShardedStateDict(const std::string &prefix) const {
+    auto state = parallel::RowParallelLinear::ShardedStateDict(prefix);
+    const int tp_size = parallel::global::GetTensorParallelSize();
+
+    const auto &lora_a = parameter(kParamLoraAName);
+    checkpoint::ShardedTensor a;
+    a.key = prefix.empty() ? kParamLoraAName : prefix + "." + kParamLoraAName;
+    a.dtype = lora_a->Dtype();
+    a.global_shape = {lora_a->Dims()[0], lora_a->Dims()[1] * tp_size};
+    a.local_shape = lora_a->Dims();
+    a.global_offset = {0, lora_a->Dims()[1] * parallel::tp_rank};
+    a.axis_fragmentations = {1, tp_size};
+    state.tensors.emplace(a.key, std::move(a));
+
+    const auto &lora_b = parameter(kParamLoraBName);
+    checkpoint::ShardedTensor b;
+    b.key = prefix.empty() ? kParamLoraBName : prefix + "." + kParamLoraBName;
+    b.dtype = lora_b->Dtype();
+    b.global_shape = lora_b->Dims();
+    b.local_shape = lora_b->Dims();
+    b.global_offset = {0, 0};
+    b.axis_fragmentations = {1, 1};
+    state.tensors.emplace(b.key, std::move(b));
+    return state;
 }
 
 bool LoRARowParallelLinear::IsMerged() const { return merged_; }

--- a/infini_train/src/nn/modules/module.cc
+++ b/infini_train/src/nn/modules/module.cc
@@ -178,6 +178,44 @@ std::unordered_map<std::string, std::shared_ptr<Tensor>> Module::StateDict() con
     return state;
 }
 
+checkpoint::ShardedStateDict Module::ShardedStateDict(const std::string &prefix) const {
+    checkpoint::ShardedStateDict sd;
+
+    for (auto &[name, param] : parameters_) {
+        checkpoint::ShardedTensor info;
+        info.key = prefix.empty() ? name : prefix + "." + name;
+        info.dtype = param->Dtype();
+        info.global_shape = param->Dims();
+        info.local_shape = param->Dims();
+        info.global_offset.assign(param->Dims().size(), 0);
+        info.axis_fragmentations.assign(param->Dims().size(), 1);
+        sd.tensors[info.key] = std::move(info);
+    }
+
+    for (auto &[name, buffer] : buffers_) {
+        checkpoint::ShardedTensor info;
+        info.key = prefix.empty() ? name : prefix + "." + name;
+        info.dtype = buffer->Dtype();
+        info.global_shape = buffer->Dims();
+        info.local_shape = buffer->Dims();
+        info.global_offset.assign(buffer->Dims().size(), 0);
+        info.axis_fragmentations.assign(buffer->Dims().size(), 1);
+        sd.tensors[info.key] = std::move(info);
+    }
+
+    for (auto &[name, module] : modules_) {
+        if (name.starts_with("__pp")) {
+            continue;
+        }
+
+        auto child_prefix = prefix.empty() ? name : prefix + "." + name;
+        auto child_sd = module->ShardedStateDict(child_prefix);
+        sd.Merge(std::move(child_sd));
+    }
+
+    return sd;
+}
+
 void Module::LoadStateDict(const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict) {
     // Stage 1: Validate all keys, shapes, and dtypes without copying
     std::vector<std::string> error_msgs;

--- a/infini_train/src/nn/modules/transformer/causal_self_attention.cc
+++ b/infini_train/src/nn/modules/transformer/causal_self_attention.cc
@@ -76,6 +76,40 @@ void CausalSelfAttention::SetupAttention(const TransformerConfig &config) {
     }
 }
 
+checkpoint::ShardedStateDict CausalSelfAttention::ShardedStateDict(const std::string &prefix) const {
+    auto state = Module::ShardedStateDict(prefix);
+    const int tp_size = parallel::global::GetTensorParallelSize();
+    const int rank = parallel::tp_rank;
+    const int64_t q_global = n_head_ * head_dim_;
+    const int64_t kv_global = n_kv_head_ * head_dim_;
+    const int64_t q_local = q_global / tp_size;
+    const int64_t kv_local = kv_global / tp_size;
+
+    const auto c_attn_prefix = prefix.empty() ? kCAttnLayerName : prefix + "." + kCAttnLayerName;
+    auto set_qkv_segments = [&](const std::string &parameter_name) {
+        const auto key = c_attn_prefix + "." + parameter_name;
+        auto it = state.tensors.find(key);
+        if (it == state.tensors.end()) {
+            return;
+        }
+        auto &tensor = it->second;
+        tensor.global_offset.assign(tensor.global_shape.size(), 0);
+        tensor.segments = {
+            {.global_offset = rank * q_local, .local_offset = 0, .length = q_local},
+            {.global_offset = q_global + rank * kv_local, .local_offset = q_local, .length = kv_local},
+            {.global_offset = q_global + kv_global + rank * kv_local,
+             .local_offset = q_local + kv_local,
+             .length = kv_local},
+        };
+    };
+
+    set_qkv_segments(parallel::ColumnParallelLinear::kParamWeightName);
+    if (config_.add_bias_linear) {
+        set_qkv_segments(parallel::ColumnParallelLinear::kParamBiasName);
+    }
+    return state;
+}
+
 std::shared_ptr<infini_train::Tensor> CausalSelfAttention::RepeatKV(const std::shared_ptr<infini_train::Tensor> &x,
                                                                     int64_t n_rep) {
     const auto &shape = x->Dims();

--- a/infini_train/src/nn/modules/transformer/causal_self_attention.cc
+++ b/infini_train/src/nn/modules/transformer/causal_self_attention.cc
@@ -10,6 +10,7 @@
 
 #include "infini_train/include/nn/functional.h"
 #include "infini_train/include/nn/init.h"
+#include "infini_train/include/nn/lora/lora_parallel_linear.h"
 #include "infini_train/include/nn/modules/normalization.h"
 #include "infini_train/include/nn/modules/sparse.h"
 #include "infini_train/include/nn/modules/transformer/transformer_config.h"
@@ -107,6 +108,7 @@ checkpoint::ShardedStateDict CausalSelfAttention::ShardedStateDict(const std::st
     if (config_.add_bias_linear) {
         set_qkv_segments(parallel::ColumnParallelLinear::kParamBiasName);
     }
+    set_qkv_segments(lora::LoRAColumnParallelLinear::kParamLoraBName);
     return state;
 }
 

--- a/infini_train/src/nn/modules/transformer/transformer.cc
+++ b/infini_train/src/nn/modules/transformer/transformer.cc
@@ -329,12 +329,30 @@ checkpoint::ShardedStateDict TransformerModel::ShardedStateDict(const std::strin
 
 std::vector<std::pair<std::string, std::shared_ptr<Tensor>>>
 TransformerModel::NamedParameters(const std::string &prefix, bool recurse, bool remove_duplicate) const {
-    auto parameters = Module::NamedParameters(prefix, recurse, remove_duplicate);
+    if (!recurse) {
+        return Module::NamedParameters(prefix, false, remove_duplicate);
+    }
+
+    // Select public aliases so optimizer state keys match ShardedStateDict keys.
+    auto parameters = Module::NamedParameters(prefix, true, false);
+    const auto sharded_state = ShardedStateDict(prefix);
     const auto global_layers = GlobalLayerIndices(stage_info_);
     std::vector<int> local_layers(global_layers.size());
     std::iota(local_layers.begin(), local_layers.end(), 0);
-    for (auto &[name, parameter] : parameters) { name = RemapLayerKey(name, local_layers, global_layers); }
-    return parameters;
+
+    std::vector<std::pair<std::string, std::shared_ptr<Tensor>>> result;
+    std::unordered_set<const Tensor *> visited;
+    for (auto &[name, parameter] : parameters) {
+        name = RemapLayerKey(name, local_layers, global_layers);
+        if (!sharded_state.tensors.contains(name)) {
+            continue;
+        }
+        if (remove_duplicate && !visited.insert(parameter.get()).second) {
+            continue;
+        }
+        result.emplace_back(std::move(name), std::move(parameter));
+    }
+    return result;
 }
 
 void TransformerModel::LoadStateDict(const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict) {

--- a/infini_train/src/nn/modules/transformer/transformer.cc
+++ b/infini_train/src/nn/modules/transformer/transformer.cc
@@ -272,6 +272,83 @@ TransformerModel::TransformerModel(const TransformerConfig config)
     }
 }
 
+namespace {
+
+std::vector<int> GlobalLayerIndices(const parallel::StageInfo &stage_info) {
+    std::vector<int> indices;
+    for (const auto &[start, end] : stage_info.layer_ranges_per_chunk) {
+        for (int layer = start; layer < end; ++layer) { indices.push_back(layer); }
+    }
+    std::sort(indices.begin(), indices.end());
+    return indices;
+}
+
+std::string RemapLayerKey(const std::string &key, const std::vector<int> &from, const std::vector<int> &to) {
+    const std::string marker
+        = std::string(TransformerModel::kTransformerModelName) + "." + TransformerChunk::kHLayerName + ".";
+    const auto marker_pos = key.find(marker);
+    if (marker_pos == std::string::npos) {
+        return key;
+    }
+    const auto index_start = marker_pos + marker.size();
+    const auto index_end = key.find('.', index_start);
+    if (index_end == std::string::npos) {
+        return key;
+    }
+    int layer = -1;
+    try {
+        layer = std::stoi(key.substr(index_start, index_end - index_start));
+    } catch (...) { return key; }
+    const auto it = std::find(from.begin(), from.end(), layer);
+    if (it == from.end()) {
+        return key;
+    }
+    const auto mapped = to[static_cast<size_t>(std::distance(from.begin(), it))];
+    return key.substr(0, index_start) + std::to_string(mapped) + key.substr(index_end);
+}
+
+} // namespace
+
+checkpoint::ShardedStateDict TransformerModel::ShardedStateDict(const std::string &prefix) const {
+    auto local_state = Module::ShardedStateDict(prefix);
+    const auto global_layers = GlobalLayerIndices(stage_info_);
+    std::vector<int> local_layers(global_layers.size());
+    std::iota(local_layers.begin(), local_layers.end(), 0);
+
+    checkpoint::ShardedStateDict global_state;
+    for (auto &[local_key, tensor] : local_state.tensors) {
+        const auto global_key = RemapLayerKey(local_key, local_layers, global_layers);
+        if (global_key != local_key) {
+            tensor.local_key = local_key;
+            tensor.key = global_key;
+        }
+        global_state.tensors.emplace(global_key, std::move(tensor));
+    }
+    return global_state;
+}
+
+std::vector<std::pair<std::string, std::shared_ptr<Tensor>>>
+TransformerModel::NamedParameters(const std::string &prefix, bool recurse, bool remove_duplicate) const {
+    auto parameters = Module::NamedParameters(prefix, recurse, remove_duplicate);
+    const auto global_layers = GlobalLayerIndices(stage_info_);
+    std::vector<int> local_layers(global_layers.size());
+    std::iota(local_layers.begin(), local_layers.end(), 0);
+    for (auto &[name, parameter] : parameters) { name = RemapLayerKey(name, local_layers, global_layers); }
+    return parameters;
+}
+
+void TransformerModel::LoadStateDict(const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict) {
+    const auto global_layers = GlobalLayerIndices(stage_info_);
+    std::vector<int> local_layers(global_layers.size());
+    std::iota(local_layers.begin(), local_layers.end(), 0);
+
+    std::unordered_map<std::string, std::shared_ptr<Tensor>> local_state;
+    for (const auto &[global_key, tensor] : state_dict) {
+        local_state.emplace(RemapLayerKey(global_key, global_layers, local_layers), tensor);
+    }
+    Module::LoadStateDict(local_state);
+}
+
 std::vector<std::shared_ptr<Tensor>> TransformerModel::Forward(const std::vector<std::shared_ptr<Tensor>> &x) {
     auto x1 = (*modules_[kPPFirstStageName])(x);
     for (int chunk_idx = 0; chunk_idx < stage_info_.layer_ranges_per_chunk.size(); ++chunk_idx) {

--- a/infini_train/src/nn/parallel/ddp/distributed_data_parallel.cc
+++ b/infini_train/src/nn/parallel/ddp/distributed_data_parallel.cc
@@ -203,6 +203,24 @@ void DistributedDataParallel::OnGradReady(const std::shared_ptr<Tensor> &param) 
     }
 }
 
+std::vector<std::pair<std::string, std::shared_ptr<Tensor>>>
+DistributedDataParallel::NamedParameters(const std::string &prefix, bool recurse, bool remove_duplicate) const {
+    return modules_.at(kModuleName)->NamedParameters(prefix, recurse, remove_duplicate);
+}
+
+std::unordered_map<std::string, std::shared_ptr<Tensor>> DistributedDataParallel::StateDict() const {
+    return modules_.at(kModuleName)->StateDict();
+}
+
+checkpoint::ShardedStateDict DistributedDataParallel::ShardedStateDict(const std::string &prefix) const {
+    return modules_.at(kModuleName)->ShardedStateDict(prefix);
+}
+
+void DistributedDataParallel::LoadStateDict(
+    const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict) {
+    modules_.at(kModuleName)->LoadStateDict(state_dict);
+}
+
 std::vector<std::shared_ptr<Tensor>>
 DistributedDataParallel::Forward(const std::vector<std::shared_ptr<Tensor>> &input_tensors) {
     auto outputs = (*modules_[kModuleName])(input_tensors);

--- a/infini_train/src/nn/parallel/pp/pipeline_parallel.cc
+++ b/infini_train/src/nn/parallel/pp/pipeline_parallel.cc
@@ -104,4 +104,21 @@ PipelineParallel::PipelineParallel(const std::shared_ptr<Module> module, int num
 }
 
 std::vector<std::shared_ptr<Module>> *PipelineParallel::mutable_chunks() { return pipeline_stage_->mutable_chunks(); }
+
+std::vector<std::pair<std::string, std::shared_ptr<Tensor>>>
+PipelineParallel::NamedParameters(const std::string &prefix, bool recurse, bool remove_duplicate) const {
+    return modules_.at(kModuleName)->NamedParameters(prefix, recurse, remove_duplicate);
+}
+
+std::unordered_map<std::string, std::shared_ptr<Tensor>> PipelineParallel::StateDict() const {
+    return modules_.at(kModuleName)->StateDict();
+}
+
+checkpoint::ShardedStateDict PipelineParallel::ShardedStateDict(const std::string &prefix) const {
+    return modules_.at(kModuleName)->ShardedStateDict(prefix);
+}
+
+void PipelineParallel::LoadStateDict(const std::unordered_map<std::string, std::shared_ptr<Tensor>> &state_dict) {
+    modules_.at(kModuleName)->LoadStateDict(state_dict);
+}
 } // namespace infini_train::nn::parallel

--- a/infini_train/src/nn/parallel/tensor_parallel.cc
+++ b/infini_train/src/nn/parallel/tensor_parallel.cc
@@ -401,7 +401,8 @@ checkpoint::ShardedStateDict RowParallelLinear::ShardedStateDict(const std::stri
 
 VocabParallelEmbedding::VocabParallelEmbedding(int64_t num_embeddings, int64_t embedding_dim,
                                                bool reduce_scatter_embeddings)
-    : CloneableModule(kType), embedding_dim_(embedding_dim), reduce_scatter_embeddings_(reduce_scatter_embeddings) {
+    : CloneableModule(kType), vocab_size_global_(num_embeddings), embedding_dim_(embedding_dim),
+      reduce_scatter_embeddings_(reduce_scatter_embeddings) {
     auto tp_size = global::GetTensorParallelSize();
     CHECK_GT(tp_size, 0) << "No available devices found for VocabParallelEmbedding";
     CHECK_GT(num_embeddings, 0);

--- a/infini_train/src/nn/parallel/tensor_parallel.cc
+++ b/infini_train/src/nn/parallel/tensor_parallel.cc
@@ -284,6 +284,36 @@ bool ColumnParallelLinear::input_is_parallel() const { return input_is_parallel_
 bool ColumnParallelLinear::skip_bias_add() const { return skip_bias_add_; }
 bool ColumnParallelLinear::sequence_parallel() const { return sequence_parallel_; }
 
+checkpoint::ShardedStateDict ColumnParallelLinear::ShardedStateDict(const std::string &prefix) const {
+    checkpoint::ShardedStateDict sd;
+    int tp_size = global::GetTensorParallelSize();
+
+    auto &weight = parameter(kParamWeightName);
+    checkpoint::ShardedTensor w;
+    w.key = prefix.empty() ? kParamWeightName : prefix + "." + kParamWeightName;
+    w.dtype = weight->Dtype();
+    w.global_shape = {output_size_per_partition_ * tp_size, weight->Dims()[1]};
+    w.local_shape = weight->Dims();
+    w.global_offset = {output_size_per_partition_ * tp_rank, 0};
+    w.axis_fragmentations = {tp_size, 1};
+    sd.tensors[w.key] = std::move(w);
+
+    // Bias is also split along dim=0
+    if (bias_) {
+        auto &bias = parameter(kParamBiasName);
+        checkpoint::ShardedTensor b;
+        b.key = prefix.empty() ? kParamBiasName : prefix + "." + kParamBiasName;
+        b.dtype = bias->Dtype();
+        b.global_shape = {static_cast<int64_t>(output_size_per_partition_ * tp_size)};
+        b.local_shape = bias->Dims();
+        b.global_offset = {output_size_per_partition_ * tp_rank};
+        b.axis_fragmentations = {tp_size};
+        sd.tensors[b.key] = std::move(b);
+    }
+
+    return sd;
+}
+
 RowParallelLinear::RowParallelLinear(int64_t in_features, int64_t out_features, bool bias, bool reduce_output,
                                      bool input_is_parallel, bool skip_bias_add, bool sequence_parallel)
     : CloneableModule(kType), bias_(bias), reduce_output_(reduce_output), input_is_parallel_(input_is_parallel),
@@ -339,6 +369,36 @@ bool RowParallelLinear::input_is_parallel() const { return input_is_parallel_; }
 bool RowParallelLinear::skip_bias_add() const { return skip_bias_add_; }
 bool RowParallelLinear::sequence_parallel() const { return sequence_parallel_; }
 
+checkpoint::ShardedStateDict RowParallelLinear::ShardedStateDict(const std::string &prefix) const {
+    checkpoint::ShardedStateDict sd;
+    int tp_size = global::GetTensorParallelSize();
+
+    auto &weight = parameter(kParamWeightName);
+    checkpoint::ShardedTensor w;
+    w.key = prefix.empty() ? kParamWeightName : prefix + "." + kParamWeightName;
+    w.dtype = weight->Dtype();
+    w.global_shape = {weight->Dims()[0], input_size_per_partition_ * tp_size};
+    w.local_shape = weight->Dims();
+    w.global_offset = {0, input_size_per_partition_ * tp_rank};
+    w.axis_fragmentations = {1, tp_size};
+    sd.tensors[w.key] = std::move(w);
+
+    // Bias is NOT sharded in RowParallelLinear
+    if (bias_) {
+        auto &bias = parameter(kParamBiasName);
+        checkpoint::ShardedTensor b;
+        b.key = prefix.empty() ? kParamBiasName : prefix + "." + kParamBiasName;
+        b.dtype = bias->Dtype();
+        b.global_shape = bias->Dims();
+        b.local_shape = bias->Dims();
+        b.global_offset = {0};
+        b.axis_fragmentations = {1};
+        sd.tensors[b.key] = std::move(b);
+    }
+
+    return sd;
+}
+
 VocabParallelEmbedding::VocabParallelEmbedding(int64_t num_embeddings, int64_t embedding_dim,
                                                bool reduce_scatter_embeddings)
     : CloneableModule(kType), embedding_dim_(embedding_dim), reduce_scatter_embeddings_(reduce_scatter_embeddings) {
@@ -393,6 +453,23 @@ VocabParallelEmbedding::Forward(const std::vector<std::shared_ptr<Tensor>> &inpu
                                              : ReduceFromTPRegionFunc(local_output)[0];
 
     return {output};
+}
+
+checkpoint::ShardedStateDict VocabParallelEmbedding::ShardedStateDict(const std::string &prefix) const {
+    checkpoint::ShardedStateDict sd;
+    int tp_size = global::GetTensorParallelSize();
+
+    auto &weight = parameter(kParamWeightName);
+    checkpoint::ShardedTensor w;
+    w.key = prefix.empty() ? kParamWeightName : prefix + "." + kParamWeightName;
+    w.dtype = weight->Dtype();
+    w.global_shape = {vocab_size_global_, embedding_dim_};
+    w.local_shape = weight->Dims();
+    w.global_offset = {vocab_start_index_, 0};
+    w.axis_fragmentations = {tp_size, 1};
+    sd.tensors[w.key] = std::move(w);
+
+    return sd;
 }
 
 std::vector<std::shared_ptr<Tensor>>
@@ -465,7 +542,7 @@ VocabParallelCrossEntropy::Forward(const std::vector<std::shared_ptr<Tensor>> &i
     auto sum_exp_local = exp_local->Sum(-1);
     auto sum_exp = (tp_size > 1) ? ReduceFromTPRegionFunc(sum_exp_local)[0] : sum_exp_local;
 
-    // 4. Perform Softmax（local shards but normalize globally）
+    // 4. Perform Softmax (local shards but normalize globally).
     auto softmax_local = exp_local->Div(sum_exp->Unsqueeze(-1));
 
     // 5. Perform allreduce to get global predicted_logit
@@ -479,7 +556,7 @@ VocabParallelCrossEntropy::Forward(const std::vector<std::shared_ptr<Tensor>> &i
     auto log_sum_exp = sum_exp->Log();
     auto loss = log_sum_exp->Sub(predicted);
 
-    // 7. Label smoothing（According to Megatron-LM）
+    // 7. Apply label smoothing according to Megatron-LM.
     // TODO(zbl): adjust smoothing coef according to vocab_size_original
     if (label_smoothing_ > 0.0f) {
         // mean_logp over *valid tokens only*:

--- a/scripts/run_models_and_profile.bash
+++ b/scripts/run_models_and_profile.bash
@@ -372,9 +372,10 @@ args_string_for_test() {
 
     jq -r --argjson g "$group_idx" --argjson t "$test_idx" --arg model "$model_name" --arg test_id "$test_id" '
     def namespaced_path($p; $model; $mode):
-        if ($p | test("/checkpoint_step_[0-9]+($|/)")) then
-            ($p | capture("^(?<prefix>.*)/(?<step>checkpoint_step_[0-9]+(?:/.*)?)$")) as $m
-            | ($m.prefix + "/" + $model + "/" + $mode + "/" + $m.step)
+        if ($p | test("/(?:checkpoint_step_|iter_)[0-9]+($|/)")) then
+            ($p | capture("^(?<prefix>.*)/(?:checkpoint_step_|iter_)(?<iteration>[0-9]+)(?<suffix>/.*)?$")) as $m
+            | ("0000000" + $m.iteration)[-7:] as $iteration
+            | ($m.prefix + "/" + $model + "/" + $mode + "/iter_" + $iteration + ($m.suffix // ""))
         else
             ($p + "/" + $model + "/" + $mode)
         end;

--- a/tests/checkpoint/test_checkpoint_serialization.cc
+++ b/tests/checkpoint/test_checkpoint_serialization.cc
@@ -4,6 +4,10 @@
 #include "gtest/gtest.h"
 
 #include "infini_train/include/checkpoint/checkpoint.h"
+#include "infini_train/include/checkpoint/load_planner.h"
+#include "infini_train/include/checkpoint/load_strategy.h"
+#include "infini_train/include/checkpoint/save_planner.h"
+#include "infini_train/include/checkpoint/shard_spec.h"
 #include "infini_train/include/nn/modules/linear.h"
 #include "infini_train/include/nn/modules/module.h"
 #include "infini_train/include/optimizer.h"
@@ -14,7 +18,57 @@
 using namespace infini_train;
 namespace nn = infini_train::nn;
 
+namespace {
+
+class NamedParameterModule final : public nn::Module {
+public:
+    void AddParameter(const std::string &name, const std::shared_ptr<Tensor> &parameter) {
+        parameters_[name] = parameter;
+    }
+
+    void AddModule(const std::string &name, const std::shared_ptr<nn::Module> &module) { modules_[name] = module; }
+};
+
+} // namespace
+
+TEST(ModuleNamedParametersTest, SupportsTorchStyleArgumentsAndSharedParameterDeduplication) {
+    auto root = std::make_shared<NamedParameterModule>();
+    auto child = std::make_shared<NamedParameterModule>();
+    auto shared = std::make_shared<Tensor>(std::vector<int64_t>{1}, DataType::kFLOAT32, Device());
+    auto child_weight = std::make_shared<Tensor>(std::vector<int64_t>{1}, DataType::kFLOAT32, Device());
+    root->AddParameter("root_weight", shared);
+    child->AddParameter("alias", shared);
+    child->AddParameter("weight", child_weight);
+    root->AddModule("child", child);
+
+    const auto local = root->NamedParameters("model", false);
+    ASSERT_EQ(local.size(), 1);
+    EXPECT_EQ(local[0].first, "model.root_weight");
+    EXPECT_EQ(local[0].second, shared);
+
+    const auto deduplicated = root->NamedParameters("model");
+    ASSERT_EQ(deduplicated.size(), 2);
+    EXPECT_EQ(deduplicated[0].first, "model.root_weight");
+    EXPECT_EQ(deduplicated[1].first, "model.child.weight");
+
+    const auto aliases = root->NamedParameters("model", true, false);
+    ASSERT_EQ(aliases.size(), 3);
+    EXPECT_EQ(aliases[0].first, "model.root_weight");
+    EXPECT_EQ(aliases[1].first, "model.child.alias");
+    EXPECT_EQ(aliases[1].second, shared);
+    EXPECT_EQ(aliases[2].first, "model.child.weight");
+}
+
 class CheckpointSerializationTest : public test::InfiniTrainTest {};
+
+TEST(ShardedStateDictTest, RejectsDuplicateKeysWhenMerging) {
+    checkpoint::ShardedStateDict destination;
+    destination.tensors["weight"] = {.key = "weight"};
+    checkpoint::ShardedStateDict source;
+    source.tensors["weight"] = {.key = "weight"};
+
+    EXPECT_DEATH(destination.Merge(std::move(source)), "Duplicate sharded state-dict key: weight");
+}
 
 TEST_P(CheckpointSerializationTest, SaveAndLoadModelFP32) {
     auto dir = std::filesystem::temp_directory_path() / "test_ckpt_fp32";
@@ -52,4 +106,350 @@ TEST_P(CheckpointSerializationTest, SaveAndLoadModelFP32) {
     std::filesystem::remove_all(dir);
 }
 
+TEST_P(CheckpointSerializationTest, DirectMetadataOffsetSupportsColumnSlices) {
+    auto dir = std::filesystem::temp_directory_path() / "test_ckpt_region";
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir);
+    auto matrix = std::make_shared<Tensor>(std::vector<int64_t>{4, 4}, DataType::kFLOAT32, Device());
+    auto *values = static_cast<float *>(matrix->DataPtr());
+    for (int row = 0; row < 4; ++row) {
+        for (int column = 0; column < 4; ++column) { values[row * 4 + column] = row * 10.0f + column; }
+    }
+    auto path = dir / "model.ckpt";
+    Checkpoint::SaveStateDictFile(path, {{"matrix", matrix}});
+    constexpr uint64_t data_offset = sizeof(uint32_t) * 3 + sizeof(uint32_t) + sizeof("matrix") - 1 + sizeof(int8_t)
+                                   + sizeof(uint32_t) + sizeof(int64_t) * 2 + sizeof(uint64_t);
+    checkpoint::LoadPlan plan;
+    plan.tensors["matrix"] = {.key = "matrix",
+                              .dtype = DataType::kFLOAT32,
+                              .global_shape = {4, 4},
+                              .target_shape = {4, 2},
+                              .shard_dim = 1,
+                              .reads = {{.key = "matrix",
+                                         .filename = "model.ckpt",
+                                         .dtype = DataType::kFLOAT32,
+                                         .global_shape = {4, 4},
+                                         .byte_size = sizeof(float) * 16,
+                                         .data_offset = data_offset,
+                                         .shard_dim = 1,
+                                         .source_offset = 1,
+                                         .target_offset = 0,
+                                         .length = 2,
+                                         .source_shape = {4, 4}}}};
+    checkpoint::IndexedRegionLoadStrategy strategy;
+    const auto planned = strategy.Execute(dir, plan);
+    const auto *planned_data = static_cast<const float *>(planned.at("matrix")->DataPtr());
+    for (int row = 0; row < 4; ++row) {
+        for (int column = 0; column < 2; ++column) {
+            EXPECT_FLOAT_EQ(planned_data[row * 2 + column], row * 10.0f + column + 1);
+        }
+    }
+
+    std::filesystem::remove_all(dir);
+}
+
+TEST(CheckpointLoadPlannerTest, PadsVocabularyTailWhenTargetTpUsesPaddedVocab) {
+    const auto dir = std::filesystem::temp_directory_path() / "test_vocab_padding_reshard";
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir);
+
+    auto source = std::make_shared<Tensor>(std::vector<int64_t>{5, 2}, DataType::kFLOAT32, Device());
+    auto *source_data = static_cast<float *>(source->DataPtr());
+    for (int i = 0; i < 10; ++i) { source_data[i] = static_cast<float>(i); }
+    Checkpoint::SaveStateDictFile(dir / "model.ckpt", {{"lm_head.weight", source}});
+    constexpr uint64_t data_offset = sizeof(uint32_t) * 3 + sizeof(uint32_t) + sizeof("lm_head.weight") - 1
+                                   + sizeof(int8_t) + sizeof(uint32_t) + sizeof(int64_t) * 2 + sizeof(uint64_t);
+
+    Checkpoint::CheckpointMetadata metadata;
+    metadata.tensors.push_back({.key = "lm_head.weight",
+                                .dtype_str = "float32",
+                                .global_shape = {5, 2},
+                                .local_shape = {5, 2},
+                                .global_offset = {0, 0},
+                                .axis_fragmentations = {1, 1},
+                                .file = "model.ckpt",
+                                .offset = data_offset,
+                                .byte_size = sizeof(float) * 10});
+
+    checkpoint::ShardedStateDict target;
+    target.tensors["lm_head.weight"] = {.key = "lm_head.weight",
+                                        .dtype = DataType::kFLOAT32,
+                                        .global_shape = {8, 2},
+                                        .local_shape = {4, 2},
+                                        .global_offset = {4, 0},
+                                        .axis_fragmentations = {2, 1}};
+
+    const auto plan = checkpoint::LoadPlanner::PlanReshard(metadata, target);
+    ASSERT_EQ(plan.tensors.at("lm_head.weight").trailing_zero_fill, 3);
+    checkpoint::IndexedRegionLoadStrategy strategy;
+    const auto loaded = strategy.Execute(dir, plan);
+    const auto *values = static_cast<const float *>(loaded.at("lm_head.weight")->DataPtr());
+    EXPECT_FLOAT_EQ(values[0], 8.0f);
+    EXPECT_FLOAT_EQ(values[1], 9.0f);
+    for (int i = 2; i < 8; ++i) { EXPECT_FLOAT_EQ(values[i], 0.0f); }
+
+    std::filesystem::remove_all(dir);
+}
+
+TEST_P(CheckpointSerializationTest, GlobalMetadataRoundTrip) {
+    auto dir = std::filesystem::temp_directory_path() / "test_global_metadata";
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir);
+    Checkpoint::CheckpointMetadata metadata;
+    metadata.version = 3;
+    metadata.iteration = 17;
+    metadata.has_metadata = true;
+    metadata.parallel_config = {.tp_size = 2, .pp_size = 2, .dp_size = 1, .sp_size = 1};
+    metadata.tensors.push_back({.key = "layer.0.weight",
+                                .dtype_str = "float32",
+                                .global_shape = {8, 4},
+                                .local_shape = {4, 4},
+                                .global_offset = {0, 0},
+                                .axis_fragmentations = {2, 1},
+                                .segments = {{.global_offset = 0, .local_offset = 0, .length = 4}},
+                                .file = "rank_000000/model.ckpt",
+                                .byte_size = 64,
+                                .stored_on_ranks = {0},
+                                .pp_rank = 0});
+    Checkpoint::SaveMetadataFile(dir / "metadata.json", metadata);
+
+    auto loaded = Checkpoint::LoadMetadata(dir);
+    ASSERT_TRUE(loaded.has_metadata);
+    EXPECT_EQ(loaded.iteration, 17);
+    EXPECT_EQ(loaded.parallel_config.tp_size, 2);
+    EXPECT_EQ(loaded.parallel_config.pp_size, 2);
+    ASSERT_EQ(loaded.tensors.size(), 1);
+    EXPECT_EQ(loaded.tensors[0].file, "rank_000000/model.ckpt");
+    EXPECT_EQ(loaded.tensors[0].global_offset, std::vector<int64_t>({0, 0}));
+    EXPECT_EQ(loaded.tensors[0].axis_fragmentations, std::vector<int>({2, 1}));
+    ASSERT_EQ(loaded.tensors[0].segments.size(), 1);
+    EXPECT_EQ(loaded.tensors[0].segments[0],
+              (checkpoint::ShardSegment{.global_offset = 0, .local_offset = 0, .length = 4}));
+    std::filesystem::remove_all(dir);
+}
+
 INFINI_TRAIN_REGISTER_TEST(CheckpointSerializationTest);
+
+namespace {
+Checkpoint::CheckpointMetadata::TensorEntry MakeSavedShard(const std::string &key, int count, int index,
+                                                           int64_t global_size, const std::string &file) {
+    return {.key = key,
+            .dtype_str = "float32",
+            .global_shape = {global_size, 4},
+            .local_shape = {global_size / count, 4},
+            .global_offset = {global_size / count * index, 0},
+            .axis_fragmentations = {count, 1},
+            .file = file};
+}
+
+checkpoint::ShardedStateDict MakeTarget(const std::string &key, int count, int index, int64_t global_size) {
+    checkpoint::ShardedStateDict target;
+    target.tensors[key] = {.key = key,
+                           .dtype = DataType::kFLOAT32,
+                           .global_shape = {global_size, 4},
+                           .local_shape = {global_size / count, 4},
+                           .global_offset = {global_size / count * index, 0},
+                           .axis_fragmentations = {count, 1}};
+    return target;
+}
+} // namespace
+
+TEST(CheckpointOptimizerShardingTest, AdamMomentsReuseModelShardMetadata) {
+    checkpoint::ShardedStateDict model;
+    model.tensors["c_attn.weight"] = {
+        .key = "c_attn.weight",
+        .dtype = DataType::kFLOAT32,
+        .global_shape = {24, 4},
+        .local_shape = {6, 4},
+        .global_offset = {0, 0},
+        .axis_fragmentations = {4, 1},
+        .segments = {
+            {.global_offset = 0, .local_offset = 0, .length = 4},
+            {.global_offset = 16, .local_offset = 4, .length = 1},
+            {.global_offset = 20, .local_offset = 5, .length = 1},
+        },
+    };
+
+    auto moment = std::make_shared<Tensor>(std::vector<int64_t>{6, 4}, DataType::kFLOAT32, Device());
+    auto step = std::make_shared<Tensor>(std::vector<int64_t>{}, DataType::kINT64, Device());
+    std::unordered_map<std::string, std::shared_ptr<Tensor>> optimizer_state = {
+        {"adam.m.c_attn.weight", moment},
+        {"adam.v.c_attn.weight", moment},
+        {"adam.t", step},
+    };
+
+    const auto optimizer = checkpoint::BuildOptimizerShardedStateDict(model, optimizer_state);
+    ASSERT_EQ(optimizer.tensors.size(), 3);
+    const auto &m = optimizer.tensors.at("adam.m.c_attn.weight");
+    EXPECT_EQ(m.global_shape, model.tensors.at("c_attn.weight").global_shape);
+    EXPECT_EQ(m.local_shape, model.tensors.at("c_attn.weight").local_shape);
+    EXPECT_EQ(m.segments, model.tensors.at("c_attn.weight").segments);
+    EXPECT_EQ(m.local_key, "adam.m.c_attn.weight");
+    const auto &t = optimizer.tensors.at("adam.t");
+    EXPECT_TRUE(t.global_shape.empty());
+    EXPECT_TRUE(t.local_shape.empty());
+}
+
+TEST(CheckpointLoadPlannerTest, RejectsUnknownCheckpointDtype) {
+    auto metadata = Checkpoint::CheckpointMetadata{};
+    metadata.tensors = {MakeSavedShard("weight", 1, 0, 16, "rank_0/model.ckpt")};
+    metadata.tensors.front().dtype_str = "unknown_dtype";
+
+    EXPECT_DEATH(checkpoint::LoadPlanner::PlanReshard(metadata, MakeTarget("weight", 1, 0, 16)),
+                 "Unsupported checkpoint tensor dtype: unknown_dtype");
+}
+
+TEST(CheckpointLoadPlannerTest, TensorParallelTwoToFourReadsOnlyOverlap) {
+    Checkpoint::CheckpointMetadata metadata;
+    metadata.tensors = {MakeSavedShard("weight", 2, 0, 16, "rank_0/model.ckpt"),
+                        MakeSavedShard("weight", 2, 1, 16, "rank_1/model.ckpt")};
+
+    auto plan = checkpoint::LoadPlanner::PlanReshard(metadata, MakeTarget("weight", 4, 1, 16));
+    const auto &reads = plan.tensors.at("weight").reads;
+    ASSERT_EQ(reads.size(), 1);
+    EXPECT_EQ(reads[0].filename, "rank_0/model.ckpt");
+    EXPECT_EQ(reads[0].source_offset, 4);
+    EXPECT_EQ(reads[0].target_offset, 0);
+    EXPECT_EQ(reads[0].length, 4);
+}
+
+TEST(CheckpointLoadPlannerTest, TensorParallelFourToTwoReadsTwoOverlaps) {
+    Checkpoint::CheckpointMetadata metadata;
+    for (int index = 0; index < 4; ++index) {
+        metadata.tensors.push_back(
+            MakeSavedShard("weight", 4, index, 16, "rank_" + std::to_string(index) + "/model.ckpt"));
+    }
+
+    auto plan = checkpoint::LoadPlanner::PlanReshard(metadata, MakeTarget("weight", 2, 1, 16));
+    const auto &reads = plan.tensors.at("weight").reads;
+    ASSERT_EQ(reads.size(), 2);
+    EXPECT_EQ(reads[0].filename, "rank_2/model.ckpt");
+    EXPECT_EQ(reads[0].target_offset, 0);
+    EXPECT_EQ(reads[1].filename, "rank_3/model.ckpt");
+    EXPECT_EQ(reads[1].target_offset, 4);
+}
+
+TEST(CheckpointLoadPlannerTest, UsesExplicitGlobalOffsetsForUnevenShards) {
+    Checkpoint::CheckpointMetadata metadata;
+    metadata.tensors = {{.key = "weight",
+                         .dtype_str = "float32",
+                         .global_shape = {8, 4},
+                         .local_shape = {3, 4},
+                         .global_offset = {0, 0},
+                         .axis_fragmentations = {2, 1},
+                         .file = "rank_0/model.ckpt"},
+                        {.key = "weight",
+                         .dtype_str = "float32",
+                         .global_shape = {8, 4},
+                         .local_shape = {5, 4},
+                         .global_offset = {3, 0},
+                         .axis_fragmentations = {2, 1},
+                         .file = "rank_1/model.ckpt"}};
+    checkpoint::ShardedStateDict target;
+    target.tensors["weight"] = {.key = "weight",
+                                .dtype = DataType::kFLOAT32,
+                                .global_shape = {8, 4},
+                                .local_shape = {4, 4},
+                                .global_offset = {2, 0},
+                                .axis_fragmentations = {2, 1}};
+
+    auto plan = checkpoint::LoadPlanner::PlanReshard(metadata, target);
+    const auto &reads = plan.tensors.at("weight").reads;
+    ASSERT_EQ(reads.size(), 2);
+    EXPECT_EQ(reads[0].source_offset, 2);
+    EXPECT_EQ(reads[0].target_offset, 0);
+    EXPECT_EQ(reads[0].length, 1);
+    EXPECT_EQ(reads[1].source_offset, 0);
+    EXPECT_EQ(reads[1].target_offset, 1);
+    EXPECT_EQ(reads[1].length, 3);
+}
+
+TEST(CheckpointLoadPlannerTest, QkvSegmentsUseDimZeroWhenTpIsOne) {
+    Checkpoint::CheckpointMetadata metadata;
+    auto saved = MakeSavedShard("c_attn.weight", 1, 0, 12, "old_pp/model.ckpt");
+    saved.local_shape = {12, 4};
+    saved.axis_fragmentations = {1, 1};
+    saved.segments = {
+        {.global_offset = 0, .local_offset = 0, .length = 8},
+        {.global_offset = 8, .local_offset = 8, .length = 2},
+        {.global_offset = 10, .local_offset = 10, .length = 2},
+    };
+    metadata.tensors.push_back(std::move(saved));
+
+    checkpoint::ShardedStateDict target;
+    target.tensors["c_attn.weight"] = {
+        .key = "c_attn.weight",
+        .dtype = DataType::kFLOAT32,
+        .global_shape = {12, 4},
+        .local_shape = {12, 4},
+        .global_offset = {0, 0},
+        .axis_fragmentations = {1, 1},
+        .segments = {
+            {.global_offset = 0, .local_offset = 0, .length = 8},
+            {.global_offset = 8, .local_offset = 8, .length = 2},
+            {.global_offset = 10, .local_offset = 10, .length = 2},
+        },
+    };
+
+    const auto plan = checkpoint::LoadPlanner::PlanReshard(metadata, target);
+    const auto &tensor_plan = plan.tensors.at("c_attn.weight");
+    EXPECT_EQ(tensor_plan.shard_dim, 0);
+    ASSERT_EQ(tensor_plan.reads.size(), 3);
+    EXPECT_EQ(tensor_plan.reads[0].target_offset, 0);
+    EXPECT_EQ(tensor_plan.reads[1].target_offset, 8);
+    EXPECT_EQ(tensor_plan.reads[2].target_offset, 10);
+}
+
+TEST(CheckpointLoadPlannerTest, QkvSegmentsPreserveTargetLocalLayoutAcrossTpChange) {
+    Checkpoint::CheckpointMetadata metadata;
+    for (int rank = 0; rank < 4; ++rank) {
+        auto shard = MakeSavedShard("c_attn.weight", 4, rank, 24, "rank_" + std::to_string(rank) + "/model.ckpt");
+        shard.local_shape = {6, 4};
+        shard.global_offset = {0, 0};
+        shard.segments = {
+            {.global_offset = rank * 4, .local_offset = 0, .length = 4},
+            {.global_offset = 16 + rank, .local_offset = 4, .length = 1},
+            {.global_offset = 20 + rank, .local_offset = 5, .length = 1},
+        };
+        metadata.tensors.push_back(std::move(shard));
+    }
+
+    checkpoint::ShardedStateDict target;
+    target.tensors["c_attn.weight"] = {
+        .key = "c_attn.weight",
+        .dtype = DataType::kFLOAT32,
+        .global_shape = {24, 4},
+        .local_shape = {12, 4},
+        .global_offset = {0, 0},
+        .axis_fragmentations = {2, 1},
+        .segments = {
+            {.global_offset = 0, .local_offset = 0, .length = 8},
+            {.global_offset = 16, .local_offset = 8, .length = 2},
+            {.global_offset = 20, .local_offset = 10, .length = 2},
+        },
+    };
+
+    const auto plan = checkpoint::LoadPlanner::PlanReshard(metadata, target);
+    const auto &reads = plan.tensors.at("c_attn.weight").reads;
+    ASSERT_EQ(reads.size(), 6);
+    const std::vector<std::string> files = {"rank_0/model.ckpt", "rank_1/model.ckpt", "rank_0/model.ckpt",
+                                            "rank_1/model.ckpt", "rank_0/model.ckpt", "rank_1/model.ckpt"};
+    const std::vector<int64_t> source_offsets = {0, 0, 4, 4, 5, 5};
+    const std::vector<int64_t> target_offsets = {0, 4, 8, 9, 10, 11};
+    for (size_t i = 0; i < reads.size(); ++i) {
+        EXPECT_EQ(reads[i].filename, files[i]);
+        EXPECT_EQ(reads[i].source_offset, source_offsets[i]);
+        EXPECT_EQ(reads[i].target_offset, target_offsets[i]);
+    }
+}
+
+TEST(CheckpointLoadPlannerTest, PipelineReshardPlansOnlyTargetStageKeys) {
+    Checkpoint::CheckpointMetadata metadata;
+    metadata.tensors = {MakeSavedShard("layer.0.weight", 1, 0, 8, "old_pp0/model.ckpt"),
+                        MakeSavedShard("layer.1.weight", 1, 0, 8, "old_pp1/model.ckpt")};
+
+    auto plan = checkpoint::LoadPlanner::PlanReshard(metadata, MakeTarget("layer.1.weight", 1, 0, 8));
+    ASSERT_EQ(plan.tensors.size(), 1);
+    ASSERT_EQ(plan.tensors.at("layer.1.weight").reads.size(), 1);
+    EXPECT_EQ(plan.tensors.at("layer.1.weight").reads[0].filename, "old_pp1/model.ckpt");
+}

--- a/tests/checkpoint/test_checkpoint_serialization.cc
+++ b/tests/checkpoint/test_checkpoint_serialization.cc
@@ -148,6 +148,45 @@ TEST_P(CheckpointSerializationTest, DirectMetadataOffsetSupportsColumnSlices) {
     std::filesystem::remove_all(dir);
 }
 
+TEST_P(CheckpointSerializationTest, ConvertsSavedBF16TensorToFP32Target) {
+    auto dir = std::filesystem::temp_directory_path() / "test_ckpt_bf16_to_fp32";
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir);
+
+    auto source_fp32 = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, Device());
+    auto *source_data = static_cast<float *>(source_fp32->DataPtr());
+    source_data[0] = 1.0f;
+    source_data[1] = 2.0f;
+    source_data[2] = 3.0f;
+    source_data[3] = 4.0f;
+    auto source_bf16 = std::make_shared<Tensor>(source_fp32->To(DataType::kBFLOAT16));
+    Checkpoint::SaveStateDictFile(dir / "model.ckpt", {{"weight", source_bf16}});
+    constexpr uint64_t data_offset = sizeof(uint32_t) * 3 + sizeof(uint32_t) + sizeof("weight") - 1
+                                   + sizeof(int8_t) + sizeof(uint32_t) + sizeof(int64_t) * 2 + sizeof(uint64_t);
+
+    checkpoint::LoadPlan plan;
+    plan.tensors["weight"] = {.key = "weight",
+                               .dtype = DataType::kFLOAT32,
+                               .global_shape = {2, 2},
+                               .target_shape = {2, 2},
+                               .reads = {{.key = "weight",
+                                          .filename = "model.ckpt",
+                                          .dtype = DataType::kBFLOAT16,
+                                          .global_shape = {2, 2},
+                                          .byte_size = source_bf16->SizeInBytes(),
+                                          .data_offset = data_offset,
+                                          .shard_dim = -1,
+                                          .source_shape = {2, 2}}}};
+
+    checkpoint::IndexedRegionLoadStrategy strategy;
+    const auto loaded = strategy.Execute(dir, plan).at("weight");
+    ASSERT_EQ(loaded->Dtype(), DataType::kFLOAT32);
+    const auto *loaded_data = static_cast<const float *>(loaded->DataPtr());
+    for (int i = 0; i < 4; ++i) { EXPECT_FLOAT_EQ(loaded_data[i], source_data[i]); }
+
+    std::filesystem::remove_all(dir);
+}
+
 TEST(CheckpointLoadPlannerTest, PadsVocabularyTailWhenTargetTpUsesPaddedVocab) {
     const auto dir = std::filesystem::temp_directory_path() / "test_vocab_padding_reshard";
     std::filesystem::remove_all(dir);
@@ -199,7 +238,7 @@ TEST_P(CheckpointSerializationTest, GlobalMetadataRoundTrip) {
     metadata.version = 3;
     metadata.iteration = 17;
     metadata.has_metadata = true;
-    metadata.parallel_config = {.tp_size = 2, .pp_size = 2, .dp_size = 1, .sp_size = 1};
+    metadata.parallel_config = {.tp_size = 2, .pp_size = 2, .dp_size = 1, .sp_size = 1, .vpp_size = 2};
     metadata.tensors.push_back({.key = "layer.0.weight",
                                 .dtype_str = "float32",
                                 .global_shape = {8, 4},
@@ -218,6 +257,7 @@ TEST_P(CheckpointSerializationTest, GlobalMetadataRoundTrip) {
     EXPECT_EQ(loaded.iteration, 17);
     EXPECT_EQ(loaded.parallel_config.tp_size, 2);
     EXPECT_EQ(loaded.parallel_config.pp_size, 2);
+    EXPECT_EQ(loaded.parallel_config.vpp_size, 2);
     ASSERT_EQ(loaded.tensors.size(), 1);
     EXPECT_EQ(loaded.tensors[0].file, "rank_000000/model.ckpt");
     EXPECT_EQ(loaded.tensors[0].global_offset, std::vector<int64_t>({0, 0}));
@@ -285,9 +325,26 @@ TEST(CheckpointOptimizerShardingTest, AdamMomentsReuseModelShardMetadata) {
     EXPECT_EQ(m.local_shape, model.tensors.at("c_attn.weight").local_shape);
     EXPECT_EQ(m.segments, model.tensors.at("c_attn.weight").segments);
     EXPECT_EQ(m.local_key, "adam.m.c_attn.weight");
+    EXPECT_EQ(m.dtype, moment->Dtype());
     const auto &t = optimizer.tensors.at("adam.t");
     EXPECT_TRUE(t.global_shape.empty());
     EXPECT_TRUE(t.local_shape.empty());
+}
+
+TEST(CheckpointOptimizerShardingTest, AdamMomentUsesOptimizerStateDtype) {
+    checkpoint::ShardedStateDict model;
+    model.tensors["weight"] = {.key = "weight",
+                               .dtype = DataType::kBFLOAT16,
+                               .global_shape = {4, 4},
+                               .local_shape = {4, 4},
+                               .global_offset = {0, 0},
+                               .axis_fragmentations = {1, 1}};
+    auto moment = std::make_shared<Tensor>(std::vector<int64_t>{4, 4}, DataType::kFLOAT32, Device());
+
+    const auto optimizer
+        = checkpoint::BuildOptimizerShardedStateDict(model, {{"adam.m.weight", moment}, {"adam.v.weight", moment}});
+    EXPECT_EQ(optimizer.tensors.at("adam.m.weight").dtype, DataType::kFLOAT32);
+    EXPECT_EQ(optimizer.tensors.at("adam.v.weight").dtype, DataType::kFLOAT32);
 }
 
 TEST(CheckpointLoadPlannerTest, RejectsUnknownCheckpointDtype) {

--- a/tests/checkpoint/test_optimizer_state.cc
+++ b/tests/checkpoint/test_optimizer_state.cc
@@ -81,8 +81,8 @@ TEST_P(OptimizerStateTest, AdamStateDictRoundTrip) {
 TEST_P(OptimizerStateTest, AdamStateDictUsesStableParameterNames) {
     auto first = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice());
     auto second = std::make_shared<Tensor>(std::vector<int64_t>{3}, DataType::kFLOAT32, GetDevice());
-    auto adam = std::make_shared<optimizers::Adam>(std::vector<std::shared_ptr<Tensor>>{first, second}, 0.001);
-    adam->set_parameter_names({"transformer.h.0.weight", "transformer.h.0.bias"});
+    const NamedParameterList named_parameters{{"transformer.h.0.weight", first}, {"transformer.h.0.bias", second}};
+    auto adam = std::make_shared<optimizers::Adam>(named_parameters, 0.001);
 
     const auto state = adam->StateDict();
     EXPECT_TRUE(state.contains("adam.m.transformer.h.0.weight"));
@@ -91,8 +91,7 @@ TEST_P(OptimizerStateTest, AdamStateDictUsesStableParameterNames) {
     EXPECT_TRUE(state.contains("adam.v.transformer.h.0.bias"));
     EXPECT_TRUE(state.contains("adam.t"));
 
-    auto restored = std::make_shared<optimizers::Adam>(std::vector<std::shared_ptr<Tensor>>{first, second}, 0.001);
-    restored->set_parameter_names({"transformer.h.0.weight", "transformer.h.0.bias"});
+    auto restored = std::make_shared<optimizers::Adam>(named_parameters, 0.001);
     restored->LoadStateDict(state);
     EXPECT_EQ(restored->StateDict().size(), state.size());
 }

--- a/tests/checkpoint/test_optimizer_state.cc
+++ b/tests/checkpoint/test_optimizer_state.cc
@@ -78,6 +78,25 @@ TEST_P(OptimizerStateTest, AdamStateDictRoundTrip) {
     }
 }
 
+TEST_P(OptimizerStateTest, AdamStateDictUsesStableParameterNames) {
+    auto first = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice());
+    auto second = std::make_shared<Tensor>(std::vector<int64_t>{3}, DataType::kFLOAT32, GetDevice());
+    auto adam = std::make_shared<optimizers::Adam>(std::vector<std::shared_ptr<Tensor>>{first, second}, 0.001);
+    adam->set_parameter_names({"transformer.h.0.weight", "transformer.h.0.bias"});
+
+    const auto state = adam->StateDict();
+    EXPECT_TRUE(state.contains("adam.m.transformer.h.0.weight"));
+    EXPECT_TRUE(state.contains("adam.v.transformer.h.0.weight"));
+    EXPECT_TRUE(state.contains("adam.m.transformer.h.0.bias"));
+    EXPECT_TRUE(state.contains("adam.v.transformer.h.0.bias"));
+    EXPECT_TRUE(state.contains("adam.t"));
+
+    auto restored = std::make_shared<optimizers::Adam>(std::vector<std::shared_ptr<Tensor>>{first, second}, 0.001);
+    restored->set_parameter_names({"transformer.h.0.weight", "transformer.h.0.bias"});
+    restored->LoadStateDict(state);
+    EXPECT_EQ(restored->StateDict().size(), state.size());
+}
+
 // ---------- SGD ----------
 TEST_P(OptimizerStateTest, SGDStateDictEmpty) {
     auto param = std::make_shared<Tensor>(std::vector<int64_t>{2, 2}, DataType::kFLOAT32, GetDevice());

--- a/tests/checkpoint/test_trainer_state.cc
+++ b/tests/checkpoint/test_trainer_state.cc
@@ -31,6 +31,7 @@ TEST_P(TrainerStateTest, DefaultValues) {
     EXPECT_EQ(state.tp_size, 1);
     EXPECT_EQ(state.sp_size, 1);
     EXPECT_EQ(state.pp_size, 1);
+    EXPECT_EQ(state.vpp_size, 1);
 }
 
 TEST_P(TrainerStateTest, TrainerStateFileCreated) {
@@ -73,6 +74,7 @@ TEST_P(TrainerStateTest, RoundTrip) {
         .tp_size = 1,
         .sp_size = 1,
         .pp_size = 2,
+        .vpp_size = 4,
     };
 
     auto model1 = std::make_shared<nn::Linear>(1, 3, true, GetDevice());
@@ -101,6 +103,7 @@ TEST_P(TrainerStateTest, RoundTrip) {
     EXPECT_EQ(loaded.vocab_size, 128256);
     EXPECT_EQ(loaded.ddp_size, 2);
     EXPECT_EQ(loaded.pp_size, 2);
+    EXPECT_EQ(loaded.vpp_size, 4);
 
     std::filesystem::remove_all(dir);
 }

--- a/tests/lora/test_lora.cc
+++ b/tests/lora/test_lora.cc
@@ -7,11 +7,13 @@
 
 #include "infini_train/include/nn/lora/lora_config.h"
 #include "infini_train/include/nn/lora/lora_linear.h"
+#include "infini_train/include/nn/lora/lora_parallel_linear.h"
 #include "infini_train/include/nn/lora/lora_utils.h"
 #include "infini_train/include/nn/modules/container.h"
 #include "infini_train/include/nn/modules/linear.h"
 #include "infini_train/include/nn/modules/module.h"
 #include "infini_train/include/nn/parallel/global.h"
+#include "infini_train/include/nn/parallel/tensor_parallel.h"
 #include "infini_train/include/tensor.h"
 
 #include "tests/common/test_utils.h"
@@ -76,6 +78,33 @@ TEST_P(LoRATest, LoRAConfigScaling) {
 
     float expected_scaling = 16.0f / 8.0f;
     EXPECT_EQ(config.Scaling(), expected_scaling);
+}
+
+TEST_P(LoRATest, ParallelLoRAShardedStateDictIncludesAdapterParameters) {
+    LoRAConfig config;
+    config.rank = 2;
+
+    auto column_base = std::make_shared<nn::parallel::ColumnParallelLinear>(
+        4, 6, /*bias=*/false, /*gather_output=*/false, /*input_is_parallel=*/false, /*skip_bias_add=*/false,
+        /*sequence_parallel=*/false);
+    auto column = std::make_shared<LoRAColumnParallelLinear>(column_base, config, 4, 6);
+    const auto column_state = column->ShardedStateDict("column");
+    ASSERT_TRUE(column_state.tensors.contains("column.lora_A"));
+    ASSERT_TRUE(column_state.tensors.contains("column.lora_B"));
+    EXPECT_EQ(column_state.tensors.at("column.lora_A").axis_fragmentations, (std::vector<int>{1, 1}));
+    EXPECT_EQ(column_state.tensors.at("column.lora_B").axis_fragmentations,
+              (std::vector<int>{nn::parallel::global::GetTensorParallelSize(), 1}));
+
+    auto row_base = std::make_shared<nn::parallel::RowParallelLinear>(
+        4, 6, /*bias=*/false, /*reduce_output=*/true, /*input_is_parallel=*/true, /*skip_bias_add=*/false,
+        /*sequence_parallel=*/false);
+    auto row = std::make_shared<LoRARowParallelLinear>(row_base, config, 4, 6);
+    const auto row_state = row->ShardedStateDict("row");
+    ASSERT_TRUE(row_state.tensors.contains("row.lora_A"));
+    ASSERT_TRUE(row_state.tensors.contains("row.lora_B"));
+    EXPECT_EQ(row_state.tensors.at("row.lora_A").axis_fragmentations,
+              (std::vector<int>{1, nn::parallel::global::GetTensorParallelSize()}));
+    EXPECT_EQ(row_state.tensors.at("row.lora_B").axis_fragmentations, (std::vector<int>{1, 1}));
 }
 
 TEST_P(LoRATest, PackedQKVShardGPTStyle) {

--- a/tests/transformer/test_transformer_architecture.cc
+++ b/tests/transformer/test_transformer_architecture.cc
@@ -159,6 +159,10 @@ TEST_P(TransformerModuleTest, LLaMA3Model) {
     auto model = std::make_shared<nn::TransformerModel>(config);
     model->To(GetDevice());
     EXPECT_FALSE(model->Parameters().empty());
+    const auto sharded_state = model->ShardedStateDict();
+    for (const auto &[name, parameter] : model->NamedParameters()) {
+        EXPECT_TRUE(sharded_state.tensors.contains(name)) << "Missing shard metadata for named parameter: " << name;
+    }
 }
 
 TEST_P(TransformerModuleTest, RoPEUtils) {


### PR DESCRIPTION
## 背景

现有 distributed checkpoint 与保存时的 TP/PP 拓扑绑定，恢复训练时要求使用相同的并行配置。本 PR 引入基于全局张量坐标的 checkpoint resharding，使 checkpoint 可以在不同 TP/PP 配置之间恢复。

设计文档：[Checkpoint Resharding 设计](https://gxtctab8no8.feishu.cn/wiki/MyixwhPSmiGznnkWgPKcuqKonag?from=from_copylink)

## 主要修改

- 新增 `ShardedTensor` / `ShardedStateDict`，描述张量的全局形状、本地分片、全局偏移和切分方式。
- 新增 `SavePlanner`，统一规划模型参数和 Adam optimizer state 的本地写入布局，并生成可用于 reshard 的全局 metadata。
- 新增 `LoadPlanner`，根据源 checkpoint 与当前目标拓扑的分片坐标计算重叠区间。
- 新增 `IndexedRegionLoadStrategy`，按 metadata 中的文件和 offset 直接读取所需区域，在加载阶段完成重组，无需预先生成中间 checkpoint。
- 支持 TP 扩大、缩小以及 PP stage 变化；支持 QKV 非连续分段布局、词表尾部 padding 和保存/目标 dtype 转换。
- 模型与 Adam `m/v` 共用参数分片信息，训练状态和 LR scheduler 状态随 checkpoint 一并恢复。
- 保存阶段仅由 `dp_rank=0` 的 TP/PP ranks 写入 shard，并在所有 rank metadata 就绪后原子发布全局 metadata。

## 当前限制

- 仅支持 checkpoint version 3。
- 每个张量目前只支持一个 fragmented axis；QKV 等非连续布局通过 `segments` 表达。
- 暂不支持 `DistributedOptimizer` / ZeRO optimizer state 的保存和恢复。
- optimizer resharding 依赖稳定的 named parameters。

## 测试

- TP 2 -> 4、TP 4 -> 2 的 overlap planning。
- 非均匀 shard 的显式 global offset。
- QKV segmented layout 在 TP 变化后的重组。
- PP stage 变化时只加载目标 stage 所需参数。
- vocabulary padding、BF16 -> FP32 dtype 转换。
- model/optimizer state metadata 和 checkpoint serialization round trip。
