### PR TITLE
fix: keep Adam moments in FP32 for BF16 parameters

### DIFF
--- a/infini_train/src/kernels/cuda/accumulate_grad.cu
+++ b/infini_train/src/kernels/cuda/accumulate_grad.cu
@@ -39,22 +39,22 @@ void AccumulateGrad(const std::shared_ptr<Tensor> &gradient, float rate, const s
         "CUDA AccumulateGrad");
 }
 
-template <typename T>
-__global__ void AdamAccumulateGradKernel(const T *grad_data, T *param_data, size_t num_elements, T *m_data, T *v_data,
-                                         float learning_rate, float beta1, float beta2, float eps,
+template <typename GradT, typename ParamT>
+__global__ void AdamAccumulateGradKernel(const GradT *grad_data, ParamT *param_data, size_t num_elements, float *m_data,
+                                         float *v_data, float learning_rate, float beta1, float beta2, float eps,
                                          const float bias_correction_m, const float bias_correction_v) {
     size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx < num_elements) {
-        m_data[idx] = common::cuda::Fma(common::cuda::Cast<T>(beta1), m_data[idx],
-                                        common::cuda::Cast<T>(1 - beta1) * grad_data[idx]);
-        v_data[idx] = common::cuda::Fma(common::cuda::Cast<T>(beta2), v_data[idx],
-                                        common::cuda::Cast<T>(1 - beta2) * grad_data[idx] * grad_data[idx]);
+        const float grad = common::cuda::Cast<float>(grad_data[idx]);
+        m_data[idx] = fmaf(beta1, m_data[idx], (1.0f - beta1) * grad);
+        v_data[idx] = fmaf(beta2, v_data[idx], (1.0f - beta2) * grad * grad);
 
-        const float m_hat = common::cuda::Cast<float>(m_data[idx]) / bias_correction_m;
-        const float v_hat = common::cuda::Cast<float>(v_data[idx]) / bias_correction_v;
+        const float m_hat = m_data[idx] / bias_correction_m;
+        const float v_hat = v_data[idx] / bias_correction_v;
 
-        param_data[idx] = common::cuda::Sub(
-            param_data[idx], common::cuda::Cast<T>(learning_rate * m_hat * __frcp_rn(__fsqrt_rn(v_hat) + eps)));
+        const float param = common::cuda::Cast<float>(param_data[idx]);
+        param_data[idx]
+            = common::cuda::Cast<ParamT>(param - learning_rate * m_hat * __frcp_rn(__fsqrt_rn(v_hat) + eps));
     }
 }
 
@@ -70,19 +70,26 @@ void AdamAccumulateGrad(const std::shared_ptr<Tensor> &grad, const std::shared_p
     int num_blocks = (num_elements + threads_per_block - 1) / threads_per_block;
 
     auto device = grad->GetDevice();
+    CHECK_EQ(static_cast<int>(m->Dtype()), static_cast<int>(DataType::kFLOAT32));
+    CHECK_EQ(static_cast<int>(v->Dtype()), static_cast<int>(DataType::kFLOAT32));
     const auto &cuda_stream = dynamic_cast<infini_train::core::cuda::CudaStream *>(
                                   infini_train::core::GetDeviceGuardImpl(device.type())->GetStream(device))
                                   ->cuda_stream();
 
     core::cuda::DispatchCudaFunc<INFINI_ALL_FLOATING_TYPES>(
         grad->Dtype(),
-        [=]<typename T>() {
-            AdamAccumulateGradKernel<<<num_blocks, threads_per_block, 0, cuda_stream>>>(
-                static_cast<const T *>(grad->DataPtr()), static_cast<T *>(param->DataPtr()), num_elements,
-                static_cast<T *>(m->DataPtr()), static_cast<T *>(v->DataPtr()), learning_rate, beta1, beta2, eps,
-                bias_correction_m, bias_correction_v);
+        [=]<typename GradT>() {
+            core::cuda::DispatchCudaFunc<INFINI_ALL_FLOATING_TYPES>(
+                param->Dtype(),
+                [=]<typename ParamT>() {
+                    AdamAccumulateGradKernel<<<num_blocks, threads_per_block, 0, cuda_stream>>>(
+                        static_cast<const GradT *>(grad->DataPtr()), static_cast<ParamT *>(param->DataPtr()),
+                        num_elements, static_cast<float *>(m->DataPtr()), static_cast<float *>(v->DataPtr()),
+                        learning_rate, beta1, beta2, eps, bias_correction_m, bias_correction_v);
+                },
+                "CUDA AdamAccumulateGrad parameter");
         },
-        "CUDA AdamAccumulateGrad");
+        "CUDA AdamAccumulateGrad gradient");
 }
 } // namespace infini_train::kernels::cuda
 

