### PR TITLE
feat(scripts): add asset preparation for example training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ build/
 *.log
 *.report.rank*
 *.records.log.rank*
+
+__pycache__/
+/data/

--- a/README.md
+++ b/README.md
@@ -97,52 +97,158 @@ For example, the `llama3` example produces a binary named `llama3`.
 To view available runtime options:
 
 ```bash
-./llama3 --help
+./build/llama3 --help
 ```
 
 ### Getting Started
 
-The following examples demonstrate **LLaMA 3 supervised fine-tuning (SFT)** using InfiniTrain.
+#### Prepare Datasets and Weights
 
-#### Single-node Training Example
+Run the asset preparation script from the repository root. Prepared files are
+written to `data/` by default.
 
 ```bash
-./llama3 \
-  --device cuda \
-  --input_bin [training_data_path] \
-  --llmc_filepath [model_path] \
-  --num_iteration 10
+# MNIST dataset
+./scripts/assets/prepare-infinitrain-assets.sh mnist
 
+# GPT-2 124M weights, tokenizer, and tokenized TinyShakespeare data
+./scripts/assets/prepare-infinitrain-assets.sh gpt2
+
+# LLaMA 3.2 1B weights and tokenized TinyShakespeare data
+HF_TOKEN=hf_xxx ./scripts/assets/prepare-infinitrain-assets.sh llama3
 ```
 
-#### Multi-nodes Training Example (3D parallel)
+Preparing LLaMA requires access to the gated
+`meta-llama/Llama-3.2-1B` repository. Accept its license on Hugging Face and
+provide `HF_TOKEN`, or authenticate with `hf auth login`, before running the
+command. The complete LLaMA preparation requires approximately 8.5 GB of free
+disk space, including the downloaded checkpoint and converted FP32 weights.
+
+Use `DATA_DIR` to write the assets elsewhere, or prepare all supported assets
+in one invocation:
 
 ```bash
-./infini_run \
+DATA_DIR=/path/to/data \
+HF_TOKEN=hf_xxx \
+./scripts/assets/prepare-infinitrain-assets.sh all
+```
+
+#### Model Examples
+
+The generated files can be passed directly to the corresponding executables:
+
+##### MNIST
+
+```bash
+./build/mnist \
+  --device cpu \
+  --dataset data/mnist
+```
+
+##### GPT-2 124M
+
+```bash
+./build/gpt2 \
+  --device cuda \
+  --input_bin data/gpt2/tiny_shakespeare_train.bin \
+  --input_val_bin data/gpt2/tiny_shakespeare_val.bin \
+  --tokenizer_bin data/gpt2/gpt2_tokenizer.bin \
+  --llmc_filepath data/gpt2/gpt2_124M.bin \
+  --num_iteration 10
+```
+
+##### LLaMA 3.2 1B
+
+```bash
+./build/llama3 \
+  --device cuda \
+  --input_bin data/llama3/tiny_shakespeare_train.bin \
+  --input_val_bin data/llama3/tiny_shakespeare_val.bin \
+  --llmc_filepath data/llama3/llama3.2_1B_fp32.bin \
+  --num_iteration 10
+```
+
+### Launch Modes
+
+GPT-2 and LLaMA training support both thread-based and process-based launches.
+The examples below use LLaMA, but the same launch modes also apply to GPT-2.
+
+#### Direct Launch
+
+Running a model executable directly uses one process and one device by default.
+Set `--nthread_per_process` to use multiple execution threads and devices in the
+same process:
+
+```bash
+./build/llama3 \
+  --device cuda \
+  --input_bin data/llama3/tiny_shakespeare_train.bin \
+  --llmc_filepath data/llama3/llama3.2_1B_fp32.bin \
+  --nthread_per_process 8 \
+  --num_iteration 10
+```
+
+#### Single-node Multi-process Launch
+
+Use `infini_run` to start multiple training processes on one node. Each process
+uses one execution thread by default:
+
+```bash
+./build/infini_run \
+  --nnodes=1 \
+  --nproc_per_node=8 \
+  ./build/llama3 \
+    --device cuda \
+    --input_bin data/llama3/tiny_shakespeare_train.bin \
+    --llmc_filepath data/llama3/llama3.2_1B_fp32.bin \
+    --num_iteration 10
+```
+
+#### Multi-node Multi-process Launch
+
+Run the following command on every node with the same rendezvous settings and
+a distinct `node_rank`:
+
+```bash
+./build/infini_run \
   --nnodes=2 \
-  --nproc_per_node=1 \
+  --nproc_per_node=4 \
   --node_rank=[rank_id] \
   --rdzv_endpoint=[master_addr]:29500 \
   --rdzv_id=[job_id] \
-  ./llama3 \
-     --device cuda \
-     --input_bin [training_data_path] \
-     --llmc_filepath [model_path] \
-     --num_iteration 10 \
-     --nthread_per_process 8 \
-     --batch_size 40 \
-     --total_batch_size 10240 \
-     --tensor_parallel 2 \
-     --pipeline_parallel 2 \
-     --sequence_parallel
+  ./build/llama3 \
+    --device cuda \
+    --input_bin data/llama3/tiny_shakespeare_train.bin \
+    --llmc_filepath data/llama3/llama3.2_1B_fp32.bin \
+    --num_iteration 10 \
+    --tensor_parallel 2 \
+    --pipeline_parallel 2 \
+    --sequence_parallel
+```
+
+`--nproc_per_node` and `--nthread_per_process` can be combined. The total
+training world size is:
+
+```text
+world_size = nnodes × nproc_per_node × nthread_per_process
 ```
 
 ### Parallelism Strategies
 
 #### Distributed Data Parallelism (DDP)
 
