### PR TITLE
fix: remove unused parallel state

### DIFF
--- a/infini_train/include/nn/parallel/pp/send_recv.h
+++ b/infini_train/include/nn/parallel/pp/send_recv.h
@@ -12,9 +12,9 @@ class Tensor;
 namespace infini_train::nn::parallel {
 
 std::vector<std::shared_ptr<Tensor>> ISend(const std::vector<std::shared_ptr<Tensor>> &input_tensors,
-                                           Device target_device, int cur_rank, int peer_rank,
+                                           Device target_device, int peer_rank,
                                            const std::vector<std::vector<int64_t>> &shape);
 
 std::vector<std::shared_ptr<Tensor>> IRecv(const std::vector<std::shared_ptr<Tensor>> &outputs, Device src_device,
-                                           int cur_rank, int peer_rank);
+                                           int peer_rank);
 } // namespace infini_train::nn::parallel

--- a/infini_train/include/nn/parallel/tensor_parallel.h
+++ b/infini_train/include/nn/parallel/tensor_parallel.h
@@ -88,7 +88,6 @@ public:
 private:
     bool reduce_scatter_embeddings_ = false; // whether to perform ReduceScatter after embedding lookup
 
-    int64_t vocab_size_global_ = 0;
     int64_t embedding_dim_ = 0;
 
     int64_t vocab_size_per_partition_ = 0;

--- a/infini_train/src/nn/parallel/pp/pipeline_schedule.cc
+++ b/infini_train/src/nn/parallel/pp/pipeline_schedule.cc
@@ -60,12 +60,12 @@ std::vector<std::shared_ptr<Tensor>> PipelineSchedule::ReceiveFromPrev(int peer_
         recv_tensors.push_back(tensor);
     }
 
-    return IRecv(recv_tensors, stage_->device(), stage_->stage_index(), peer_rank);
+    return IRecv(recv_tensors, stage_->device(), peer_rank);
 }
 
 std::vector<std::shared_ptr<Tensor>> PipelineSchedule::SendToNext(const std::vector<std::shared_ptr<Tensor>> &tensors,
                                                                   int peer_rank) {
-    return ISend(tensors, stage_->device(), stage_->stage_index(), peer_rank, stage_->recv_shape());
+    return ISend(tensors, stage_->device(), peer_rank, stage_->recv_shape());
 }
 
 PipelineParallelScheduler::Task PipelineParallelScheduler::CreateTask(int step, int mb, int global_chunk,

--- a/infini_train/src/nn/parallel/pp/send_recv.cc
+++ b/infini_train/src/nn/parallel/pp/send_recv.cc
@@ -18,9 +18,8 @@ class ISend : public autograd::Function {
 public:
     static constexpr char kType[] = "ISendFunction";
 
-    explicit ISend(Device target_device, int cur_rank, int peer_rank, const std::vector<std::vector<int64_t>> &shape)
-        : autograd::Function(kType), target_device_(target_device), cur_rank_(cur_rank), peer_rank_(peer_rank),
-          shapes_(shape) {}
+    explicit ISend(Device target_device, int peer_rank, const std::vector<std::vector<int64_t>> &shape)
+        : autograd::Function(kType), target_device_(target_device), peer_rank_(peer_rank), shapes_(shape) {}
 
     std::vector<std::shared_ptr<Tensor>> Forward(const std::vector<std::shared_ptr<Tensor>> &input_tensors) override;
 
@@ -29,7 +28,6 @@ public:
 private:
     Device target_device_;
     Device input_device_;
-    int cur_rank_ = -1;
     int peer_rank_ = -1;
     const std::vector<std::vector<int64_t>> &shapes_;
 };
@@ -38,8 +36,8 @@ class IRecv : public autograd::Function {
 public:
     static constexpr char kType[] = "IRecvFunction";
 
-    explicit IRecv(Device src_device, int cur_rank, int peer_rank)
-        : autograd::Function(kType), src_device_(src_device), cur_rank_(cur_rank), peer_rank_(peer_rank) {}
+    explicit IRecv(Device src_device, int peer_rank)
+        : autograd::Function(kType), src_device_(src_device), peer_rank_(peer_rank) {}
 
     std::vector<std::shared_ptr<Tensor>> Forward(const std::vector<std::shared_ptr<Tensor>> &input_tensors) override;
 
@@ -51,7 +49,6 @@ public:
 private:
     Device src_device_;
     Device cur_device_;
-    int cur_rank_ = -1;
     int peer_rank_ = -1;
 };
 
@@ -110,15 +107,15 @@ std::vector<std::shared_ptr<Tensor>> IRecv::Backward(const std::vector<std::shar
 } // namespace functions
 
 std::vector<std::shared_ptr<Tensor>> ISend(const std::vector<std::shared_ptr<Tensor>> &input_tensors,
-                                           Device target_device, int cur_rank, int peer_rank,
+                                           Device target_device, int peer_rank,
                                            const std::vector<std::vector<int64_t>> &shape) {
-    auto func = std::make_shared<functions::ISend>(target_device, cur_rank, peer_rank, shape);
+    auto func = std::make_shared<functions::ISend>(target_device, peer_rank, shape);
     return func->Apply(input_tensors);
 }
 
 std::vector<std::shared_ptr<Tensor>> IRecv(const std::vector<std::shared_ptr<Tensor>> &outputs, Device src_device,
-                                           int cur_rank, int peer_rank) {
-    auto func = std::make_shared<functions::IRecv>(src_device, cur_rank, peer_rank);
+                                           int peer_rank) {
+    auto func = std::make_shared<functions::IRecv>(src_device, peer_rank);
     return func->Apply(outputs);
 }
 } // namespace infini_train::nn::parallel

--- a/infini_train/src/nn/parallel/tensor_parallel.cc
+++ b/infini_train/src/nn/parallel/tensor_parallel.cc
@@ -341,8 +341,7 @@ bool RowParallelLinear::sequence_parallel() const { return sequence_parallel_; }
 
 VocabParallelEmbedding::VocabParallelEmbedding(int64_t num_embeddings, int64_t embedding_dim,
                                                bool reduce_scatter_embeddings)
-    : CloneableModule(kType), vocab_size_global_(num_embeddings), embedding_dim_(embedding_dim),
-      reduce_scatter_embeddings_(reduce_scatter_embeddings) {
+    : CloneableModule(kType), embedding_dim_(embedding_dim), reduce_scatter_embeddings_(reduce_scatter_embeddings) {
     auto tp_size = global::GetTensorParallelSize();
     CHECK_GT(tp_size, 0) << "No available devices found for VocabParallelEmbedding";
     CHECK_GT(num_embeddings, 0);


### PR DESCRIPTION
## 背景

编译时，流水线并行的当前部分字段会触发 `-Wunused-private-field` 警告。

流水线并行的进程组已经通过 Tensor 或 Device 的 global rank 获取，额外传递的 `cur_rank` 不参与实际逻辑。`VocabParallelEmbedding` 也直接使用构造参数 `num_embeddings` 计算分区范围，因此无需保存对应成员。

## 修改内容

- 移除流水线并行 `ISend` 和 `IRecv` 中未使用的 `cur_rank` 参数及成员。
- 移除未使用的 `VocabParallelEmbedding::vocab_size_global_` 成员。