--- a/infini_train/src/optimizer.cc
+++ b/infini_train/src/optimizer.cc
@@ -82,8 +82,8 @@ Adam::Adam(const std::vector<std::shared_ptr<Tensor>> &params, float learning_ra
     : Optimizer(params, learning_rate), t_(0), beta1_(beta1), beta2_(beta2), eps_(eps) {
 
     for (const auto &param : params_) {
-        m_.emplace_back(std::make_shared<Tensor>(param->Dims(), param->Dtype(), param->GetDevice()));
-        v_.emplace_back(std::make_shared<Tensor>(param->Dims(), param->Dtype(), param->GetDevice()));
+        m_.emplace_back(std::make_shared<Tensor>(param->Dims(), DataType::kFLOAT32, param->GetDevice()));
+        v_.emplace_back(std::make_shared<Tensor>(param->Dims(), DataType::kFLOAT32, param->GetDevice()));
         m_.back()->Fill(0.0);
         v_.back()->Fill(0.0);
     }
@@ -92,8 +92,8 @@ Adam::Adam(const std::vector<std::shared_ptr<Tensor>> &params, float learning_ra
 Adam::Adam(const NamedParameterList &named_params, float learning_rate, float beta1, float beta2, float eps)
     : Optimizer(named_params, learning_rate), t_(0), beta1_(beta1), beta2_(beta2), eps_(eps) {
     for (const auto &[name, param] : named_params) {
-        m_.emplace_back(std::make_shared<Tensor>(param->Dims(), param->Dtype(), param->GetDevice()));
-        v_.emplace_back(std::make_shared<Tensor>(param->Dims(), param->Dtype(), param->GetDevice()));
+        m_.emplace_back(std::make_shared<Tensor>(param->Dims(), DataType::kFLOAT32, param->GetDevice()));
+        v_.emplace_back(std::make_shared<Tensor>(param->Dims(), DataType::kFLOAT32, param->GetDevice()));
         m_.back()->Fill(0.0);
         v_.back()->Fill(0.0);
     }

--- a/tests/optimizer/test_optimizer_creation.cc
+++ b/tests/optimizer/test_optimizer_creation.cc
@@ -25,6 +25,23 @@ TEST_P(OptimizerCreationTest, AdamCreation) {
     EXPECT_NE(optimizer, nullptr);
 }
 
+TEST_P(OptimizerCreationTest, AdamStateIsFP32ForBF16Parameters) {
+    auto param = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kBFLOAT16, GetDevice());
+    auto optimizer = std::make_shared<optimizers::Adam>(std::vector<std::shared_ptr<Tensor>>{param}, 0.001);
+    const auto state = optimizer->StateDict();
+    EXPECT_EQ(state.at("adam.m.0")->Dtype(), DataType::kFLOAT32);
+    EXPECT_EQ(state.at("adam.v.0")->Dtype(), DataType::kFLOAT32);
+}
+
+TEST_P(OptimizerCreationTest, NamedAdamStateIsFP32ForBF16Parameters) {
+    auto param = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kBFLOAT16, GetDevice());
+    const NamedParameterList named_params{{"weight", param}};
+    auto optimizer = std::make_shared<optimizers::Adam>(named_params, 0.001);
+    const auto state = optimizer->StateDict();
+    EXPECT_EQ(state.at("adam.m.weight")->Dtype(), DataType::kFLOAT32);
+    EXPECT_EQ(state.at("adam.v.weight")->Dtype(), DataType::kFLOAT32);
+}
+
 TEST_P(OptimizerCreationTest, SGDMultiParams) {
     std::vector<std::shared_ptr<Tensor>> params;
     for (int i = 0; i < 3; ++i) {

--- a/tests/optimizer/test_optimizer_step.cc
+++ b/tests/optimizer/test_optimizer_step.cc
@@ -30,6 +30,26 @@ TEST_P(OptimizerStepTest, AdamStep) {
     optimizer->Step();
 }
 
+TEST_P(OptimizerStepTest, AdamUpdatesBF16ParameterWithFP32State) {
+    if (GetDevice().type() != Device::DeviceType::kCUDA) {
+        GTEST_SKIP() << "BF16 Adam update is CUDA-only";
+    }
+    auto param = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kBFLOAT16, GetDevice());
+    param->set_requires_grad(true);
+    param->Fill(1.0f);
+    auto grad = std::make_shared<Tensor>(param->Dims(), DataType::kBFLOAT16, GetDevice());
+    grad->Fill(0.5f);
+    param->set_grad(grad);
+
+    auto optimizer = std::make_shared<optimizers::Adam>(std::vector<std::shared_ptr<Tensor>>{param}, 0.01);
+    optimizer->Step();
+
+    const auto updated = param->To(DataType::kFLOAT32).To(Device());
+    const auto *data = static_cast<const float *>(updated.DataPtr());
+    EXPECT_LT(data[0], 1.0f);
+    EXPECT_EQ(optimizer->StateDict().at("adam.m.0")->Dtype(), DataType::kFLOAT32);
+}
+
 TEST_P(OptimizerStepTest, ZeroGrad) {
     auto param = std::make_shared<Tensor>(std::vector<int64_t>{2, 3}, DataType::kFLOAT32, GetDevice());
     param->set_requires_grad(true);


### PR DESCRIPTION
## 修改背景

Adam 的一阶动量和二阶动量会在训练过程中持续累积。原实现让 `m`、`v` 跟随模型参数的数据类型，BF16 参数会因此使用 BF16 optimizer state，容易损失较小的梯度变化。

## 主要修改

- Adam 一阶动量 `m` 和二阶动量 `v` 统一使用 FP32 保存和计算
- CUDA Adam kernel 分别处理梯度类型、参数类型和 FP32 optimizer state
- 同时覆盖普通参数列表和 named-parameter 两种 Adam 构造路径
- 增加 BF16 参数使用 FP32 Adam state 的创建和更新测试


该 PR 位于 checkpoint stack 中，依赖 #195，后续 PR 为 #196。