+For a direct launch with TP and PP disabled, the following starts eight
+data-parallel workers in one process:
+
 ```bash
---nthread_per_process 8 	# ddp_size = nthread_per_process / (tensor_parallel × pipeline_parallel)
+--nthread_per_process 8  # 8-way DDP when TP=1 and PP=1
+```
+
+For all launch modes, the data-parallel size is derived from the total world
+size after accounting for tensor and pipeline parallelism:
+
+```text
+data_parallel_size = world_size / (tensor_parallel × pipeline_parallel)
 ```
 
 #### Tensor Parallelism (TP)

--- a/scripts/assets/prepare-infinitrain-assets.sh
+++ b/scripts/assets/prepare-infinitrain-assets.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prepare datasets / weights that can be read directly by InfiniTrain examples.
+#
+# Usage:
+#   ./scripts/assets/prepare-infinitrain-assets.sh gpt2
+#   ./scripts/assets/prepare-infinitrain-assets.sh llama3
+#   ./scripts/assets/prepare-infinitrain-assets.sh mnist
+#   ./scripts/assets/prepare-infinitrain-assets.sh all
+#
+# Optional environment variables:
+#   DATA_DIR=/path/to/data
+#   PYTHON=python3
+#   HF_TOKEN=hf_xxx
+#   FORCE=1
+#   SKIP_LLAMA3_WEIGHTS=1
+#
+# Output layout:
+#   data/
+#   ├── gpt2/
+#   │   ├── gpt2_124M.bin
+#   │   ├── gpt2_tokenizer.bin
+#   │   ├── tiny_shakespeare_train.bin
+#   │   └── tiny_shakespeare_val.bin
+#   ├── llama3/
+#   │   ├── llama3.2_1B_fp32.bin
+#   │   ├── tiny_shakespeare_train.bin
+#   │   └── tiny_shakespeare_val.bin
+#   └── mnist/
+#       ├── train-images-idx3-ubyte
+#       ├── train-labels-idx1-ubyte
+#       ├── t10k-images-idx3-ubyte
+#       └── t10k-labels-idx1-ubyte
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+DATA_DIR="${DATA_DIR:-${REPO_ROOT}/data}"
+CACHE_DIR="${DATA_DIR}/.cache"
+PYTHON="${PYTHON:-python3}"
+FORCE="${FORCE:-0}"
+SKIP_LLAMA3_WEIGHTS="${SKIP_LLAMA3_WEIGHTS:-0}"
+
+GPT2_DIR="${DATA_DIR}/gpt2"
+LLAMA3_DIR="${DATA_DIR}/llama3"
+MNIST_DIR="${DATA_DIR}/mnist"
+
+TARGET="${1:-all}"
+
+case "${TARGET}" in
+  gpt2|llama3|mnist|all) ;;
+  *)
+    echo "Usage: $0 {gpt2|llama3|mnist|all}"
+    exit 2
+    ;;
+esac
+
+mkdir -p "${CACHE_DIR}" "${GPT2_DIR}" "${LLAMA3_DIR}" "${MNIST_DIR}"
+
+log() {
+  printf '\n[%s] %s\n' "$(date '+%H:%M:%S')" "$*"
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+download_file() {
+  local url="$1"
+  local dst="$2"
+
+  if [[ -s "${dst}" && "${FORCE}" != "1" ]]; then
+    echo "skip existing: ${dst}"
+    return 0
+  fi
+
+  mkdir -p "$(dirname "${dst}")"
+  local tmp="${dst}.part"
+  rm -f "${tmp}"
+
+  echo "download: ${url}"
+  curl -fL --retry 4 --retry-delay 2 --connect-timeout 20 \
+    -o "${tmp}" "${url}"
+  mv "${tmp}" "${dst}"
+}
+
+prepare_gpt2() {
+  log "Preparing GPT-2 dataset / weights"
+
+  # InfiniTrain's GPT-2 LLMC loader currently accepts the FP32 v3 file.
+  # These artifacts are the same llm.c starter-pack files used by TinyInfiniTrain.
+  local base="https://huggingface.co/datasets/karpathy/llmc-starter-pack/resolve/main"
+
+  local files=(
+    "gpt2_124M.bin"
+    "gpt2_tokenizer.bin"
+    "tiny_shakespeare_train.bin"
+    "tiny_shakespeare_val.bin"
+  )
+
+  local f
+  for f in "${files[@]}"; do
+    download_file "${base}/${f}?download=true" "${GPT2_DIR}/${f}"
+  done
+
+  echo
+  echo "GPT-2 ready:"
+  echo "  weights:   ${GPT2_DIR}/gpt2_124M.bin"
+  echo "  tokenizer: ${GPT2_DIR}/gpt2_tokenizer.bin"
+  echo "  train:     ${GPT2_DIR}/tiny_shakespeare_train.bin"
+  echo "  val:       ${GPT2_DIR}/tiny_shakespeare_val.bin"
+}
+
+ensure_llama_python() {
+  need_cmd "${PYTHON}"
+
+  local venv="${CACHE_DIR}/llama3-venv"
+  LLAMA_PY="${venv}/bin/python"
+  local py="${LLAMA_PY}"
+
+  if [[ ! -x "${py}" ]]; then
+    log "Creating local Python environment for LLaMA3 preparation"
+    "${PYTHON}" -m venv "${venv}"
+  fi
+
+  if ! "${py}" - <<'PY' >/dev/null 2>&1
+import numpy
+import huggingface_hub
+import socksio
+import transformers
+PY
+  then
+    log "Installing LLaMA3 preparation dependencies into ${venv}"
+    "${py}" -m pip install --upgrade pip
+    "${py}" -m pip install \
+      "numpy>=1.24" \
+      "huggingface_hub>=0.24" \
+      "socksio>=1.0" \
+      "transformers>=4.43"
+  fi
+
+}
+
+prepare_llama3() {
+  log "Preparing LLaMA 3.2 1B dataset / weights"
+
+  local LLAMA_PY=""
+  ensure_llama_python
+  local py="${LLAMA_PY}"
+
+  local tiny_txt="${CACHE_DIR}/tiny_shakespeare.txt"
+  download_file \
+    "https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt" \
+    "${tiny_txt}"
+
+  # The model repository is gated. The Python helper accepts either HF_TOKEN or
+  # the token saved by `hf auth login`.
+  TINY_SHAKESPEARE_TXT="${tiny_txt}" \
+  LLAMA3_OUTPUT_DIR="${LLAMA3_DIR}" \
+  LLAMA3_CACHE_DIR="${CACHE_DIR}/llama3-hf" \
+  SKIP_LLAMA3_WEIGHTS="${SKIP_LLAMA3_WEIGHTS}" \
+  FORCE="${FORCE}" \
+  "${py}" "${SCRIPT_DIR}/prepare_llama3_assets.py"
+
+  echo
+  echo "LLaMA3 ready:"
+  if [[ "${SKIP_LLAMA3_WEIGHTS}" != "1" ]]; then
+    echo "  weights: ${LLAMA3_DIR}/llama3.2_1B_fp32.bin"
+  fi
+  echo "  train:   ${LLAMA3_DIR}/tiny_shakespeare_train.bin"
+  echo "  val:     ${LLAMA3_DIR}/tiny_shakespeare_val.bin"
+}
+
+prepare_mnist() {
+  log "Preparing MNIST IDX dataset"
+
+  # TorchVision's public MNIST mirror.
+  local base="https://ossci-datasets.s3.amazonaws.com/mnist"
+  local files=(
+    "train-images-idx3-ubyte"
+    "train-labels-idx1-ubyte"
+    "t10k-images-idx3-ubyte"
+    "t10k-labels-idx1-ubyte"
+  )
+
+  local f
+  for f in "${files[@]}"; do
+    local gz="${MNIST_DIR}/${f}.gz"
+    local dst="${MNIST_DIR}/${f}"
+
+    download_file "${base}/${f}.gz" "${gz}"
+
+    if [[ ! -s "${dst}" || "${FORCE}" == "1" ]]; then
+      echo "extract: ${gz}"
+      gzip -dc "${gz}" > "${dst}.part"
+      mv "${dst}.part" "${dst}"
+    else
+      echo "skip existing: ${dst}"
+    fi
+  done
+
+  echo
+  echo "MNIST ready:"
+  echo "  dataset: ${MNIST_DIR}"
+}
+
+need_cmd curl
+need_cmd gzip
+
+case "${TARGET}" in
+  gpt2)
+    prepare_gpt2
+    ;;
+  llama3)
+    prepare_llama3
+    ;;
+  mnist)
+    prepare_mnist
+    ;;
+  all)
+    prepare_gpt2
+    prepare_llama3
+    prepare_mnist
+    ;;
+esac
+
+log "Done"

--- a/scripts/assets/prepare_llama3_assets.py
+++ b/scripts/assets/prepare_llama3_assets.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+
+import json
+import mmap
+import os
+import struct
+from pathlib import Path
+
+import numpy as np
+from huggingface_hub import get_token, snapshot_download
+from transformers import AutoTokenizer
+
+MODEL_ID = "meta-llama/Llama-3.2-1B"
+
+out_dir = Path(os.environ["LLAMA3_OUTPUT_DIR"])
+cache_dir = Path(os.environ["LLAMA3_CACHE_DIR"])
+tiny_path = Path(os.environ["TINY_SHAKESPEARE_TXT"])
+force = os.environ.get("FORCE", "0") == "1"
+skip_weights = os.environ.get("SKIP_LLAMA3_WEIGHTS", "0") == "1"
+
+out_dir.mkdir(parents=True, exist_ok=True)
+cache_dir.mkdir(parents=True, exist_ok=True)
+
+token = os.environ.get("HF_TOKEN") or get_token()
+if not token:
+    raise SystemExit(
+        f"\nLLaMA3 preparation needs access to {MODEL_ID}.\n"
+        "1) Accept the model license on Hugging Face.\n"
+        "2) Run `hf auth login` or export HF_TOKEN=hf_xxx.\n"
+    )
+
+allow_patterns = [
+    "config.json",
+    "generation_config.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "special_tokens_map.json",
+    "added_tokens.json",
+    "*.model",
+]
+if not skip_weights:
+    allow_patterns.extend([
+        "model.safetensors",
+        "model-*.safetensors",
+        "model.safetensors.index.json",
+    ])
+
+print(f"[llama3] downloading/reusing Hugging Face files for {MODEL_ID}")
+model_dir = Path(snapshot_download(
+    repo_id=MODEL_ID,
+    token=token,
+    cache_dir=str(cache_dir),
+    allow_patterns=allow_patterns,
+))
+
+# ---------------------------------------------------------------------------
+# TinyShakespeare -> InfiniTrain / llm.c LLaMA-3 data format
+# header: 256 int32 = 1024 bytes
+#   [0] magic   = 20240801
+#   [1] version = 7
+#   [2] ntokens
+# payload: uint32 token ids
+# ---------------------------------------------------------------------------
+
+def write_datafile(path: Path, toks):
+    if path.exists() and path.stat().st_size > 0 and not force:
+        print(f"[llama3] skip existing: {path}")
+        return
+
+    header = np.zeros(256, dtype="<i4")
+    header[0] = 20240801
+    header[1] = 7
+    header[2] = len(toks)
+    toks_np = np.asarray(toks, dtype="<u4")
+
+    tmp = path.with_suffix(path.suffix + ".part")
+    with tmp.open("wb") as f:
+        f.write(header.tobytes())
+        f.write(toks_np.tobytes())
+    tmp.replace(path)
+    print(f"[llama3] wrote {len(toks):,} tokens -> {path}")
+
+tokenizer = AutoTokenizer.from_pretrained(
+    model_dir,
+    local_files_only=True,
+    token=token,
+    use_fast=True,
+)
+
+text = tiny_path.read_text(encoding="utf-8")
+sections = text.split("\n\n")
+
+bos = tokenizer.bos_token_id
+if bos is None:
+    probe = tokenizer.encode("")
+    if not probe:
+        raise RuntimeError("could not determine LLaMA3 BOS token")
+    bos = probe[0]
+
+def encode_no_special(s: str):
+    # Match llm.c's tinyshakespeare.py behavior as closely as current
+    # transformers versions permit.
+    try:
+        return tokenizer.encode(
+            s,
+            add_special_tokens=False,
+            verbose=False,
+            split_special_tokens=True,
+        )
+    except TypeError:
+        return tokenizer.encode(s, add_special_tokens=False)
+
+tokens = []
+for i, section in enumerate(sections):
+    tokens.append(int(bos))
+    padded = section + "\n\n" if i != len(sections) - 1 else section
+    tokens.extend(int(x) for x in encode_no_special(padded))
+
+val_tokens = tokens[:32768]
+train_tokens = tokens[32768:]
+
+write_datafile(out_dir / "tiny_shakespeare_val.bin", val_tokens)
+write_datafile(out_dir / "tiny_shakespeare_train.bin", train_tokens)
+
+if skip_weights:
+    print("[llama3] SKIP_LLAMA3_WEIGHTS=1: dataset prepared; weight conversion skipped")
+    raise SystemExit(0)
+
+# ---------------------------------------------------------------------------
+# Hugging Face safetensors -> InfiniTrain LLaMA3 LLMC FP32 format
+#
+# InfiniTrain's current loader expects:
+#   magic   = 20240803
+#   version = 3 (FP32)
+#
+# Followed by weights in the same order as llm.c train_llama3.py:
+#   wte
+#   all ln_1
+#   all packed QKV
+#   all attention output projections
+#   all ln_2
+#   all up projections
+#   all gate projections
+#   all down projections
+#   final norm
+#   lm_head
+#
+# This implementation parses safetensors directly and streams large matrices,
+# so it does not need to instantiate the model or load all tensors into memory.
+# ---------------------------------------------------------------------------
+
+weight_out = out_dir / "llama3.2_1B_fp32.bin"
+if weight_out.exists() and weight_out.stat().st_size > 0 and not force:
+    print(f"[llama3] skip existing: {weight_out}")
+    raise SystemExit(0)
+
+config = json.loads((model_dir / "config.json").read_text())
+
+hidden = int(config["hidden_size"])
+n_layer = int(config["num_hidden_layers"])
+n_head = int(config["num_attention_heads"])
+n_kv_head = int(config["num_key_value_heads"])
+vocab = int(config["vocab_size"])
+intermediate = int(config["intermediate_size"])
+norm_eps = float(config.get("rms_norm_eps", 1e-5))
+rope_theta = float(config.get("rope_theta", 500000.0))
+
+# InfiniTrain's current TinyShakespeare reader caps LLaMA-3 sequence length at
+# 8192, matching the llm.c reference config used by this loader.
+block_size = 8192
+
+if (hidden, intermediate) != (2048, 8192):
+    raise RuntimeError(
+        "unexpected LLaMA 3.2 1B dimensions: "
+        f"hidden_size={hidden}, intermediate_size={intermediate}"
+    )
+
+ffn_dim_multiplier = 1.5
+multiple_of = 256
+
+# Match the current InfiniTrain-Test 3.2 1B baseline, which trains with an
+# 8192-token context and writes use_scaled_rope=0. InfiniTrain does not yet
+# implement the extended-context LLaMA RoPE scaling path.
+use_scaled_rope = 0
+max_gen_bs = 4
+
+# Sanity checks for the requested model.
+if n_head % n_kv_head != 0:
+    raise RuntimeError("num_attention_heads must be divisible by num_key_value_heads")
+if hidden % n_head != 0:
+    raise RuntimeError("hidden_size must be divisible by num_attention_heads")
+
+# Build key -> safetensors shard mapping.
+index_path = model_dir / "model.safetensors.index.json"
+if index_path.exists():
+    index = json.loads(index_path.read_text())
+    weight_map = dict(index["weight_map"])
+else:
+    weight_map = {}
+
+class SafeTensorShard:
+    _dtype_map = {
+        "F32": np.dtype("<f4"),
+        "F16": np.dtype("<f2"),
+        "BF16": np.dtype("<u2"),  # converted manually
+    }
+
+    def __init__(self, path: Path):
+        self.path = path
+        self.fp = path.open("rb")
+        raw = self.fp.read(8)
+        if len(raw) != 8:
+            raise RuntimeError(f"invalid safetensors file: {path}")
+        self.header_len = struct.unpack("<Q", raw)[0]
+        self.header = json.loads(self.fp.read(self.header_len))
+        self.data_base = 8 + self.header_len
+        self.mm = mmap.mmap(self.fp.fileno(), 0, access=mmap.ACCESS_READ)
+
+    def has(self, key):
+        return key in self.header and key != "__metadata__"
+
+    def raw_array(self, key):
+        meta = self.header[key]
+        dtype_name = meta["dtype"]
+        if dtype_name not in self._dtype_map:
+            raise RuntimeError(f"unsupported safetensors dtype {dtype_name} for {key}")
+        dtype = self._dtype_map[dtype_name]
+        begin, end = meta["data_offsets"]
+        shape = tuple(meta["shape"])
+        return np.ndarray(
+            shape=shape,
+            dtype=dtype,
+            buffer=self.mm,
+            offset=self.data_base + begin,
+            order="C",
+        ), dtype_name
+
+    def close(self):
+        self.mm.close()
+        self.fp.close()
+
+readers = {}
+
+def reader_for_file(filename: str):
+    if filename not in readers:
+        readers[filename] = SafeTensorShard(model_dir / filename)
+    return readers[filename]
+
+if not weight_map:
+    for sf in sorted(model_dir.glob("*.safetensors")):
+        r = reader_for_file(sf.name)
+        for key in r.header:
+            if key != "__metadata__":
+                weight_map[key] = sf.name
+
+def locate(key):
+    if key not in weight_map:
+        raise KeyError(f"tensor not found in HF checkpoint: {key}")
+    return reader_for_file(weight_map[key])
+
+def bf16_to_f32(x):
+    u32 = np.asarray(x, dtype=np.uint16).astype(np.uint32)
+    u32 <<= 16
+    return u32.view(np.float32)
+
+def as_f32(x, dtype_name):
+    if dtype_name == "BF16":
+        return bf16_to_f32(x)
+    return np.asarray(x).astype(np.float32, copy=False)
+
+def get_full_f32(key):
+    r = locate(key)
+    arr, dtype_name = r.raw_array(key)
+    return np.ascontiguousarray(as_f32(arr, dtype_name))
+
+def write_tensor_stream(out, key, chunk_rows=256):
+    r = locate(key)
+    arr, dtype_name = r.raw_array(key)
+
+    if arr.ndim == 0:
+        out.write(np.asarray(as_f32(arr, dtype_name), dtype="<f4").tobytes())
+        return
+
+    if arr.ndim == 1:
+        chunk = np.ascontiguousarray(as_f32(arr, dtype_name), dtype="<f4")
+        out.write(chunk.tobytes(order="C"))
+        return
+
+    rows = arr.shape[0]
+    for start in range(0, rows, chunk_rows):
+        end = min(start + chunk_rows, rows)
+        chunk = np.ascontiguousarray(as_f32(arr[start:end], dtype_name), dtype="<f4")
+        out.write(chunk.tobytes(order="C"))
+
+def unpermute(w, n_heads):
+    dim1, dim2 = w.shape
+    if dim1 % (n_heads * 2) != 0:
+        raise RuntimeError(f"cannot unpermute shape={w.shape}, n_heads={n_heads}")
+    return (
+        w.reshape(n_heads, 2, dim1 // n_heads // 2, dim2)
+         .transpose(0, 2, 1, 3)
+         .reshape(dim1, dim2)
+    )
+
+def pack_header():
+    h = bytearray(256 * 4)
+    struct.pack_into("<i", h, 0, 20240803)
+    struct.pack_into("<i", h, 4, 3)  # FP32
+    struct.pack_into("<I", h, 8, block_size)
+    struct.pack_into("<I", h, 12, vocab)
+    struct.pack_into("<I", h, 16, n_layer)
+    struct.pack_into("<I", h, 20, n_head)
+    struct.pack_into("<I", h, 24, n_kv_head)
+    struct.pack_into("<I", h, 28, hidden)
+    struct.pack_into("<f", h, 32, ffn_dim_multiplier)
+    struct.pack_into("<I", h, 36, multiple_of)
+    struct.pack_into("<f", h, 40, norm_eps)
+    struct.pack_into("<f", h, 44, rope_theta)
+    struct.pack_into("<i", h, 48, use_scaled_rope)
+    struct.pack_into("<i", h, 52, max_gen_bs)
+    struct.pack_into("<i", h, 56, 3)
+    struct.pack_into("<i", h, 60, 2)
+    return h
+
+tmp = weight_out.with_suffix(weight_out.suffix + ".part")
+print(
+    "[llama3] converting to InfiniTrain FP32 LLMC format\n"
+    f"         hidden={hidden}, layers={n_layer}, heads={n_head}, kv_heads={n_kv_head}, "
+    f"intermediate={intermediate}, vocab={vocab}\n"
+    f"         output={weight_out}\n"
+    "         note: the final FP32 file is roughly 6 GB for LLaMA-3.2 1B"
+)
+
+with tmp.open("wb") as out:
+    out.write(pack_header())
+
+    # token embedding
+    write_tensor_stream(out, "model.embed_tokens.weight")
+
+    # attention RMSNorm
+    for i in range(n_layer):
+        write_tensor_stream(out, f"model.layers.{i}.input_layernorm.weight")
+
+    # packed Q | K | V
+    for i in range(n_layer):
+        q = get_full_f32(f"model.layers.{i}.self_attn.q_proj.weight")
+        k = get_full_f32(f"model.layers.{i}.self_attn.k_proj.weight")
+
+        q = np.ascontiguousarray(unpermute(q, n_head), dtype="<f4")
+        k = np.ascontiguousarray(unpermute(k, n_kv_head), dtype="<f4")
+
+        out.write(q.tobytes(order="C"))
+        out.write(k.tobytes(order="C"))
+        write_tensor_stream(out, f"model.layers.{i}.self_attn.v_proj.weight")
+
+        del q, k
+
+    # attention output projection
+    for i in range(n_layer):
+        write_tensor_stream(out, f"model.layers.{i}.self_attn.o_proj.weight")
+
+    # FFN RMSNorm
+    for i in range(n_layer):
+        write_tensor_stream(out, f"model.layers.{i}.post_attention_layernorm.weight")
+
+    # llm.c c_fc  <- HF up_proj
+    for i in range(n_layer):
+        write_tensor_stream(out, f"model.layers.{i}.mlp.up_proj.weight")
+
+    # llm.c c_fc2 <- HF gate_proj
+    for i in range(n_layer):
+        write_tensor_stream(out, f"model.layers.{i}.mlp.gate_proj.weight")
+
+    # llm.c c_proj <- HF down_proj
+    for i in range(n_layer):
+        write_tensor_stream(out, f"model.layers.{i}.mlp.down_proj.weight")
+
+    # final norm
+    write_tensor_stream(out, "model.norm.weight")
+
+    # output head
+    if "lm_head.weight" in weight_map:
+        write_tensor_stream(out, "lm_head.weight")
+    elif bool(config.get("tie_word_embeddings", False)):
+        write_tensor_stream(out, "model.embed_tokens.weight")
+    else:
+        raise KeyError("lm_head.weight missing and tie_word_embeddings is false")
+
+tmp.replace(weight_out)
+
+for r in readers.values():
+    r.close()
+
+print(f"[llama3] wrote FP32 weights -> {weight_out}")


### PR DESCRIPTION
## 背景

InfiniTrain 的 MNIST、GPT-2 和 LLaMA 3 示例依赖不同来源、不同格式的数据集与模型权重。此前缺少统一的数据生成入口，用户需要手动运行 python 脚本下载并转换相关文件。

## 主要改动

- 新增统一数据准备脚本，支持：
  - `mnist`
  - `gpt2` 
  - `llama3`
  - `all`
- 支持通过 `DATA_DIR` 自定义输出目录。
- 支持复用已有文件，并通过 `FORCE=1` 强制重新生成。
- 下载过程使用临时文件和原子替换，避免保留不完整的目标文件。
- 在数据缓存目录创建隔离的 Python 虚拟环境，自动安装 LLaMA python 数据处理脚本准备依赖，不修改用户当前 Python 环境。
- 安装 SOCKS 客户端依赖，兼容已通过环境变量配置 SOCKS 代理的下载环境。

### MNIST

- 从公开镜像下载四个 IDX 压缩文件。
- 自动解压为 InfiniTrain MNIST 示例可直接读取的格式。

### GPT-2

- 下载 GPT-2 124M FP32 LLMC 权重。
- 下载 tokenizer。
- 下载已经完成 tokenization 的 TinyShakespeare 训练集和验证集。

### LLaMA 3.2 1B

- 从 Hugging Face 下载 `meta-llama/Llama-3.2-1B`。
- 使用 LLaMA tokenizer 将 TinyShakespeare 转换为 InfiniTrain 数据格式。
- 生成训练集和验证集。
- 将 safetensors 权重流式转换为 InfiniTrain LLMC FP32 格式：
  - 写入 InfiniTrain 模型头；
  - 转换并合并 Q/K/V 权重；
  - 处理 Q/K 权重排列；
  - 按 InfiniTrain 要求写入 attention、FFN 和 normalization 权重；
  - 处理共享 embedding 和输出层权重；
  - 避免一次性将整个模型加载到内存。
- 严格校验 LLaMA 3.2 1B 的模型维度，避免误转换其他模型。
- 支持 `SKIP_LLAMA3_WEIGHTS=1`，仅准备 tokenizer 数据。
- 支持 `HF_TOKEN` 或 Hugging Face 本地登录凭据。

### 目录整理

数据生成脚本统一放置在：

```text
scripts/assets/
├── prepare-infinitrain-assets.sh
└── prepare_llama3_assets.py
```

同时在 .gitignore 中补充 Python 字节码缓存忽略规则。

## 使用方式

```bash
# MNIST
./scripts/assets/prepare-infinitrain-assets.sh mnist

# GPT-2
./scripts/assets/prepare-infinitrain-assets.sh gpt2

# LLaMA 3.2 1B
HF_TOKEN=hf_xxx \
./scripts/assets/prepare-infinitrain-assets.sh llama3

# 准备全部数据
HF_TOKEN=hf_xxx \
./scripts/assets/prepare-infinitrain-assets.sh all
```

自定义输出目录：

```bash
DATA_DIR=/path/to/data \
./scripts/assets/prepare-infinitrain-assets.sh gpt2
```

## 资源说明

LLaMA 3.2 1B 完整准备过程大约需要：

- 2.4GB Hugging Face 原始权重；
- 6GB InfiniTrain FP32 权重；
- 约 8.5GB 可用磁盘空间；
- 已获模型访问权限的 Hugging Face 账号。